### PR TITLE
feat(contracts): enforce contract boundaries + contract map (Phase 3)

### DIFF
--- a/docs/architecture/contract-map.md
+++ b/docs/architecture/contract-map.md
@@ -1,0 +1,120 @@
+# Contract Map
+
+Single source of truth for what each canonical contract is, where it lives,
+who produces it, and who consumes it.
+
+---
+
+## Canonical Contracts
+
+| Contract | File | Line | Description |
+|---|---|---|---|
+| `TaskProposal` | `src/control_plane/contracts/proposal.py` | 31 | What needs to be done, where, and under what constraints |
+| `LaneDecision` | `src/control_plane/contracts/routing.py` | 28 | Selected lane/backend and routing rationale from SwitchBoard |
+| `ExecutionRequest` | `src/control_plane/contracts/execution.py` | 38 | Everything a backend adapter needs to carry out the work |
+| `ExecutionResult` | `src/control_plane/contracts/execution.py` | 146 | Backend-agnostic outcome of one execution run |
+
+All four are Pydantic v2 `BaseModel` with `model_config = {"frozen": True}`.
+All four are fully serializable via `.model_dump(mode="json")` / `.model_validate()`.
+All four are re-exported from `control_plane.contracts` (the public API surface).
+
+---
+
+## Supporting Types
+
+| Type | File | Role |
+|---|---|---|
+| `TaskTarget` | `contracts/common.py` | Repo coordinates (key, clone URL, base branch, allowed paths) |
+| `ExecutionConstraints` | `contracts/common.py` | Execution limits (timeout, max files, path restriction) |
+| `ValidationProfile` | `contracts/common.py` | Validation commands and fail-fast policy |
+| `BranchPolicy` | `contracts/common.py` | Branch prefix, push-on-success, PR policy |
+| `ExecutionArtifact` | `contracts/execution.py` | Discrete artifact produced during execution (diff, log, report) |
+| `RunTelemetry` | `contracts/execution.py` | Timing and token counts for one run |
+| `LaneName`, `BackendName`, `TaskType`, etc. | `contracts/enums.py` | Closed enum sets for all typed fields |
+
+---
+
+## Contract Flow
+
+```
+PlanningContext          internal ControlPlane type; pre-validation raw input
+    │
+    │  planning/proposal_builder.py :: build_proposal()
+    │  (enum validation, field mapping, branch/validation policy construction)
+    ▼
+TaskProposal             frozen Pydantic model; backend-agnostic
+    │
+    │  routing/client.py :: HttpLaneRoutingClient.select_lane()
+    │  (HTTP POST /route → SwitchBoard; deserializes response)
+    ▼
+LaneDecision             frozen Pydantic model; produced exclusively by SwitchBoard
+    │
+    │  [bundled as ProposalDecisionBundle in planning/models.py]
+    │
+    │  execution/handoff.py :: ExecutionRequestBuilder.build()
+    │  (merges proposal + decision + runtime context)
+    ▼
+ExecutionRequest         frozen Pydantic model; adapter input
+    │
+    │  backends/{kodo,archon,openclaw,direct_local}/adapter.py :: execute()
+    ▼
+ExecutionResult          frozen Pydantic model; backend-agnostic outcome
+    │
+    │  observability/service.py :: ExecutionObservabilityService.observe()
+    ▼
+ExecutionRecord + ExecutionTrace   internal observability types (not part of the public contract chain)
+```
+
+---
+
+## Producer / Consumer Table
+
+| Contract | Producer | Consumers |
+|---|---|---|
+| `TaskProposal` | `planning/proposal_builder.py::build_proposal()` | `HttpLaneRoutingClient` (→ SwitchBoard), `PolicyEngine`, `ExecutionRequestBuilder` |
+| `LaneDecision` | SwitchBoard (external service, via `routing/client.py`) | `ExecutionCoordinator`, `PolicyEngine`, `ExecutionRequestBuilder` |
+| `ExecutionRequest` | `execution/handoff.py::ExecutionRequestBuilder.build()` | All backend adapters (`kodo`, `archon`, `openclaw`, `direct_local`) |
+| `ExecutionResult` | Backend adapters | `ExecutionCoordinator`, `ExecutionObservabilityService` |
+
+---
+
+## Invariants
+
+1. **One definition per contract.** Each of the four contracts is defined in exactly
+   one file. No aliases, re-implementations, or competing definitions exist.
+
+2. **SwitchBoard owns `LaneDecision`.** ControlPlane never constructs a `LaneDecision`
+   in the live execution path. The only live producer is `HttpLaneRoutingClient`, which
+   deserializes the SwitchBoard HTTP response.
+
+3. **`TaskProposal` is produced once per task.** Only `proposal_builder.py::build_proposal()`
+   constructs `TaskProposal` in the live path. No adapter, coordinator, or policy engine
+   creates one.
+
+4. **No raw dicts cross contract boundaries.** `ExecutionRequest` and `ExecutionResult`
+   are always Pydantic models at the adapter boundary. Dicts appear only in serialization
+   output (`.model_dump(mode="json")`) and in observability metadata annotations.
+
+5. **Policy gates validate, not re-route.** `PolicyEngine._check_routing_constraints()`
+   blocks proposals whose labels conflict with SwitchBoard's decision — it does not
+   override or replace the routing decision with a different lane.
+
+6. **`ExecutionCoordinator` constructs `ExecutionResult` only on policy block.**
+   In the policy-blocked case, no adapter runs; the coordinator synthesizes a
+   `SKIPPED` result. This is the one exception to "adapters produce `ExecutionResult`"
+   and is intentional — no execution occurred.
+
+---
+
+## Internal Boundary Types (Not Contracts)
+
+These types carry context within ControlPlane but are not part of the public contract chain:
+
+| Type | File | Purpose |
+|---|---|---|
+| `PlanningContext` | `planning/models.py` | Raw planning input; pre-validation; converted to `TaskProposal` by `proposal_builder.py` |
+| `ProposalBuildResult` | `planning/models.py` | Wraps `TaskProposal` + original context for traceability |
+| `ProposalDecisionBundle` | `planning/models.py` | Pairs `TaskProposal` + `LaneDecision` for handoff to execution |
+| `ExecutionRuntimeContext` | `execution/handoff.py` | Runtime-resolved paths (workspace, branch) not present in the proposal |
+| `PolicyDecision` | `policy/models.py` | Policy gate outcome; consumed by `ExecutionCoordinator` only |
+| `ExecutionRecord`, `ExecutionTrace` | `observability/models.py` | Audit log entries; not returned to callers |

