### PR TITLE
refactor(contracts): align ExecutionStatus spelling with ECP

### DIFF
--- a/src/operations_center/backends/archon/normalize.py
+++ b/src/operations_center/backends/archon/normalize.py
@@ -59,7 +59,7 @@ def normalize(
         validation_duration_ms: Validation wall-clock time.
     """
     success = capture.succeeded
-    status = ExecutionStatus.SUCCESS if success else _map_failure_status(capture)
+    status = ExecutionStatus.SUCCEEDED if success else _map_failure_status(capture)
 
     changed_files, changed_files_source, changed_files_confidence = (
         _discover_changed_files(workspace_path) if workspace_path else ([], "unknown", 0.0)
@@ -109,7 +109,7 @@ def normalize(
 
 def _map_failure_status(capture: ArchonRunCapture) -> ExecutionStatus:
     if capture.timeout_hit or capture.outcome == "timeout":
-        return ExecutionStatus.TIMEOUT
+        return ExecutionStatus.TIMED_OUT
     return ExecutionStatus.FAILED
 
 

--- a/src/operations_center/backends/direct_local/adapter.py
+++ b/src/operations_center/backends/direct_local/adapter.py
@@ -56,7 +56,7 @@ class DirectLocalBackendAdapter:
             run_id=request.run_id,
             proposal_id=request.proposal_id,
             decision_id=request.decision_id,
-            status=ExecutionStatus.SUCCESS if result.success else _failure_status(result),
+            status=ExecutionStatus.SUCCEEDED if result.success else _failure_status(result),
             success=result.success,
             changed_files=changed_files,
             changed_files_source=changed_files_source,
@@ -150,7 +150,7 @@ class _DirectLocalRunResult:
 
 def _failure_status(result) -> ExecutionStatus:
     if result.metadata.get("timeout_hit"):
-        return ExecutionStatus.TIMEOUT
+        return ExecutionStatus.TIMED_OUT
     return ExecutionStatus.FAILED
 
 

--- a/src/operations_center/backends/kodo/normalize.py
+++ b/src/operations_center/backends/kodo/normalize.py
@@ -54,7 +54,7 @@ def normalize(
         validation_excerpt:   First failure output if validation failed.
         validation_duration_ms: Validation wall-clock time.
     """
-    status = ExecutionStatus.SUCCESS if capture.succeeded else _map_failure_status(capture)
+    status = ExecutionStatus.SUCCEEDED if capture.succeeded else _map_failure_status(capture)
     success = capture.succeeded
 
     changed_files, changed_files_source, changed_files_confidence = (
@@ -105,7 +105,7 @@ def normalize(
 
 def _map_failure_status(capture: KodoRunCapture) -> ExecutionStatus:
     if capture.timeout_hit:
-        return ExecutionStatus.TIMEOUT
+        return ExecutionStatus.TIMED_OUT
     return ExecutionStatus.FAILED
 
 

--- a/src/operations_center/backends/openclaw/normalize.py
+++ b/src/operations_center/backends/openclaw/normalize.py
@@ -71,7 +71,7 @@ def normalize(
         validation_duration_ms: Validation wall-clock time.
     """
     success = capture.succeeded
-    status = ExecutionStatus.SUCCESS if success else _map_failure_status(capture)
+    status = ExecutionStatus.SUCCEEDED if success else _map_failure_status(capture)
 
     changed_files, resolved_source = _resolve_changed_files(capture, workspace_path)
     diff_stat = _build_diff_stat(changed_files)
@@ -205,7 +205,7 @@ def _git_status_to_change_type(status: str) -> str:
 
 def _map_failure_status(capture: OpenClawRunCapture) -> ExecutionStatus:
     if capture.timeout_hit or capture.outcome == "timeout":
-        return ExecutionStatus.TIMEOUT
+        return ExecutionStatus.TIMED_OUT
     return ExecutionStatus.FAILED
 
 

--- a/src/operations_center/contracts/enums.py
+++ b/src/operations_center/contracts/enums.py
@@ -51,10 +51,10 @@ class ExecutionStatus(str, Enum):
     """Terminal or in-progress outcome of an execution run."""
     PENDING = "pending"
     RUNNING = "running"
-    SUCCESS = "success"
+    SUCCEEDED = "succeeded"
     FAILED = "failed"
     SKIPPED = "skipped"
-    TIMEOUT = "timeout"
+    TIMED_OUT = "timed_out"
     CANCELLED = "cancelled"
 
 

--- a/src/operations_center/contracts/execution.py
+++ b/src/operations_center/contracts/execution.py
@@ -158,7 +158,7 @@ class ExecutionResult(BaseModel):
 
     # Outcome
     status: ExecutionStatus
-    success: bool = Field(description="True only when status == SUCCESS")
+    success: bool = Field(description="True only when status == SUCCEEDED")
 
     # What changed
     changed_files: list[ChangedFileRef] = Field(default_factory=list)

--- a/src/operations_center/tuning/compare.py
+++ b/src/operations_center/tuning/compare.py
@@ -172,7 +172,7 @@ def _build_summary(
     timeout_count = sum(
         1 for r in records
         if r.result.failure_category == FailureReasonCategory.TIMEOUT
-        or r.result.status == ExecutionStatus.TIMEOUT
+        or r.result.status == ExecutionStatus.TIMED_OUT
     )
 
     val_pass_count = sum(

--- a/tests/integration/test_execution_boundary.py
+++ b/tests/integration/test_execution_boundary.py
@@ -171,7 +171,7 @@ def test_aider_adapter_returns_result_for_trivial_goal(tmp_path: Path, aider_bin
     assert isinstance(result, ExecutionResult)
     assert result.proposal_id == bundle.proposal.proposal_id
     # Status may be SUCCESS or FAILED depending on aider's result — both are valid
-    assert result.status in {ExecutionStatus.SUCCESS, ExecutionStatus.FAILED}
+    assert result.status in {ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/archon/test_adapter.py
+++ b/tests/unit/backends/archon/test_adapter.py
@@ -81,7 +81,7 @@ def test_execute_returns_execution_result(tmp_path):
 
 def test_successful_execution_gives_success_status(tmp_path):
     result = _adapter(_mock_archon(outcome="success")).execute(_req(tmp_path))
-    assert result.status == ExecutionStatus.SUCCESS
+    assert result.status == ExecutionStatus.SUCCEEDED
     assert result.success is True
 
 
@@ -118,7 +118,7 @@ def test_backend_failure_returns_failed_status(tmp_path):
 def test_timeout_outcome_gives_timeout_status(tmp_path):
     archon = _mock_archon(outcome="timeout")
     result = ArchonBackendAdapter(archon).execute(_req(tmp_path))
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
     assert result.failure_category == FailureReasonCategory.TIMEOUT
 
 

--- a/tests/unit/backends/archon/test_normalize.py
+++ b/tests/unit/backends/archon/test_normalize.py
@@ -50,7 +50,7 @@ def _capture(
 
 def test_success_outcome_gives_success_status():
     result = normalize(_capture(), proposal_id="p1", decision_id="d1")
-    assert result.status == ExecutionStatus.SUCCESS
+    assert result.status == ExecutionStatus.SUCCEEDED
     assert result.success is True
 
 
@@ -124,13 +124,13 @@ def test_failure_reason_set_on_failure():
 def test_timeout_outcome_gives_timeout_status():
     c = _capture(outcome="timeout", timeout_hit=True)
     result = normalize(c, proposal_id="p1", decision_id="d1")
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
 
 
 def test_timeout_hit_flag_gives_timeout_status():
     c = _capture(outcome="failure", timeout_hit=True)
     result = normalize(c, proposal_id="p1", decision_id="d1")
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
 
 
 def test_timeout_failure_category():

--- a/tests/unit/backends/direct_local/test_adapter.py
+++ b/tests/unit/backends/direct_local/test_adapter.py
@@ -98,7 +98,7 @@ class TestSuccess:
         with patch("subprocess.run", return_value=_fake_proc(returncode=0)):
             result = _adapter().execute(_request(tmp_path))
         assert result.success is True
-        assert result.status == ExecutionStatus.SUCCESS
+        assert result.status == ExecutionStatus.SUCCEEDED
 
     def test_success_has_no_failure_category(self, tmp_path):
         repo = tmp_path / "repo"
@@ -157,7 +157,7 @@ class TestTimeout:
         repo.mkdir()
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="aider", timeout=30)):
             result = _adapter(timeout_seconds=30).execute(_request(tmp_path))
-        assert result.status == ExecutionStatus.TIMEOUT
+        assert result.status == ExecutionStatus.TIMED_OUT
 
     def test_timeout_sets_timeout_failure_category(self, tmp_path):
         repo = tmp_path / "repo"

--- a/tests/unit/backends/kodo/test_adapter.py
+++ b/tests/unit/backends/kodo/test_adapter.py
@@ -88,7 +88,7 @@ class TestExecuteSuccess:
         adapter = _adapter(_mock_kodo(exit_code=0))
         result = adapter.execute(_request(tmp_path))
         assert result.success is True
-        assert result.status == ExecutionStatus.SUCCESS
+        assert result.status == ExecutionStatus.SUCCEEDED
 
     def test_run_id_preserved(self, tmp_path):
         repo = tmp_path / "repo"

--- a/tests/unit/backends/kodo/test_normalize.py
+++ b/tests/unit/backends/kodo/test_normalize.py
@@ -63,7 +63,7 @@ class TestSuccessNormalization:
     def test_success_result_fields(self):
         result = _normalize(_capture(exit_code=0))
         assert result.success is True
-        assert result.status == ExecutionStatus.SUCCESS
+        assert result.status == ExecutionStatus.SUCCEEDED
         assert result.failure_category is None
         assert result.failure_reason is None
 
@@ -120,7 +120,7 @@ class TestFailureNormalization:
     def test_timeout_status(self):
         capture = _capture(exit_code=-1, stderr="[timeout: process group killed after 300s]", timeout_hit=True)
         result = _normalize(capture)
-        assert result.status == ExecutionStatus.TIMEOUT
+        assert result.status == ExecutionStatus.TIMED_OUT
         assert result.failure_category == FailureReasonCategory.TIMEOUT
 
     def test_failure_reason_populated(self):
@@ -212,4 +212,4 @@ class TestResultSerialisation:
         import json
         result = _normalize(_capture())
         parsed = json.loads(result.model_dump_json())
-        assert parsed["status"] == "success"
+        assert parsed["status"] == "succeeded"

--- a/tests/unit/backends/openclaw/test_adapter.py
+++ b/tests/unit/backends/openclaw/test_adapter.py
@@ -85,7 +85,7 @@ def test_execute_returns_execution_result(tmp_path):
 def test_execute_success_status(tmp_path):
     adapter = OpenClawBackendAdapter.with_stub(outcome="success")
     result = adapter.execute(_req(tmp_path))
-    assert result.status == ExecutionStatus.SUCCESS
+    assert result.status == ExecutionStatus.SUCCEEDED
     assert result.success is True
 
 
@@ -125,7 +125,7 @@ def test_execute_failure_status(tmp_path):
 def test_execute_timeout_status(tmp_path):
     adapter = OpenClawBackendAdapter.with_stub(outcome="timeout")
     result = adapter.execute(_req(tmp_path))
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
 
 
 def test_execute_unsupported_request_returns_unsupported_request(tmp_path):

--- a/tests/unit/backends/openclaw/test_normalize.py
+++ b/tests/unit/backends/openclaw/test_normalize.py
@@ -56,7 +56,7 @@ def _capture(
 
 def test_success_outcome_gives_success_status():
     result = normalize(_capture(), proposal_id="p1", decision_id="d1")
-    assert result.status == ExecutionStatus.SUCCESS
+    assert result.status == ExecutionStatus.SUCCEEDED
     assert result.success is True
 
 
@@ -113,7 +113,7 @@ def test_timeout_gives_timeout_status():
         _capture(outcome="timeout", timeout_hit=True),
         proposal_id="p1", decision_id="d1",
     )
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
     assert result.success is False
 
 
@@ -122,7 +122,7 @@ def test_timeout_hit_flag_also_gives_timeout():
         _capture(outcome="failure", timeout_hit=True),
         proposal_id="p1", decision_id="d1",
     )
-    assert result.status == ExecutionStatus.TIMEOUT
+    assert result.status == ExecutionStatus.TIMED_OUT
 
 
 def test_failure_category_set():

--- a/tests/unit/contracts/test_enums.py
+++ b/tests/unit/contracts/test_enums.py
@@ -50,7 +50,7 @@ class TestBackendName:
 
 class TestExecutionStatus:
     def test_terminal_states_present(self):
-        terminals = {"success", "failed", "skipped", "timeout", "cancelled"}
+        terminals = {"succeeded", "failed", "skipped", "timed_out", "cancelled"}
         assert terminals <= {m.value for m in ExecutionStatus}
 
     def test_in_progress_states_present(self):

--- a/tests/unit/contracts/test_execution.py
+++ b/tests/unit/contracts/test_execution.py
@@ -47,7 +47,7 @@ def _minimal_result(**kw) -> ExecutionResult:
         run_id="run-1",
         proposal_id="prop-1",
         decision_id="dec-1",
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
     )
     defaults.update(kw)
@@ -227,7 +227,7 @@ class TestExecutionResult:
     def test_minimal_success(self):
         r = _minimal_result()
         assert r.success is True
-        assert r.status == ExecutionStatus.SUCCESS
+        assert r.status == ExecutionStatus.SUCCEEDED
         assert r.changed_files == []
         assert r.artifacts == []
         assert r.branch_pushed is False
@@ -298,7 +298,7 @@ class TestExecutionResult:
     def test_json_enum_values_are_strings(self):
         r = _minimal_result()
         parsed = json.loads(r.model_dump_json())
-        assert parsed["status"] == "success"
+        assert parsed["status"] == "succeeded"
 
     def test_failed_result_round_trip(self):
         r = _minimal_result(
@@ -323,7 +323,7 @@ class TestContractIntegration:
             run_id="run-99",
             proposal_id="prop-1",
             decision_id="dec-1",
-            status=ExecutionStatus.SUCCESS,
+            status=ExecutionStatus.SUCCEEDED,
             success=True,
             changed_files=[ChangedFileRef(path="src/x.py", lines_added=5)],
             changed_files_source="git_diff",

--- a/tests/unit/execution/test_artifact_writer.py
+++ b/tests/unit/execution/test_artifact_writer.py
@@ -53,7 +53,7 @@ def _success_result(request: ExecutionRequest) -> ExecutionResult:
         run_id=request.run_id,
         proposal_id=request.proposal_id,
         decision_id=request.decision_id,
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         validation=ValidationSummary(status=ValidationStatus.PASSED),
     )
@@ -174,7 +174,7 @@ class TestWriteRun:
         run_dir = tmp_path / "runs" / result.run_id
         data = json.loads((run_dir / "result.json").read_text())
         assert data["success"] is True
-        assert data["status"] == ExecutionStatus.SUCCESS.value
+        assert data["status"] == ExecutionStatus.SUCCEEDED.value
 
     def test_execution_request_json_is_valid(self, tmp_path):
         bundle = _bundle()

--- a/tests/unit/execution/test_coordinator.py
+++ b/tests/unit/execution/test_coordinator.py
@@ -108,7 +108,7 @@ def _success_result(bundle: ProposalDecisionBundle) -> ExecutionResult:
         run_id="run-1",
         proposal_id=bundle.proposal.proposal_id,
         decision_id=bundle.decision.decision_id,
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         validation=ValidationSummary(status=ValidationStatus.SKIPPED),
     )
@@ -218,7 +218,7 @@ def test_canonical_observability_preserves_inferred_changed_files_status() -> No
         run_id="run-2",
         proposal_id=bundle.proposal.proposal_id,
         decision_id=bundle.decision.decision_id,
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[ChangedFileRef(path="src/inferred.py", change_type="modified")],
         changed_files_source="event_stream",

--- a/tests/unit/observability/conftest.py
+++ b/tests/unit/observability/conftest.py
@@ -25,7 +25,7 @@ def make_result(
     run_id: str = "run-0001",
     proposal_id: str = "prop-0001",
     decision_id: str = "dec-0001",
-    status: ExecutionStatus = ExecutionStatus.SUCCESS,
+    status: ExecutionStatus = ExecutionStatus.SUCCEEDED,
     success: bool = True,
     changed_files: Optional[list[ChangedFileRef]] = None,
     changed_files_source: Optional[str] = None,
@@ -91,7 +91,7 @@ def successful_rich_result() -> ExecutionResult:
     """Successful run: known changed files, validation passed, diff artifact."""
     return make_result(
         run_id="run-rich-01",
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[
             make_changed_file("src/main.py", "modified"),
@@ -132,7 +132,7 @@ def timeout_result() -> ExecutionResult:
     """Timeout: no artifacts, no changed files."""
     return make_result(
         run_id="run-timeout-01",
-        status=ExecutionStatus.TIMEOUT,
+        status=ExecutionStatus.TIMED_OUT,
         success=False,
         failure_category=FailureReasonCategory.TIMEOUT,
         failure_reason="kodo exited -1: [timeout: process group killed after 300s]",

--- a/tests/unit/observability/test_changed_files.py
+++ b/tests/unit/observability/test_changed_files.py
@@ -161,7 +161,7 @@ def test_unsupported_request_notes_do_not_blame_policy():
 
 def test_empty_files_and_no_special_category_is_unknown():
     result = make_result(
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[],
         failure_category=None,

--- a/tests/unit/observability/test_recorder.py
+++ b/tests/unit/observability/test_recorder.py
@@ -245,7 +245,7 @@ def test_sparse_result_produces_valid_record(recorder, sparse_result):
 
 def test_timeout_result_produces_valid_record(recorder):
     result = make_result(
-        status=ExecutionStatus.TIMEOUT,
+        status=ExecutionStatus.TIMED_OUT,
         success=False,
         failure_category=FailureReasonCategory.TIMEOUT,
         artifacts=[],

--- a/tests/unit/observability/test_trace.py
+++ b/tests/unit/observability/test_trace.py
@@ -55,7 +55,7 @@ def test_record_id_links_to_record(recorder, builder, successful_rich_result):
 def test_status_matches_result(recorder, builder, successful_rich_result):
     record = recorder.record(successful_rich_result)
     trace = builder.build_report(record)
-    assert trace.status == ExecutionStatus.SUCCESS
+    assert trace.status == ExecutionStatus.SUCCEEDED
 
 
 def test_generated_at_is_set(recorder, builder, successful_rich_result):
@@ -71,7 +71,7 @@ def test_generated_at_is_set(recorder, builder, successful_rich_result):
 
 def test_headline_contains_status(recorder, builder, successful_rich_result):
     trace = _trace(successful_rich_result, recorder, builder)
-    assert "SUCCESS" in trace.headline
+    assert "SUCCEEDED" in trace.headline
 
 
 def test_headline_contains_backend(recorder, builder, successful_rich_result):
@@ -102,7 +102,7 @@ def test_headline_for_failure(recorder, builder, failed_result_with_logs):
 
 def test_headline_for_timeout(recorder, builder, timeout_result):
     trace = _trace(timeout_result, recorder, builder)
-    assert "TIMEOUT" in trace.headline
+    assert "TIMED_OUT" in trace.headline
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/openclaw_shell/test_bridge.py
+++ b/tests/unit/openclaw_shell/test_bridge.py
@@ -44,7 +44,7 @@ def _success_result(**kw):
         run_id="run-br01",
         proposal_id="prop-br01",
         decision_id="dec-br01",
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[make_changed_file("src/main.py")],
         validation_status=ValidationStatus.PASSED,
@@ -250,7 +250,7 @@ def test_inspect_from_record_status(bridge):
     record = recorder.record(result, backend="kodo", lane="claude_cli")
     trace = builder.build_report(record)
     r = bridge.inspect_from_record(record, trace)
-    assert r.status == ExecutionStatus.SUCCESS.value
+    assert r.status == ExecutionStatus.SUCCEEDED.value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/openclaw_shell/test_models.py
+++ b/tests/unit/openclaw_shell/test_models.py
@@ -134,7 +134,7 @@ def _status_summary(**kw) -> ShellStatusSummary:
         run_id="run-1",
         proposal_id="prop-1",
         decision_id="dec-1",
-        status="success",
+        status="succeeded",
         success=True,
         headline="SUCCESS | kodo @ claude_cli | run=run-1abc",
         summary="Run run-1abc; changed 3 files",
@@ -146,7 +146,7 @@ def _status_summary(**kw) -> ShellStatusSummary:
 def test_status_summary_construction():
     s = _status_summary()
     assert s.run_id == "run-1"
-    assert s.status == "success"
+    assert s.status == "succeeded"
     assert s.success is True
 
 
@@ -193,7 +193,7 @@ def _inspection(**kw) -> ShellInspectionResult:
         run_id="run-1",
         proposal_id="prop-1",
         decision_id="dec-1",
-        status="success",
+        status="succeeded",
         headline="SUCCESS | kodo @ claude_cli | run=run-1",
         summary="Run run-1; changed 3 files; validation=passed",
     )
@@ -204,7 +204,7 @@ def _inspection(**kw) -> ShellInspectionResult:
 def test_inspection_construction():
     r = _inspection()
     assert r.run_id == "run-1"
-    assert r.status == "success"
+    assert r.status == "succeeded"
 
 
 def test_inspection_defaults():

--- a/tests/unit/openclaw_shell/test_service.py
+++ b/tests/unit/openclaw_shell/test_service.py
@@ -42,7 +42,7 @@ def _success_result(**kw):
         run_id="run-svc01",
         proposal_id="prop-svc01",
         decision_id="dec-svc01",
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[make_changed_file("src/main.py")],
         validation_status=ValidationStatus.PASSED,
@@ -192,7 +192,7 @@ def test_summarize_result_success(stub_svc):
     result = _success_result()
     summary = stub_svc.summarize_result(result, lane="claude_cli", backend="kodo")
     assert summary.success is True
-    assert summary.status == ExecutionStatus.SUCCESS.value
+    assert summary.status == ExecutionStatus.SUCCEEDED.value
 
 
 def test_summarize_result_failure(stub_svc):
@@ -281,7 +281,7 @@ def test_inspect_record_status(stub_svc):
     record = recorder.record(result, backend="kodo", lane="claude_cli")
     trace = builder.build_report(record)
     r = stub_svc.inspect_record(record, trace)
-    assert r.status == ExecutionStatus.SUCCESS.value
+    assert r.status == ExecutionStatus.SUCCEEDED.value
     assert r.run_id == "run-svc01"
 
 

--- a/tests/unit/openclaw_shell/test_status.py
+++ b/tests/unit/openclaw_shell/test_status.py
@@ -47,7 +47,7 @@ def _success_result(**kw):
         run_id="run-s01",
         proposal_id="prop-s01",
         decision_id="dec-s01",
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[make_changed_file("src/main.py")],
         validation_status=ValidationStatus.PASSED,
@@ -94,7 +94,7 @@ def test_status_from_record_success_fields():
     record, trace = _make_record_and_trace(_success_result())
     summary = status_from_record(record, trace)
     assert summary.success is True
-    assert summary.status == ExecutionStatus.SUCCESS.value
+    assert summary.status == ExecutionStatus.SUCCEEDED.value
 
 
 def test_status_from_record_failure_fields():
@@ -188,7 +188,7 @@ def test_status_from_result_only_success():
     result = _success_result()
     summary = status_from_result_only(result)
     assert summary.success is True
-    assert summary.status == ExecutionStatus.SUCCESS.value
+    assert summary.status == ExecutionStatus.SUCCEEDED.value
 
 
 def test_status_from_result_only_failure():
@@ -201,7 +201,7 @@ def test_status_from_result_only_failure():
 def test_status_from_result_only_headline_contains_status():
     result = _success_result()
     summary = status_from_result_only(result, lane="claude_cli", backend="kodo")
-    assert "SUCCESS" in summary.headline.upper()
+    assert "SUCCEEDED" in summary.headline.upper()
 
 
 def test_status_from_result_only_headline_contains_run_id():
@@ -311,7 +311,7 @@ def test_inspection_from_record_identifiers():
 def test_inspection_from_record_status():
     record, trace = _make_record_and_trace(_success_result())
     r = inspection_from_record(record, trace)
-    assert r.status == ExecutionStatus.SUCCESS.value
+    assert r.status == ExecutionStatus.SUCCEEDED.value
 
 
 def test_inspection_from_record_headline_and_summary():

--- a/tests/unit/tuning/conftest.py
+++ b/tests/unit/tuning/conftest.py
@@ -25,7 +25,7 @@ _recorder = ExecutionRecorder()
 def make_result(
     *,
     run_id: str = "run-0001",
-    status: ExecutionStatus = ExecutionStatus.SUCCESS,
+    status: ExecutionStatus = ExecutionStatus.SUCCEEDED,
     success: bool = True,
     failure_category: FailureReasonCategory | None = None,
     validation_status: ValidationStatus = ValidationStatus.SKIPPED,
@@ -55,7 +55,7 @@ def make_record(
     run_id: str = "run-0001",
     backend: str = "kodo",
     lane: str = "claude_cli",
-    status: ExecutionStatus = ExecutionStatus.SUCCESS,
+    status: ExecutionStatus = ExecutionStatus.SUCCEEDED,
     success: bool = True,
     failure_category: FailureReasonCategory | None = None,
     validation_status: ValidationStatus = ValidationStatus.SKIPPED,
@@ -99,7 +99,7 @@ def make_success(backend: str = "kodo", lane: str = "claude_cli", **kw) -> Execu
     return make_record(
         backend=backend,
         lane=lane,
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         **kw,
     )
@@ -121,7 +121,7 @@ def make_timeout(backend: str = "kodo", lane: str = "claude_cli", **kw) -> Execu
     return make_record(
         backend=backend,
         lane=lane,
-        status=ExecutionStatus.TIMEOUT,
+        status=ExecutionStatus.TIMED_OUT,
         success=False,
         failure_category=FailureReasonCategory.TIMEOUT,
         changed_files=[],
@@ -147,7 +147,7 @@ def make_unknown_changed_files(
     """Successful run but no changed-file info (backend didn't report)."""
     result = make_result(
         run_id=kw.pop("run_id", "run-0001"),
-        status=ExecutionStatus.SUCCESS,
+        status=ExecutionStatus.SUCCEEDED,
         success=True,
         changed_files=[],  # empty → normalize_changed_files returns UNKNOWN
     )


### PR DESCRIPTION
## Summary

- Renames \`ExecutionStatus.SUCCESS\` → \`SUCCEEDED\` (\`\"succeeded\"\`) and \`TIMEOUT\` → \`TIMED_OUT\` (\`\"timed_out\"\`) to match canonical ECP v0.2 status vocabulary.
- \`FailureReasonCategory.TIMEOUT\` (separate concept — failure reason, not run status) is left unchanged.
- Prerequisite for treating ECP as the canonical contract source: OC's \`ExecutionResult\` payloads now use the spellings ECP's \`schemas/v0.2/execution_result.schema.json\` requires.

Pure rename — no behavior change.

## Test plan

- [x] \`.venv/bin/python -m pytest tests/unit -q\` → 2029 passed
- [ ] CI validates integration tests