### PR TITLE
Harden Plane+Kodo MVP execution semantics and artifact reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ PYTHONPATH=src python -m control_plane.entrypoints.worker.main --config config/c
 ```bash
 PYTHONPATH=src uvicorn control_plane.entrypoints.api.main:app --reload
 ```
+
+
+## Plane API verification note
+
+- Adapter targets Plane `work-items` endpoints under `/api/v1/workspaces/{workspace}/projects/{project}/work-items/{id}/`.
+- Auth header is `X-API-Key`.
+- Status transitions use `PATCH` with `{ "state": "<state>" }`.
+- Comments use `POST .../comments/` with structured `comment_html`.
+- This repository currently verifies these contracts via mocked HTTP tests; run a live smoke test against your Plane deployment before production use.

--- a/docs/design/plane_kodo_wrapper.md
+++ b/docs/design/plane_kodo_wrapper.md
@@ -38,7 +38,7 @@ allowed_paths:
   - src/workflow/long_form/
   - tools/audit/
 validation_profile: default
-open_pr: false
+# open_pr is reserved for future PR automation and ignored in MVP
 
 ## Goal
 Improve reporting output and ensure policy violations are visible.
@@ -46,3 +46,9 @@ Improve reporting output and ensure policy violations are visible.
 ## Constraints
 - Keep changes inside wrapper service code.
 ```
+
+
+## Runtime semantics
+
+- Current operation is **manual-by-task-id** (no scheduler/webhook yet).
+- If validation fails but `push_on_validation_failure` is enabled, the branch may still be pushed as **draft output**. This does not indicate run success.

--- a/src/control_plane/adapters/git/client.py
+++ b/src/control_plane/adapters/git/client.py
@@ -33,12 +33,33 @@ class GitClient:
         self._run(["git", "config", "user.email", author_email], cwd=repo_path)
 
     def changed_files(self, repo_path: Path) -> list[str]:
-        out = self._run(["git", "status", "--porcelain"], cwd=repo_path)
+        out = self._run(["git", "diff", "--name-status", "-z", "HEAD"], cwd=repo_path)
+        if not out:
+            return []
+
+        parts = [part for part in out.split("\x00") if part]
         files: list[str] = []
-        for line in out.splitlines():
-            if len(line) > 3:
-                files.append(line[3:])
-        return files
+        idx = 0
+        while idx < len(parts):
+            status = parts[idx]
+            idx += 1
+            status_code = status[0]
+            if status_code in {"R", "C"}:
+                if idx + 1 >= len(parts):
+                    break
+                idx += 1  # old path
+                new_path = parts[idx]
+                idx += 1
+                files.append(new_path)
+                continue
+
+            if idx >= len(parts):
+                break
+            files.append(parts[idx])
+            idx += 1
+
+        normalized = [str(Path(path)).replace("\\", "/").lstrip("./") for path in files]
+        return sorted(set(normalized))
 
     def commit_all(self, repo_path: Path, message: str) -> bool:
         self._run(["git", "add", "-A"], cwd=repo_path)

--- a/src/control_plane/adapters/plane/client.py
+++ b/src/control_plane/adapters/plane/client.py
@@ -45,7 +45,7 @@ class PlaneClient:
             labels=[label.get("name", "") for label in issue.get("labels", []) if isinstance(label, dict)],
             repo_key=str(metadata["repo"]),
             base_branch=str(metadata["base_branch"]),
-            execution_mode=str(metadata["mode"]),
+            execution_mode=metadata["mode"],
             allowed_paths=[str(path) for path in metadata.get("allowed_paths", [])],
             validation_profile=(
                 str(metadata.get("validation_profile")) if metadata.get("validation_profile") else None
@@ -65,8 +65,21 @@ class PlaneClient:
             f"/api/v1/workspaces/{self.workspace_slug}/projects/{self.project_id}/"
             f"work-items/{task_id}/comments/"
         )
-        html_body = "<p>" + "</p><p>".join(
-            html.escape(line) for line in comment_markdown.split("\n") if line.strip()
-        ) + "</p>"
-        response = self._client.post(url, json={"comment_html": html_body})
+        response = self._client.post(url, json={"comment_html": self._render_comment_html(comment_markdown)})
         response.raise_for_status()
+
+    @staticmethod
+    def _render_comment_html(comment_markdown: str) -> str:
+        lines = [line.strip() for line in comment_markdown.splitlines() if line.strip()]
+        if not lines:
+            return "<p>(no summary)</p>"
+
+        header = html.escape(lines[0])
+        items: list[str] = []
+        for line in lines[1:]:
+            if line.startswith("- "):
+                items.append(f"<li>{html.escape(line[2:])}</li>")
+
+        if items:
+            return f"<p>{header}</p><ul>{''.join(items)}</ul>"
+        return f"<p>{header}</p>"

--- a/src/control_plane/adapters/reporting/reporter.py
+++ b/src/control_plane/adapters/reporting/reporter.py
@@ -17,6 +17,21 @@ class Reporter:
         run_dir.mkdir(parents=True, exist_ok=True)
         return run_dir
 
+    def write_request_context(self, run_dir: Path, task_id: str, run_id: str, phase: str) -> str:
+        path = run_dir / "request_context.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "phase": phase,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
+        return str(path)
+
     def write_request(self, run_dir: Path, req: ExecutionRequest) -> str:
         path = run_dir / "request.json"
         path.write_text(req.model_dump_json(indent=2, exclude={"workspace_path", "goal_file_path"}))
@@ -41,9 +56,18 @@ class Reporter:
         path.write_text(json.dumps({"violations": violations}, indent=2))
         return str(path)
 
-    def write_failure(self, run_dir: Path, error: str) -> str:
-        path = run_dir / "failure.md"
-        path.write_text("# Execution Failure\n\n" + error + "\n")
+    def write_failure(self, run_dir: Path, error: str, phase: str) -> str:
+        path = run_dir / "failure.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "phase": phase,
+                    "error": error,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
         return str(path)
 
     def write_summary(self, run_dir: Path, result: ExecutionResult) -> str:
@@ -54,6 +78,8 @@ class Reporter:
             f"- success: {result.success}",
             f"- validation_passed: {result.validation_passed}",
             f"- branch_pushed: {result.branch_pushed}",
+            f"- draft_branch_pushed: {result.draft_branch_pushed}",
+            f"- push_reason: {result.push_reason}",
             f"- pull_request_url: {result.pull_request_url}",
             "",
             "## Changed Files",

--- a/src/control_plane/application/service.py
+++ b/src/control_plane/application/service.py
@@ -4,7 +4,6 @@ import os
 import re
 import traceback
 import uuid
-from pathlib import Path
 
 from control_plane.adapters.git import GitClient, branch_allowed
 from control_plane.adapters.kodo import KodoAdapter
@@ -47,25 +46,24 @@ class ExecutionService:
     def run_task(self, plane_client: PlaneClient, task_id: str) -> ExecutionResult:
         run_id = uuid.uuid4().hex[:12]
         workspace_path = self.workspace.create()
-        run_dir: Path | None = None
-        repo_path = Path()
+        run_dir = self.reporter.create_run_dir(task_id, run_id)
+        artifacts = [self.reporter.write_request_context(run_dir, task_id, run_id, phase="initialized")]
         task: BoardTask | None = None
+        phase = "initialized"
 
         try:
+            phase = "fetch_task"
             issue = plane_client.fetch_issue(task_id)
             task = plane_client.to_board_task(issue)
             repo_target = self._repo_target_for(task)
 
-            if task.execution_mode != "goal":
-                raise ValueError(
-                    f"Unsupported execution mode '{task.execution_mode}'. MVP currently supports only 'goal'."
-                )
-
             if not branch_allowed(task.base_branch, repo_target.allowed_base_branches):
                 raise ValueError(f"Base branch '{task.base_branch}' is not allowed by policy")
 
+            phase = "running"
             plane_client.transition_issue(task.task_id, "Running")
 
+            phase = "repo_setup"
             repo_path = self.git.clone(repo_target.clone_url, workspace_path)
             self.git.verify_remote_branch_exists(repo_path, task.base_branch)
             self.git.checkout_base(repo_path, task.base_branch)
@@ -89,9 +87,9 @@ class ExecutionService:
                 task_branch=task_branch,
                 goal_file_path=goal_file,
             )
-            run_dir = self.reporter.create_run_dir(task.task_id, run_id)
-            artifacts = [self.reporter.write_request(run_dir, req)]
+            artifacts.append(self.reporter.write_request(run_dir, req))
 
+            phase = "kodo"
             kodo_result = self.kodo.run(goal_file, repo_path)
             artifacts.extend(
                 self.reporter.write_kodo(
@@ -102,6 +100,7 @@ class ExecutionService:
                 )
             )
 
+            phase = "validation"
             run_env = os.environ.copy()
             run_env.update(repo_target.env)
             validation_results = self.validation.run(repo_target.validation_commands, repo_path, env=run_env)
@@ -118,19 +117,31 @@ class ExecutionService:
             if policy_violations:
                 artifacts.append(self.reporter.write_policy_violation(run_dir, policy_violations))
 
-            success = kodo_result.exit_code == 0 and validation_ok and not policy_violations
+            execution_success = kodo_result.exit_code == 0
+            policy_success = not policy_violations
+            success = execution_success and validation_ok and policy_success
 
             branch_pushed = False
-            if changed_files and not policy_violations and (success or self.settings.git.push_on_validation_failure):
+            draft_branch_pushed = False
+            push_reason: str | None = None
+            if changed_files and policy_success:
                 committed = self.git.commit_all(repo_path, f"chore: apply Plane task {task.task_id}")
                 if committed:
-                    self.git.push_branch(repo_path, task_branch)
-                    branch_pushed = True
+                    if success:
+                        self.git.push_branch(repo_path, task_branch)
+                        branch_pushed = True
+                        push_reason = "success"
+                    elif self.settings.git.push_on_validation_failure:
+                        self.git.push_branch(repo_path, task_branch)
+                        branch_pushed = True
+                        draft_branch_pushed = True
+                        push_reason = "draft_on_validation_failure"
 
             summary = (
-                f"run_id={run_id} kodo_exit={kodo_result.exit_code} "
+                f"run_id={run_id} execution={'passed' if execution_success else 'failed'} "
                 f"validation={'passed' if validation_ok else 'failed'} "
-                f"policy={'passed' if not policy_violations else 'failed'} "
+                f"policy={'passed' if policy_success else 'failed'} "
+                f"branch_push={push_reason or 'not_pushed'} "
                 f"changed_files={len(changed_files)}"
             )
 
@@ -141,6 +152,8 @@ class ExecutionService:
                 validation_passed=validation_ok,
                 validation_results=validation_results,
                 branch_pushed=branch_pushed,
+                draft_branch_pushed=draft_branch_pushed,
+                push_reason=push_reason,
                 pull_request_url=None,
                 summary=summary,
                 artifacts=artifacts,
@@ -153,12 +166,18 @@ class ExecutionService:
             plane_client.comment_issue(task.task_id, self._comment_markdown(task, result))
             return result
         except Exception:
-            if run_dir is not None:
-                self.reporter.write_failure(run_dir, traceback.format_exc())
+            artifacts.append(self.reporter.write_failure(run_dir, traceback.format_exc(), phase=phase))
             plane_client.transition_issue(task_id, "Blocked")
             plane_client.comment_issue(
                 task_id,
-                f"Execution failed (run_id={run_id}). See retained artifacts for details.",
+                "\n".join(
+                    [
+                        f"Execution failed for {task_id}",
+                        f"- run_id: {run_id}",
+                        f"- phase: {phase}",
+                        "- status: blocked",
+                    ]
+                ),
             )
             raise
         finally:
@@ -167,16 +186,15 @@ class ExecutionService:
     @staticmethod
     def _comment_markdown(task: BoardTask, result: ExecutionResult) -> str:
         lines = [
-            f"### AI execution result for {task.task_id}",
+            f"AI execution result for {task.task_id}",
             f"- run_id: {result.run_id}",
             f"- success: {result.success}",
             f"- validation_passed: {result.validation_passed}",
             f"- branch_pushed: {result.branch_pushed}",
+            f"- draft_branch_pushed: {result.draft_branch_pushed}",
+            f"- push_reason: {result.push_reason or 'not_pushed'}",
             f"- summary: {result.summary}",
         ]
         if result.policy_violations:
-            lines.append("- policy_violations:")
-            lines.extend([f"  - {path}" for path in result.policy_violations])
-        lines.extend(["", "Artifacts:"])
-        lines.extend([f"- `{artifact}`" for artifact in result.artifacts])
+            lines.append(f"- policy_violations: {', '.join(result.policy_violations)}")
         return "\n".join(lines)

--- a/src/control_plane/application/task_parser.py
+++ b/src/control_plane/application/task_parser.py
@@ -12,6 +12,7 @@ SECTION_PATTERN = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 
 class TaskParser:
     REQUIRED_EXEC_FIELDS = ("repo", "base_branch", "mode")
+    SUPPORTED_MODES = {"goal"}
 
     def parse(self, description: str) -> ParsedTaskBody:
         sections = self._extract_sections(description)
@@ -51,9 +52,15 @@ class TaskParser:
             sections[title] = description[content_start:content_end].strip("\n")
         return sections
 
-    @staticmethod
-    def _normalize_metadata(metadata: dict[str, Any]) -> dict[str, object]:
+    def _normalize_metadata(self, metadata: dict[str, Any]) -> dict[str, object]:
         data = dict(metadata)
+        mode = str(data["mode"]).strip().lower()
+        if mode not in self.SUPPORTED_MODES:
+            raise ValueError(
+                f"Unsupported execution mode '{data['mode']}'. MVP currently supports only 'goal'."
+            )
+        data["mode"] = mode
+
         allowed_paths = data.get("allowed_paths", [])
         if isinstance(allowed_paths, str):
             allowed_paths = [allowed_paths]

--- a/src/control_plane/domain/models.py
+++ b/src/control_plane/domain/models.py
@@ -6,7 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-ExecutionMode = Literal["goal", "test", "improve"]
+ExecutionMode = Literal["goal"]
 
 
 class ParsedTaskBody(BaseModel):
@@ -66,6 +66,8 @@ class ExecutionResult(BaseModel):
     validation_passed: bool = False
     validation_results: list[ValidationResult] = Field(default_factory=list)
     branch_pushed: bool = False
+    draft_branch_pushed: bool = False
+    push_reason: str | None = None
     pull_request_url: str | None = None
     summary: str
     artifacts: list[str] = Field(default_factory=list)

--- a/tests/test_git_client.py
+++ b/tests/test_git_client.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from control_plane.adapters.git.client import GitClient
+
+
+class FakeGitClient(GitClient):
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+    def _run(self, args: list[str], cwd: Path | None = None) -> str:  # noqa: ARG002
+        return self.output
+
+
+def test_changed_files_handles_rename_output() -> None:
+    output = "R100\x00old/path.py\x00new/path.py\x00M\x00src/main.py\x00"
+    client = FakeGitClient(output)
+
+    assert client.changed_files(Path(".")) == ["new/path.py", "src/main.py"]

--- a/tests/test_plane_client_http.py
+++ b/tests/test_plane_client_http.py
@@ -6,11 +6,11 @@ from control_plane.adapters.plane import PlaneClient
 
 
 def test_plane_comment_and_state_update_flow() -> None:
-    calls: list[tuple[str, str, dict[str, object] | None]] = []
+    calls: list[tuple[str, str, dict[str, object] | None, dict[str, str]]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         payload = json.loads(request.content.decode()) if request.content else None
-        calls.append((request.method, str(request.url), payload))
+        calls.append((request.method, str(request.url), payload, dict(request.headers)))
 
         if request.method == "GET":
             return httpx.Response(
@@ -35,20 +35,28 @@ Do thing.
 
     transport = httpx.MockTransport(handler)
     client = PlaneClient("http://plane.local", "token", "ws", "proj")
-    client._client = httpx.Client(transport=transport, base_url="http://plane.local")  # type: ignore[attr-defined]
+    client._client = httpx.Client(  # type: ignore[attr-defined]
+        transport=transport,
+        base_url="http://plane.local",
+        headers={"X-API-Key": "token", "Content-Type": "application/json"},
+    )
 
     try:
         issue = client.fetch_issue("TASK-1")
         task = client.to_board_task(issue)
         client.transition_issue(task.task_id, "Running")
-        client.comment_issue(task.task_id, "Hello\nworld")
+        client.comment_issue(task.task_id, "Result\n- success: true\n- run_id: abc")
     finally:
         client.close()
 
-    assert any("/work-items/TASK-1/" in url for _, url, _ in calls)
-    patch_call = next(payload for method, _, payload in calls if method == "PATCH")
+    assert any("/work-items/TASK-1/" in url for _, url, _, _ in calls)
+    patch_call = next(payload for method, _, payload, _ in calls if method == "PATCH")
     assert patch_call == {"state": "Running"}
-    post_call = next(payload for method, _, payload in calls if method == "POST")
+
+    post_call = next(payload for method, _, payload, _ in calls if method == "POST")
     assert isinstance(post_call, dict)
     assert "comment_html" in post_call
-    assert "<p>Hello</p><p>world</p>" in str(post_call["comment_html"])
+    assert "<ul><li>success: true</li><li>run_id: abc</li></ul>" in str(post_call["comment_html"])
+
+    for _, _, _, headers in calls:
+        assert headers.get("x-api-key") == "token"

--- a/tests/test_plane_parsing.py
+++ b/tests/test_plane_parsing.py
@@ -1,3 +1,5 @@
+import pytest
+
 from control_plane.application.task_parser import TaskParser
 
 
@@ -7,7 +9,7 @@ def test_parser_extracts_execution_goal_constraints() -> None:
         """## Execution
 repo: repo_a
 base_branch: main
-mode: goal
+mode: GOAL
 allowed_paths:
   - src/
 open_pr: true
@@ -30,7 +32,7 @@ Do the thing.
 def test_parser_rejects_missing_required_execution_fields() -> None:
     parser = TaskParser()
 
-    try:
+    with pytest.raises(ValueError, match="Missing execution metadata fields"):
         parser.parse(
             """## Execution
 repo: repo_a
@@ -39,7 +41,18 @@ repo: repo_a
 Do the thing.
 """
         )
-    except ValueError as exc:
-        assert "Missing execution metadata fields" in str(exc)
-    else:
-        raise AssertionError("Expected ValueError")
+
+
+def test_parser_rejects_invalid_execution_mode() -> None:
+    parser = TaskParser()
+    with pytest.raises(ValueError, match="supports only 'goal'"):
+        parser.parse(
+            """## Execution
+repo: repo_a
+base_branch: main
+mode: improve
+
+## Goal
+Do the thing.
+"""
+        )

--- a/tests/test_service_reporting.py
+++ b/tests/test_service_reporting.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+
+from control_plane.application.service import ExecutionService
+from control_plane.config.settings import Settings
+from control_plane.domain.models import ExecutionResult
+
+
+class FailingParsePlaneClient:
+    def fetch_issue(self, task_id: str) -> dict[str, object]:
+        return {
+            "id": task_id,
+            "name": "Task",
+            "project_id": "proj",
+            "description": """## Execution
+repo: repo_a
+base_branch: main
+mode: bad
+
+## Goal
+Do thing.
+""",
+            "state": {"name": "Ready for AI"},
+            "labels": [],
+        }
+
+    def to_board_task(self, issue: dict[str, object]):  # type: ignore[no-untyped-def]
+        from control_plane.adapters.plane import PlaneClient
+
+        c = PlaneClient("http://plane.local", "token", "ws", "proj")
+        try:
+            return c.to_board_task(issue)
+        finally:
+            c.close()
+
+    def transition_issue(self, task_id: str, state: str) -> None:  # noqa: ARG002
+        return
+
+    def comment_issue(self, task_id: str, comment_markdown: str) -> None:  # noqa: ARG002
+        return
+
+
+@pytest.fixture
+def settings(tmp_path: Path) -> Settings:
+    return Settings.model_validate(
+        {
+            "plane": {
+                "base_url": "http://plane.local",
+                "api_token_env": "PLANE_API_TOKEN",
+                "workspace_slug": "ws",
+                "project_id": "proj",
+            },
+            "git": {"provider": "github"},
+            "kodo": {},
+            "repos": {
+                "repo_a": {
+                    "clone_url": "git@github.com:you/repo_a.git",
+                    "default_branch": "main",
+                }
+            },
+            "report_root": str(tmp_path / "reports"),
+        }
+    )
+
+
+def test_early_failure_writes_retained_failure_artifact(settings: Settings) -> None:
+    service = ExecutionService(settings)
+    with pytest.raises(ValueError, match="supports only 'goal'"):
+        service.run_task(FailingParsePlaneClient(), "TASK-2")
+
+    run_dirs = list(settings.report_root.glob("*_TASK-2_*"))
+    assert len(run_dirs) == 1
+    run_dir = run_dirs[0]
+    assert (run_dir / "request_context.json").exists()
+    assert (run_dir / "failure.json").exists()
+
+
+def test_draft_push_summary_is_explicit() -> None:
+    task = type("Task", (), {"task_id": "TASK-3"})
+    result = ExecutionResult(
+        run_id="abc",
+        success=False,
+        validation_passed=False,
+        branch_pushed=True,
+        draft_branch_pushed=True,
+        push_reason="draft_on_validation_failure",
+        summary="run_id=abc execution=passed validation=failed policy=passed branch_push=draft_on_validation_failure",
+    )
+
+    comment = ExecutionService._comment_markdown(task, result)
+    assert "- draft_branch_pushed: True" in comment
+    assert "- push_reason: draft_on_validation_failure" in comment


### PR DESCRIPTION
### Motivation

- Make the wrapper trustworthy by ensuring every run (including early failures) produces retained artifacts and a stable `run_id` for operator troubleshooting.
- Prevent accidental misuse by validating and normalizing execution mode at parse time and enforcing MVP support for `goal` only.
- Improve scope and git handling by making changed-file detection rename-aware and making branch-push semantics explicit so draft pushes are not mistaken for success.
- Reduce fragile Plane interactions by producing deliberate, structured comment HTML and documenting the verified API contract.

### Description

- Create the retained run directory immediately and write a `request_context.json` at start, and write structured `failure.json` on all failure paths; Reporter gained `write_request_context` and `write_failure` now emits JSON with `phase` metadata.
- Tighten parsing and domain contracts: `TaskParser` normalizes/validates `mode` (rejects unsupported modes) and `ExecutionMode` in `domain/models.py` is narrowed to `"goal"`; parsed `goal_text`/`constraints_text` are used for Kodo goal material only.
- Strengthen changed-file detection by replacing porcelain parsing with `git diff --name-status -z HEAD` handling that explicitly supports renames/copies and returns normalized repo-relative paths; `GitClient.changed_files` updated accordingly.
- Clarify push/report semantics: `ExecutionResult` and reporting now include `draft_branch_pushed` and `push_reason`; `ExecutionService` tracks `phase`, writes early artifacts, records failures with phase, and only pushes branches according to policy and success/draft rules.
- Plane adapter now renders structured HTML for comments (`<p>` + optional `<ul><li>...</li>`) and uses the `work-items` endpoints with `X-API-Key` header; README/docs updated to mark `open_pr` as reserved and include a Plane API verification note.
- Tests added/updated to cover parsing normalization and rejection, rename-aware changed-file parsing, early failure retained artifacts, Plane comment/state flow with mocked HTTP, and draft-push summary semantics.

### Testing

- Ran `pytest -q` and all tests passed (`11 passed`).
- Ran lint and checks with `ruff check . && pytest -q` and fixed the one reported lint issue; final run passed.
- Key test files exercised: `tests/test_plane_parsing.py`, `tests/test_plane_client_http.py`, `tests/test_git_client.py`, and `tests/test_service_reporting.py` (mocked HTTP and unit checks covered).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb30d21f688324995ac38f3675a366)