--- a/src/control_plane/planning/models.py
+++ b/src/control_plane/planning/models.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from control_plane.contracts.proposal import TaskProposal
+    from control_plane.contracts.routing import LaneDecision
 
 
 def _utcnow() -> datetime:
@@ -64,8 +68,6 @@ class PlanningContext:
 class ProposalBuildResult:
     """Outcome of building a TaskProposal from a PlanningContext."""
 
-    from control_plane.contracts.proposal import TaskProposal
-
     proposal: "TaskProposal"
     context: PlanningContext
     built_at: datetime = field(default_factory=_utcnow)
@@ -79,9 +81,6 @@ class ProposalDecisionBundle:
     Downstream execution phases use this bundle to construct ExecutionRequest
     without needing to re-derive context or re-query SwitchBoard.
     """
-
-    from control_plane.contracts.proposal import TaskProposal
-    from control_plane.contracts.routing import LaneDecision
 
     proposal: "TaskProposal"
     decision: "LaneDecision"

--- a/src/control_plane/policy/engine.py
+++ b/src/control_plane/policy/engine.py
@@ -31,6 +31,7 @@ import fnmatch
 import logging
 from typing import Optional
 
+from control_plane.contracts.enums import LaneName
 from control_plane.contracts.execution import ExecutionRequest
 from control_plane.contracts.proposal import TaskProposal
 from control_plane.contracts.routing import LaneDecision
@@ -50,7 +51,7 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 # Lane names that are considered "local" execution.
-_LOCAL_LANES = frozenset({"aider_local"})
+_LOCAL_LANES = frozenset({LaneName.AIDER_LOCAL.value})
 
 # Labels on a proposal that restrict to local execution only.
 _LOCAL_ONLY_LABELS = frozenset({"local_only", "no_remote"})


### PR DESCRIPTION
## Summary

- `planning/models.py`: remove class-level imports of `TaskProposal`/`LaneDecision` from `ProposalBuildResult` and `ProposalDecisionBundle`; replace with `TYPE_CHECKING` block at module level
- `policy/engine.py`: derive `_LOCAL_LANES` from `LaneName.AIDER_LOCAL.value` instead of hardcoding the string `"aider_local"`
- `docs/architecture/contract-map.md`: new — canonical contract ownership, flow diagram, producer/consumer table, and six invariants

## Findings

All four contracts were already defined in exactly one place with no duplicates, the flow already strictly followed `TaskProposal → LaneDecision → ExecutionRequest → ExecutionResult` with no raw dict bypasses, and SwitchBoard was already the only routing boundary. Two precision issues remained:

1. Class-level imports in `planning/models.py` created unexpected class attributes and defeated static analysis — no runtime impact but bad semantics
2. `_LOCAL_LANES` used a raw string literal instead of the canonical enum value — potential drift if the enum value ever changed

## Test plan

- [x] All 1791 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)