### PR TITLE
Harden Plane–Kodo wrapper: parse task body, enforce scope, add run-id & reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,27 @@
 
 Self-hosted AI execution wrapper that uses **Plane** as the Jira-like board and **Kodo** as the coding engine.
 
-## What this repo provides
+## Current MVP (implemented)
 
-- Typed execution contracts (`BoardTask`, `RepoTarget`, `ExecutionRequest`, `ExecutionResult`)
-- Plane adapter for task fetch/comment/status update
-- Git/workspace orchestration for isolated ephemeral clones
-- Kodo CLI adapter
-- Validation runner and retained artifact writer
-- Worker orchestrator for end-to-end run of one Plane task
-- Optional FastAPI entrypoint for health and dry-run task parsing
+- Run **one Plane work-item by id** via worker CLI.
+- Parse structured task body sections: `## Execution`, `## Goal`, optional `## Constraints`.
+- Use explicit repo/base branch metadata from the task.
+- Create an isolated ephemeral clone and task branch (`plane/<task_id>-<slug>`).
+- Generate Kodo goal file from Goal/Constraints only (Execution metadata is excluded).
+- Run Kodo, then repo-configured validation commands.
+- Enforce `allowed_paths` policy against changed files before commit/push.
+- Set repo-local git identity from config before committing.
+- Emit retained artifacts with a `run_id` under `tools/report/kodo_plane/`.
+- Update Plane state and add short result comments.
 
-## Layout
+## Not implemented yet
 
-```text
-control-plane/
-  README.md
-  pyproject.toml
-  src/
-    control_plane/
-      config/
-      domain/
-      application/
-      adapters/
-        plane/
-        git/
-        kodo/
-        workspace/
-        reporting/
-      entrypoints/
-        api/
-        worker/
-  docs/
-    design/
-      plane_kodo_wrapper.md
-```
+- PR creation.
+- Webhook consumer.
+- Polling scheduler.
+- Concurrency locking.
+- Retries/idempotency.
+- Multi-repo tasks.
 
 ## Quick start
 
@@ -47,12 +34,8 @@ control-plane/
 PYTHONPATH=src python -m control_plane.entrypoints.worker.main --config config/control_plane.yaml --task-id TASK-123
 ```
 
-4. Or run API:
+4. Optional API:
 
 ```bash
 PYTHONPATH=src uvicorn control_plane.entrypoints.api.main:app --reload
 ```
-
-## Config example
-
-See `docs/design/plane_kodo_wrapper.md` for full details.

--- a/docs/design/plane_kodo_wrapper.md
+++ b/docs/design/plane_kodo_wrapper.md
@@ -4,18 +4,28 @@
 
 Build a self-hosted AI execution wrapper that uses Plane as the Jira-like board and Kodo as the coding engine, with explicit repo and base-branch selection per task.
 
-## MVP behavior
+## Current behavior
 
-1. Plane task enters `Ready for AI`.
-2. Worker fetches task and parses `## Execution` metadata.
-3. Worker resolves repo config and verifies base branch policy.
-4. Worker creates isolated ephemeral clone.
-5. Worker creates `plane/<task_id>-<slug>` branch.
-6. Worker writes goal file and invokes Kodo.
-7. Worker runs validation commands.
-8. Worker commits and pushes branch based on policy.
-9. Worker writes retained artifacts under `tools/report/kodo_plane/`.
-10. Worker comments result in Plane and updates status.
+1. Worker fetches one Plane **work-item** by id.
+2. Parser extracts `Execution` metadata, `Goal`, and optional `Constraints`.
+3. Worker validates mode support (current MVP: `goal` only).
+4. Worker resolves repo config and base-branch policy.
+5. Worker creates isolated ephemeral clone and task branch.
+6. Worker writes `goal.md` from Goal/Constraints only.
+7. Worker runs Kodo and validation commands.
+8. Worker enforces `allowed_paths` policy for changed files.
+9. Worker commits/pushes only when policy allows.
+10. Worker writes retained artifacts under `tools/report/kodo_plane/<timestamp>_<task_id>_<run_id>/`.
+11. Worker posts a short Plane comment and updates status.
+
+## Explicit MVP boundaries (not implemented)
+
+- PR creation
+- webhook ingestion
+- polling scheduler
+- concurrency locks
+- retries/idempotency
+- multi-repo orchestration
 
 ## Task metadata template
 
@@ -28,42 +38,11 @@ allowed_paths:
   - src/workflow/long_form/
   - tools/audit/
 validation_profile: default
