### PR TITLE
feat(routing): consume ECP-shaped LaneDecision from /route

### DIFF
--- a/src/operations_center/contracts/ecp_mapper.py
+++ b/src/operations_center/contracts/ecp_mapper.py
@@ -39,6 +39,7 @@ from ecp.contracts import (
 from ecp.vocabulary.lane import LaneType
 from ecp.vocabulary.status import ExecutionStatus as EcpExecutionStatus
 
+from .enums import BackendName, LaneName
 from .execution import ExecutionRequest, ExecutionResult
 from .proposal import TaskProposal
 from .routing import LaneDecision
@@ -112,6 +113,39 @@ def to_ecp_lane_decision(
         alternatives=[
             EcpLaneAlternative(lane=_category_for(alt.value), executor=alt.value)
             for alt in oc.alternatives_considered
+        ],
+    )
+
+
+def from_ecp_lane_decision(payload: dict[str, Any]) -> LaneDecision:
+    """Reconstruct an OC ``LaneDecision`` from an ECP wire payload.
+
+    Used at the OC consume boundary (``HttpLaneRoutingClient``) to accept
+    SwitchBoard's ECP-shaped ``/route`` response. Narrows ECP's
+    open-string ``executor``/``backend`` back into OC's ``LaneName``/
+    ``BackendName`` ``Literal`` constraints; raises ``ValueError`` if the
+    incoming executor or backend is not one OC recognises.
+    """
+    executor = payload.get("executor")
+    backend = payload.get("backend")
+    if executor is None or backend is None:
+        raise ValueError(
+            "ECP LaneDecision missing executor/backend; "
+            "OC requires both to narrow into LaneName/BackendName."
+        )
+    metadata = payload.get("metadata") or {}
+    return LaneDecision(
+        decision_id=payload["decision_id"],
+        proposal_id=payload["proposal_id"],
+        selected_lane=LaneName(executor),
+        selected_backend=BackendName(backend),
+        confidence=payload.get("confidence", 1.0),
+        policy_rule_matched=metadata.get("policy_rule_matched"),
+        rationale=payload.get("rationale") or None,
+        alternatives_considered=[
+            LaneName(alt["executor"])
+            for alt in payload.get("alternatives", [])
+            if alt.get("executor") is not None
         ],
     )
 

--- a/src/operations_center/routing/client.py
+++ b/src/operations_center/routing/client.py
@@ -12,6 +12,7 @@ from typing import Protocol, runtime_checkable
 
 import httpx
 
+from operations_center.contracts.ecp_mapper import from_ecp_lane_decision
 from operations_center.contracts.proposal import TaskProposal
 from operations_center.contracts.routing import LaneDecision
 
@@ -73,7 +74,7 @@ class HttpLaneRoutingClient:
                 f"SwitchBoard request timed out at {self.base_url}. "
                 f"Cause: {exc}"
             ) from exc
-        return LaneDecision.model_validate(response.json())
+        return _decode_route_response(response.json())
 
     def close(self) -> None:
         self._client.close()
@@ -96,3 +97,16 @@ class StubLaneRoutingClient:
 
     def select_lane(self, proposal: TaskProposal) -> LaneDecision:
         return self._decision
+
+
+def _decode_route_response(payload: dict) -> LaneDecision:
+    """Decode SwitchBoard's /route response into an OC LaneDecision.
+
+    SwitchBoard emits the ECP v0.2 envelope (``contract_kind ==
+    "lane_decision"`` and ``schema_version == "0.2"``). Older deployments
+    may still emit OC's rich Pydantic shape; we accept both during the
+    wire-flip transition.
+    """
+    if payload.get("contract_kind") == "lane_decision" and payload.get("schema_version", "").startswith("0."):
+        return from_ecp_lane_decision(payload)
+    return LaneDecision.model_validate(payload)

--- a/tests/unit/routing/test_client.py
+++ b/tests/unit/routing/test_client.py
@@ -124,6 +124,59 @@ def test_stub_returns_fixed_decision() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_http_client_decodes_ecp_shape_response() -> None:
+    """SwitchBoard emits ECP v0.2 envelope; the client must deserialize it
+    back into the OC LaneDecision."""
+    ecp_payload = {
+        "schema_version": "0.2",
+        "contract_kind": "lane_decision",
+        "decision_id": "dec-ecp-1",
+        "proposal_id": "prop-ecp-1",
+        "metadata": {"policy_rule_matched": "test_rule"},
+        "lane": "coding_agent",
+        "executor": "claude_cli",
+        "backend": "kodo",
+        "rationale": "ecp-shape decision",
+        "confidence": 0.88,
+        "alternatives": [
+            {"lane": "coding_agent", "executor": "codex_cli"}
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=ecp_payload)
+
+    client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
+    proposal = build_proposal(_ctx())
+    try:
+        decision = client.select_lane(proposal)
+    finally:
+        client.close()
+
+    assert decision.selected_lane == LaneName.CLAUDE_CLI
+    assert decision.selected_backend == BackendName.KODO
+    assert decision.confidence == 0.88
+    assert decision.policy_rule_matched == "test_rule"
+    assert decision.alternatives_considered == [LaneName.CODEX_CLI]
+
+
+def test_http_client_still_accepts_legacy_oc_shape_response() -> None:
+    """Backward compatibility during the wire-flip transition: the client
+    accepts OC's rich Pydantic shape from older SwitchBoard deployments."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_stub_decision().model_dump(mode="json"))
+
+    client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
+    proposal = build_proposal(_ctx())
+    try:
+        decision = client.select_lane(proposal)
+    finally:
+        client.close()
+
+    assert decision.selected_lane == LaneName.CLAUDE_CLI
+
+
 def test_connect_error_raises_switchboard_unavailable() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("Connection refused")


### PR DESCRIPTION
## Summary

- Adds \`from_ecp_lane_decision\` to \`operations_center.contracts.ecp_mapper\` — narrows ECP's open \`executor\`/\`backend\` strings back into OC's \`LaneName\`/\`BackendName\` Literal enums.
- \`HttpLaneRoutingClient.select_lane\` sniffs the \`/route\` response: ECP envelope (\`contract_kind == "lane_decision"\` and \`schema_version\` starting with "0.") goes through the new mapper; older OC-rich shape still works during the transition.
- 2 new tests cover both code paths.

## Contract Impact

- [x] No contract change (refactor, docs, tests, tooling only)

## Downstream Consumers

Pairs with the SwitchBoard wire-flip PR (will be opened next). Order-independent: this PR accepts both shapes, so it can land before SB's switch.

## Testing

- [x] \`.venv/bin/python -m pytest tests/unit -q\` → 2050 passed
- [x] \`.venv/bin/ruff check\` → clean