-open_pr: true
-```
+open_pr: false
 
-## Config example
+## Goal
+Improve reporting output and ensure policy violations are visible.
 
-```yaml
-plane:
-  base_url: http://plane.local
-  api_token_env: PLANE_API_TOKEN
-  workspace_slug: engineering
-  project_id: project-123
-
-git:
-  provider: github
-  token_env: GITHUB_TOKEN
-  open_pr_default: true
-  push_on_validation_failure: true
-
-kodo:
-  binary: kodo
-  team: full
-  cycles: 3
-  exchanges: 20
-  orchestrator: api
-  effort: medium
-  timeout_seconds: 3600
-
-repos:
-  code_youtube_shorts:
-    clone_url: git@github.com:you/code_youtube_shorts.git
-    default_branch: main
-    validation_commands:
-      - pytest -m "unit or contract"
-      - ruff check .
-    allowed_base_branches:
-      - main
-      - develop
-      - feature/*
+## Constraints
+- Keep changes inside wrapper service code.
 ```

--- a/src/control_plane/adapters/git/client.py
+++ b/src/control_plane/adapters/git/client.py
@@ -28,6 +28,10 @@ class GitClient:
     def create_task_branch(self, repo_path: Path, task_branch: str) -> None:
         self._run(["git", "checkout", "-b", task_branch], cwd=repo_path)
 
+    def set_identity(self, repo_path: Path, author_name: str, author_email: str) -> None:
+        self._run(["git", "config", "user.name", author_name], cwd=repo_path)
+        self._run(["git", "config", "user.email", author_email], cwd=repo_path)
+
     def changed_files(self, repo_path: Path) -> list[str]:
         out = self._run(["git", "status", "--porcelain"], cwd=repo_path)
         files: list[str] = []
@@ -36,9 +40,13 @@ class GitClient:
                 files.append(line[3:])
         return files
 
-    def commit_all(self, repo_path: Path, message: str) -> None:
+    def commit_all(self, repo_path: Path, message: str) -> bool:
         self._run(["git", "add", "-A"], cwd=repo_path)
+        status = self._run(["git", "status", "--porcelain"], cwd=repo_path)
+        if not status:
+            return False
         self._run(["git", "commit", "-m", message], cwd=repo_path)
+        return True
 
     def push_branch(self, repo_path: Path, branch: str) -> None:
         self._run(["git", "push", "-u", "origin", branch], cwd=repo_path)

--- a/src/control_plane/adapters/kodo/adapter.py
+++ b/src/control_plane/adapters/kodo/adapter.py
@@ -19,8 +19,11 @@ class KodoAdapter:
     def __init__(self, settings: KodoSettings) -> None:
         self.settings = settings
 
-    def write_goal_file(self, path: Path, goal_text: str) -> Path:
-        path.write_text(goal_text)
+    def write_goal_file(self, path: Path, goal_text: str, constraints_text: str | None = None) -> Path:
+        lines = ["## Goal", goal_text.strip()]
+        if constraints_text:
+            lines.extend(["", "## Constraints", constraints_text.strip()])
+        path.write_text("\n".join(lines).strip() + "\n")
         return path
 
     def build_command(self, goal_file: Path, repo_path: Path) -> list[str]:

--- a/src/control_plane/adapters/plane/client.py
+++ b/src/control_plane/adapters/plane/client.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import re
+import html
 from typing import Any
 
 import httpx
-import yaml
 
+from control_plane.application.task_parser import TaskParser
 from control_plane.domain import BoardTask
-
-EXEC_BLOCK_PATTERN = re.compile(r"## Execution\n(.*?)(?:\n## |\Z)", re.DOTALL)
 
 
 class PlaneClient:
@@ -16,9 +14,10 @@ class PlaneClient:
         self.base_url = base_url.rstrip("/")
         self.workspace_slug = workspace_slug
         self.project_id = project_id
+        self.task_parser = TaskParser()
         self._client = httpx.Client(
             base_url=self.base_url,
-            headers={"x-api-key": api_token, "Content-Type": "application/json"},
+            headers={"X-API-Key": api_token, "Content-Type": "application/json"},
             timeout=30.0,
         )
 
@@ -26,50 +25,48 @@ class PlaneClient:
         self._client.close()
 
     def fetch_issue(self, task_id: str) -> dict[str, Any]:
-        url = f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/issues/{task_id}/"
+        url = f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/work-items/{task_id}/"
         response = self._client.get(url)
         response.raise_for_status()
         return response.json()
 
     def to_board_task(self, issue: dict[str, Any]) -> BoardTask:
-        metadata = self.parse_execution_metadata(issue.get("description_html") or issue.get("description_stripped") or "")
+        description = issue.get("description") or issue.get("description_stripped") or ""
+        parsed_body = self.task_parser.parse(description)
+        metadata = parsed_body.execution_metadata
+        state = issue.get("state")
+        status_value = state.get("name", "Unknown") if isinstance(state, dict) else str(state or "Unknown")
         return BoardTask(
             task_id=str(issue["id"]),
             project_id=str(issue.get("project_id", self.project_id)),
             title=issue.get("name", "Untitled"),
-            description=issue.get("description_stripped"),
-            status=issue.get("state", {}).get("name", "Unknown"),
+            description=description,
+            status=status_value,
             labels=[label.get("name", "") for label in issue.get("labels", []) if isinstance(label, dict)],
-            repo_key=metadata["repo"],
-            base_branch=metadata["base_branch"],
-            execution_mode=metadata["mode"],
-            allowed_paths=metadata.get("allowed_paths", []),
-            validation_profile=metadata.get("validation_profile"),
+            repo_key=str(metadata["repo"]),
+            base_branch=str(metadata["base_branch"]),
+            execution_mode=str(metadata["mode"]),
+            allowed_paths=[str(path) for path in metadata.get("allowed_paths", [])],
+            validation_profile=(
+                str(metadata.get("validation_profile")) if metadata.get("validation_profile") else None
+            ),
             open_pr=bool(metadata.get("open_pr", False)),
+            goal_text=parsed_body.goal_text,
+            constraints_text=parsed_body.constraints_text,
         )
 
-    def parse_execution_metadata(self, description: str) -> dict[str, Any]:
-        match = EXEC_BLOCK_PATTERN.search(description)
-        if not match:
-            raise ValueError("Missing '## Execution' block in task description")
-
-        yaml_block = match.group(1).strip()
-        data = yaml.safe_load(yaml_block) or {}
-        required = ("repo", "base_branch", "mode")
-        missing = [key for key in required if key not in data]
-        if missing:
-            raise ValueError(f"Missing execution metadata fields: {', '.join(missing)}")
-        return data
-
-    def transition_issue(self, task_id: str, state_name: str) -> None:
-        url = f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/issues/{task_id}/"
-        response = self._client.patch(url, json={"state": state_name})
+    def transition_issue(self, task_id: str, state: str) -> None:
+        url = f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/work-items/{task_id}/"
+        response = self._client.patch(url, json={"state": state})
         response.raise_for_status()
 
     def comment_issue(self, task_id: str, comment_markdown: str) -> None:
         url = (
             f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/"
-            f"issues/{task_id}/comments/"
+            f"work-items/{task_id}/comments/"
         )
-        response = self._client.post(url, json={"comment_html": comment_markdown})
+        html_body = "<p>" + "</p><p>".join(
+            html.escape(line) for line in comment_markdown.split("\n") if line.strip()
+        ) + "</p>"
+        response = self._client.post(url, json={"comment_html": html_body})
         response.raise_for_status()

--- a/src/control_plane/adapters/reporting/reporter.py
+++ b/src/control_plane/adapters/reporting/reporter.py
@@ -11,9 +11,9 @@ class Reporter:
     def __init__(self, report_root: Path) -> None:
         self.report_root = report_root
 
-    def create_run_dir(self, task_id: str) -> Path:
+    def create_run_dir(self, task_id: str, run_id: str) -> Path:
         ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-        run_dir = self.report_root / f"{ts}_{task_id}"
+        run_dir = self.report_root / f"{ts}_{task_id}_{run_id}"
         run_dir.mkdir(parents=True, exist_ok=True)
         return run_dir
 
@@ -36,10 +36,21 @@ class Reporter:
         path.write_text(json.dumps(data, indent=2))
         return str(path)
 
+    def write_policy_violation(self, run_dir: Path, violations: list[str]) -> str:
+        path = run_dir / "policy_violation.json"
+        path.write_text(json.dumps({"violations": violations}, indent=2))
+        return str(path)
+
+    def write_failure(self, run_dir: Path, error: str) -> str:
+        path = run_dir / "failure.md"
+        path.write_text("# Execution Failure\n\n" + error + "\n")
+        return str(path)
+
     def write_summary(self, run_dir: Path, result: ExecutionResult) -> str:
         path = run_dir / "result_summary.md"
         lines = [
             "# Execution Result",
+            f"- run_id: {result.run_id}",
             f"- success: {result.success}",
             f"- validation_passed: {result.validation_passed}",
             f"- branch_pushed: {result.branch_pushed}",
@@ -48,6 +59,8 @@ class Reporter:
             "## Changed Files",
         ]
         lines.extend([f"- {f}" for f in result.changed_files] or ["- (none)"])
+        lines.extend(["", "## Policy Violations"])
+        lines.extend([f"- {f}" for f in result.policy_violations] or ["- (none)"])
         lines.extend(["", "## Summary", result.summary])
         path.write_text("\n".join(lines))
         return str(path)

--- a/src/control_plane/application/__init__.py
+++ b/src/control_plane/application/__init__.py
@@ -1,3 +1,5 @@
+from control_plane.application.scope_policy import ChangedFilePolicyChecker
 from control_plane.application.service import ExecutionService
+from control_plane.application.task_parser import TaskParser
 
-__all__ = ["ExecutionService"]
+__all__ = ["ChangedFilePolicyChecker", "ExecutionService", "TaskParser"]

--- a/src/control_plane/application/scope_policy.py
+++ b/src/control_plane/application/scope_policy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+
+class ChangedFilePolicyChecker:
+    def find_violations(self, changed_files: list[str], allowed_paths: list[str]) -> list[str]:
+        if not allowed_paths:
+            return []
+
+        normalized_patterns = [self._normalize_pattern(path) for path in allowed_paths]
+        violations: list[str] = []
+        for changed in changed_files:
+            normalized_changed = self._normalize_changed_path(changed)
+            if not any(fnmatch.fnmatch(normalized_changed, pattern) for pattern in normalized_patterns):
+                violations.append(normalized_changed)
+        return sorted(set(violations))
+
+    @staticmethod
+    def _normalize_pattern(path: str) -> str:
+        cleaned = path.strip().replace("\\", "/").lstrip("./")
+        if cleaned.endswith("/"):
+            return f"{cleaned}*"
+        return str(Path(cleaned)).replace("\\", "/")
+
+    @staticmethod
+    def _normalize_changed_path(path: str) -> str:
+        normalized = path.strip()
+        if " -> " in normalized:
+            normalized = normalized.split(" -> ", maxsplit=1)[1]
+        return str(Path(normalized)).replace("\\", "/").lstrip("./")

--- a/src/control_plane/application/service.py
+++ b/src/control_plane/application/service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import re
+import traceback
+import uuid
 from pathlib import Path
 
 from control_plane.adapters.git import GitClient, branch_allowed
@@ -9,6 +11,7 @@ from control_plane.adapters.kodo import KodoAdapter
 from control_plane.adapters.plane import PlaneClient
 from control_plane.adapters.reporting import Reporter
 from control_plane.adapters.workspace import WorkspaceManager
+from control_plane.application.scope_policy import ChangedFilePolicyChecker
 from control_plane.application.validation import ValidationRunner
 from control_plane.config import Settings
 from control_plane.domain import BoardTask, ExecutionRequest, ExecutionResult, RepoTarget
@@ -22,6 +25,7 @@ class ExecutionService:
         self.kodo = KodoAdapter(settings.kodo)
         self.validation = ValidationRunner()
         self.reporter = Reporter(settings.report_root)
+        self.scope_checker = ChangedFilePolicyChecker()
 
     @staticmethod
     def task_branch(task: BoardTask) -> str:
@@ -41,36 +45,51 @@ class ExecutionService:
         )
 
     def run_task(self, plane_client: PlaneClient, task_id: str) -> ExecutionResult:
-        issue = plane_client.fetch_issue(task_id)
-        task = plane_client.to_board_task(issue)
-        repo_target = self._repo_target_for(task)
-
-        if not branch_allowed(task.base_branch, repo_target.allowed_base_branches):
-            raise ValueError(f"Base branch '{task.base_branch}' is not allowed by policy")
-
-        plane_client.transition_issue(task.task_id, "Running")
-
+        run_id = uuid.uuid4().hex[:12]
         workspace_path = self.workspace.create()
+        run_dir: Path | None = None
         repo_path = Path()
+        task: BoardTask | None = None
+
         try:
+            issue = plane_client.fetch_issue(task_id)
+            task = plane_client.to_board_task(issue)
+            repo_target = self._repo_target_for(task)
+
+            if task.execution_mode != "goal":
+                raise ValueError(
+                    f"Unsupported execution mode '{task.execution_mode}'. MVP currently supports only 'goal'."
+                )
+
+            if not branch_allowed(task.base_branch, repo_target.allowed_base_branches):
+                raise ValueError(f"Base branch '{task.base_branch}' is not allowed by policy")
+
+            plane_client.transition_issue(task.task_id, "Running")
+
             repo_path = self.git.clone(repo_target.clone_url, workspace_path)
             self.git.verify_remote_branch_exists(repo_path, task.base_branch)
             self.git.checkout_base(repo_path, task.base_branch)
+            self.git.set_identity(
+                repo_path,
+                author_name=self.settings.git.author_name,
+                author_email=self.settings.git.author_email,
+            )
 
             task_branch = self.task_branch(task)
             self.git.create_task_branch(repo_path, task_branch)
 
             goal_file = workspace_path / "goal.md"
-            self.kodo.write_goal_file(goal_file, task.description or task.title)
+            self.kodo.write_goal_file(goal_file, task.goal_text, task.constraints_text)
 
             req = ExecutionRequest(
+                run_id=run_id,
                 task=task,
                 repo_target=repo_target,
                 workspace_path=workspace_path,
                 task_branch=task_branch,
                 goal_file_path=goal_file,
             )
-            run_dir = self.reporter.create_run_dir(task.task_id)
+            run_dir = self.reporter.create_run_dir(task.task_id, run_id)
             artifacts = [self.reporter.write_request(run_dir, req)]
 
             kodo_result = self.kodo.run(goal_file, repo_path)
@@ -95,20 +114,28 @@ class ExecutionService:
             )
 
             changed_files = self.git.changed_files(repo_path)
-            success = kodo_result.exit_code == 0 and validation_ok
+            policy_violations = self.scope_checker.find_violations(changed_files, task.allowed_paths)
+            if policy_violations:
+                artifacts.append(self.reporter.write_policy_violation(run_dir, policy_violations))
+
+            success = kodo_result.exit_code == 0 and validation_ok and not policy_violations
 
             branch_pushed = False
-            if changed_files and (success or self.settings.git.push_on_validation_failure):
-                self.git.commit_all(repo_path, f"chore: apply Plane task {task.task_id}")
-                self.git.push_branch(repo_path, task_branch)
-                branch_pushed = True
+            if changed_files and not policy_violations and (success or self.settings.git.push_on_validation_failure):
+                committed = self.git.commit_all(repo_path, f"chore: apply Plane task {task.task_id}")
+                if committed:
+                    self.git.push_branch(repo_path, task_branch)
+                    branch_pushed = True
 
             summary = (
-                f"Kodo exit={kodo_result.exit_code}, validation={'passed' if validation_ok else 'failed'}, "
+                f"run_id={run_id} kodo_exit={kodo_result.exit_code} "
+                f"validation={'passed' if validation_ok else 'failed'} "
+                f"policy={'passed' if not policy_violations else 'failed'} "
                 f"changed_files={len(changed_files)}"
             )
 
             result = ExecutionResult(
+                run_id=run_id,
                 success=success,
                 changed_files=changed_files,
                 validation_passed=validation_ok,
@@ -117,16 +144,22 @@ class ExecutionService:
                 pull_request_url=None,
                 summary=summary,
                 artifacts=artifacts,
+                policy_violations=policy_violations,
             )
             artifacts.append(self.reporter.write_summary(run_dir, result))
 
-            status = "Review" if branch_pushed else "Blocked"
+            status = "Blocked" if policy_violations or not success else "Review"
             plane_client.transition_issue(task.task_id, status)
             plane_client.comment_issue(task.task_id, self._comment_markdown(task, result))
             return result
-        except Exception as exc:
+        except Exception:
+            if run_dir is not None:
+                self.reporter.write_failure(run_dir, traceback.format_exc())
             plane_client.transition_issue(task_id, "Blocked")
-            plane_client.comment_issue(task_id, f"Execution failed: `{exc}`")
+            plane_client.comment_issue(
+                task_id,
+                f"Execution failed (run_id={run_id}). See retained artifacts for details.",
+            )
             raise
         finally:
             self.workspace.cleanup(workspace_path)
@@ -135,12 +168,15 @@ class ExecutionService:
     def _comment_markdown(task: BoardTask, result: ExecutionResult) -> str:
         lines = [
             f"### AI execution result for {task.task_id}",
+            f"- run_id: {result.run_id}",
             f"- success: {result.success}",
             f"- validation_passed: {result.validation_passed}",
             f"- branch_pushed: {result.branch_pushed}",
             f"- summary: {result.summary}",
-            "",
-            "Artifacts:",
         ]
+        if result.policy_violations:
+            lines.append("- policy_violations:")
+            lines.extend([f"  - {path}" for path in result.policy_violations])
+        lines.extend(["", "Artifacts:"])
         lines.extend([f"- `{artifact}`" for artifact in result.artifacts])
         return "\n".join(lines)

--- a/src/control_plane/application/task_parser.py
+++ b/src/control_plane/application/task_parser.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import yaml
+
+from control_plane.domain import ParsedTaskBody
+
+SECTION_PATTERN = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+class TaskParser:
+    REQUIRED_EXEC_FIELDS = ("repo", "base_branch", "mode")
+
+    def parse(self, description: str) -> ParsedTaskBody:
+        sections = self._extract_sections(description)
+        execution_raw = sections.get("execution", "").strip()
+        if not execution_raw:
+            raise ValueError("Missing '## Execution' section in task description")
+
+        metadata = yaml.safe_load(execution_raw) or {}
+        if not isinstance(metadata, dict):
+            raise ValueError("Execution section must be valid key/value YAML")
+
+        missing = [key for key in self.REQUIRED_EXEC_FIELDS if key not in metadata]
+        if missing:
+            raise ValueError(f"Missing execution metadata fields: {', '.join(missing)}")
+
+        goal_text = sections.get("goal", "").strip()
+        if not goal_text:
+            raise ValueError("Missing '## Goal' section in task description")
+
+        constraints_text = sections.get("constraints", "").strip() or None
+        return ParsedTaskBody(
+            execution_metadata=self._normalize_metadata(metadata),
+            goal_text=goal_text,
+            constraints_text=constraints_text,
+        )
+
+    def _extract_sections(self, description: str) -> dict[str, str]:
+        headers = list(SECTION_PATTERN.finditer(description))
+        if not headers:
+            return {}
+
+        sections: dict[str, str] = {}
+        for idx, match in enumerate(headers):
+            title = match.group(1).strip().lower()
+            content_start = match.end()
+            content_end = headers[idx + 1].start() if idx + 1 < len(headers) else len(description)
+            sections[title] = description[content_start:content_end].strip("\n")
+        return sections
+
+    @staticmethod
+    def _normalize_metadata(metadata: dict[str, Any]) -> dict[str, object]:
+        data = dict(metadata)
+        allowed_paths = data.get("allowed_paths", [])
+        if isinstance(allowed_paths, str):
+            allowed_paths = [allowed_paths]
+        data["allowed_paths"] = [str(path).strip() for path in allowed_paths if str(path).strip()]
+        data["open_pr"] = bool(data.get("open_pr", False))
+        return data

--- a/src/control_plane/config/settings.py
+++ b/src/control_plane/config/settings.py
@@ -19,6 +19,8 @@ class GitSettings(BaseModel):
     token_env: str | None = None
     open_pr_default: bool = True
     push_on_validation_failure: bool = True
+    author_name: str = "Control Plane Bot"
+    author_email: str = "control-plane-bot@example.com"
 
 
 class KodoSettings(BaseModel):

--- a/src/control_plane/domain/__init__.py
+++ b/src/control_plane/domain/__init__.py
@@ -2,14 +2,16 @@ from control_plane.domain.models import (
     BoardTask,
     ExecutionRequest,
     ExecutionResult,
+    ParsedTaskBody,
     RepoTarget,
     ValidationResult,
 )
 
 __all__ = [
     "BoardTask",
-    "RepoTarget",
     "ExecutionRequest",
     "ExecutionResult",
+    "ParsedTaskBody",
+    "RepoTarget",
     "ValidationResult",
 ]

--- a/src/control_plane/domain/models.py
+++ b/src/control_plane/domain/models.py
@@ -9,6 +9,12 @@ from pydantic import BaseModel, Field
 ExecutionMode = Literal["goal", "test", "improve"]
 
 
+class ParsedTaskBody(BaseModel):
+    execution_metadata: dict[str, object]
+    goal_text: str
+    constraints_text: str | None = None
+
+
 class BoardTask(BaseModel):
     task_id: str
     project_id: str
@@ -22,6 +28,8 @@ class BoardTask(BaseModel):
     allowed_paths: list[str] = Field(default_factory=list)
     validation_profile: str | None = None
     open_pr: bool = False
+    goal_text: str
+    constraints_text: str | None = None
 
 
 class RepoTarget(BaseModel):
@@ -35,6 +43,7 @@ class RepoTarget(BaseModel):
 
 
 class ExecutionRequest(BaseModel):
+    run_id: str
     task: BoardTask
     repo_target: RepoTarget
     workspace_path: Path
@@ -51,6 +60,7 @@ class ValidationResult(BaseModel):
 
 
 class ExecutionResult(BaseModel):
+    run_id: str
     success: bool
     changed_files: list[str] = Field(default_factory=list)
     validation_passed: bool = False
@@ -59,3 +69,4 @@ class ExecutionResult(BaseModel):
     pull_request_url: str | None = None
     summary: str
     artifacts: list[str] = Field(default_factory=list)
+    policy_violations: list[str] = Field(default_factory=list)

--- a/tests/test_execution_modes.py
+++ b/tests/test_execution_modes.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from control_plane.application.service import ExecutionService
+from control_plane.config.settings import Settings
+
+
+class DummyPlaneClient:
+    def fetch_issue(self, task_id: str) -> dict[str, object]:
+        return {
+            "id": task_id,
+            "name": "Task",
+            "project_id": "proj",
+            "description": """## Execution
+repo: repo_a
+base_branch: main
+mode: test
+
+## Goal
+Do thing.
+""",
+            "state": {"name": "Ready for AI"},
+            "labels": [],
+        }
+
+    def to_board_task(self, issue: dict[str, object]):  # type: ignore[no-untyped-def]
+        from control_plane.adapters.plane import PlaneClient
+
+        c = PlaneClient("http://plane.local", "token", "ws", "proj")
+        try:
+            return c.to_board_task(issue)
+        finally:
+            c.close()
+
+    def transition_issue(self, task_id: str, state: str) -> None:  # noqa: ARG002
+        return
+
+    def comment_issue(self, task_id: str, comment_markdown: str) -> None:  # noqa: ARG002
+        return
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> Settings:
+    return Settings.model_validate(
+        {
+            "plane": {
+                "base_url": "http://plane.local",
+                "api_token_env": "PLANE_API_TOKEN",
+                "workspace_slug": "ws",
+                "project_id": "proj",
+            },
+            "git": {"provider": "github"},
+            "kodo": {},
+            "repos": {
+                "repo_a": {
+                    "clone_url": "git@github.com:you/repo_a.git",
+                    "default_branch": "main",
+                }
+            },
+            "report_root": str(tmp_path / "reports"),
+        }
+    )
+
+
+def test_unsupported_execution_mode_fails_cleanly(settings: Settings) -> None:
+    service = ExecutionService(settings)
+    with pytest.raises(ValueError, match="supports only 'goal'"):
+        service.run_task(DummyPlaneClient(), "TASK-1")

--- a/tests/test_plane_client_http.py
+++ b/tests/test_plane_client_http.py
@@ -1,0 +1,54 @@
+import json
+
+import httpx
+
+from control_plane.adapters.plane import PlaneClient
+
+
+def test_plane_comment_and_state_update_flow() -> None:
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode()) if request.content else None
+        calls.append((request.method, str(request.url), payload))
+
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "TASK-1",
+                    "project_id": "proj",
+                    "name": "Task",
+                    "description": """## Execution
+repo: repo_a
+base_branch: main
+mode: goal
+
+## Goal
+Do thing.
+""",
+                    "state": {"name": "Ready for AI"},
+                    "labels": [],
+                },
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    client = PlaneClient("http://plane.local", "token", "ws", "proj")
+    client._client = httpx.Client(transport=transport, base_url="http://plane.local")  # type: ignore[attr-defined]
+
+    try:
+        issue = client.fetch_issue("TASK-1")
+        task = client.to_board_task(issue)
+        client.transition_issue(task.task_id, "Running")
+        client.comment_issue(task.task_id, "Hello\nworld")
+    finally:
+        client.close()
+
+    assert any("/work-items/TASK-1/" in url for _, url, _ in calls)
+    patch_call = next(payload for method, _, payload in calls if method == "PATCH")
+    assert patch_call == {"state": "Running"}
+    post_call = next(payload for method, _, payload in calls if method == "POST")
+    assert isinstance(post_call, dict)
+    assert "comment_html" in post_call
+    assert "<p>Hello</p><p>world</p>" in str(post_call["comment_html"])

--- a/tests/test_plane_parsing.py
+++ b/tests/test_plane_parsing.py
@@ -1,22 +1,45 @@
-from control_plane.adapters.plane import PlaneClient
+from control_plane.application.task_parser import TaskParser
 
 
-def test_execution_block_parse() -> None:
-    client = PlaneClient("http://plane.local", "token", "ws", "proj")
-    try:
-        parsed = client.parse_execution_metadata(
-            """## Execution
+def test_parser_extracts_execution_goal_constraints() -> None:
+    parser = TaskParser()
+    parsed = parser.parse(
+        """## Execution
 repo: repo_a
 base_branch: main
 mode: goal
+allowed_paths:
+  - src/
 open_pr: true
 
 ## Goal
-Do thing
+Do the thing.
+
+## Constraints
+- Keep tests green.
+"""
+    )
+
+    assert parsed.execution_metadata["repo"] == "repo_a"
+    assert parsed.execution_metadata["base_branch"] == "main"
+    assert parsed.execution_metadata["mode"] == "goal"
+    assert parsed.goal_text == "Do the thing."
+    assert parsed.constraints_text == "- Keep tests green."
+
+
+def test_parser_rejects_missing_required_execution_fields() -> None:
+    parser = TaskParser()
+
+    try:
+        parser.parse(
+            """## Execution
+repo: repo_a
+
+## Goal
+Do the thing.
 """
         )
-        assert parsed["repo"] == "repo_a"
-        assert parsed["base_branch"] == "main"
-        assert parsed["mode"] == "goal"
-    finally:
-        client.close()
+    except ValueError as exc:
+        assert "Missing execution metadata fields" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")

--- a/tests/test_scope_policy.py
+++ b/tests/test_scope_policy.py
@@ -1,0 +1,19 @@
+from control_plane.application.scope_policy import ChangedFilePolicyChecker
+
+
+def test_allowed_paths_accepts_in_scope_changes() -> None:
+    checker = ChangedFilePolicyChecker()
+    violations = checker.find_violations(
+        changed_files=["src/workflow/task.py", "tools/audit/report.py"],
+        allowed_paths=["src/workflow/", "tools/audit/"],
+    )
+    assert violations == []
+
+
+def test_allowed_paths_rejects_out_of_scope_changes() -> None:
+    checker = ChangedFilePolicyChecker()
+    violations = checker.find_violations(
+        changed_files=["src/workflow/task.py", "deployment/docker-compose.yml"],
+        allowed_paths=["src/workflow/"],
+    )
+    assert violations == ["deployment/docker-compose.yml"]


### PR DESCRIPTION
### Motivation

- Prevent control metadata from leaking into Kodo by separating `## Execution` from `## Goal` and `## Constraints` and making goal content first-class for execution. 
- Enforce repository edit scope so runs are blocked when changed files fall outside declared `allowed_paths`.
- Make Plane adapter and reporting behavior trustworthy for operators by verifying API shape, adding `run_id`-scoped retained artifacts, and ensuring reproducible commits via configurable git identity.

### Description

- Added a focused task parser `TaskParser` that extracts `execution_metadata`, `goal_text`, and optional `constraints_text` from task body sections and validates required fields; promoted parsed data into domain contracts (`ParsedTaskBody`, `goal_text`, `constraints_text`, `run_id`, `policy_violations`).
- Enforced scope and mode in the orchestration flow by updating `ExecutionService` to support `goal`-only mode, generate a `run_id`, compose `goal.md` from parsed goal/constraints only, set repo-local git identity before commits, and block/persist policy violations instead of pushing out-of-scope changes. 
- Implemented `ChangedFilePolicyChecker` and integrated it into the run flow to detect and record changes outside `allowed_paths`; reporter now writes `policy_violation.json` and `failure.md` and uses run-id keyed directories. 
- Updated adapters: Plane client moved to `work-items` endpoints, uses `X-API-Key`, parses canonical `description` via `TaskParser`, and posts `comment_html` as escaped HTML; Kodo adapter now writes a controlled `goal.md` composed of `Goal` and optional `Constraints`; Git client gained `set_identity` and no-op `commit_all` behavior. 
- Tests added/updated for task parsing, scope policy acceptance/rejection, unsupported execution mode handling, and mocked Plane HTTP flows; docs/README updated to reflect implemented MVP boundaries and current behavior.

### Testing

- Installed dev dependencies with `python -m pip install -q -e '.[dev]'` and ran linting with `ruff check .`; lint passed after a small fix. 
- Ran unit tests with `pytest -q`; all tests passed (`7 passed`). 
- Exercised the Plane adapter behavior with a mocked `httpx.MockTransport` test that verified fetch/patch/post interaction and `comment_html` rendering; the test succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb2e29b49c83249e79f8c15a9bb696)