### PR TITLE
refactor: migrate ecp.* → cxrp.*; drop wire-flip back-compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "PyYAML>=6.0",
   "httpx>=0.27",
   "typer>=0.12",
-  "execution-contract-protocol @ git+https://github.com/Velascat/ExecutionContractProtocol.git",
+  "cxrp @ git+https://github.com/Velascat/ExecutionContractProtocol.git",
 ]
 
 [project.scripts]

--- a/src/operations_center/contracts/__init__.py
+++ b/src/operations_center/contracts/__init__.py
@@ -2,7 +2,7 @@
 contracts — OperationsCenter's internal subtype of the ECP envelope.
 
 The canonical cross-repo wire contract is **ExecutionContractProtocol**
-(``ecp.contracts``). The classes here are OperationsCenter's *internal*
+(``cxrp.contracts``). The classes here are OperationsCenter's *internal*
 Pydantic representation: they layer narrower types (``LaneName``,
 ``BackendName``, structured ``TaskTarget``/``BranchPolicy``/
 ``ValidationProfile``) on top of ECP's open envelope so adapters and

--- a/src/operations_center/contracts/ecp_mapper.py
+++ b/src/operations_center/contracts/ecp_mapper.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ecp.contracts import (
+from cxrp.contracts import (
     Artifact as EcpArtifact,
     ExecutionLimits as EcpExecutionLimits,
     ExecutionRequest as EcpExecutionRequest,
@@ -36,8 +36,8 @@ from ecp.contracts import (
     LaneDecision as EcpLaneDecision,
     TaskProposal as EcpTaskProposal,
 )
-from ecp.vocabulary.lane import LaneType
-from ecp.vocabulary.status import ExecutionStatus as EcpExecutionStatus
+from cxrp.vocabulary.lane import LaneType
+from cxrp.vocabulary.status import ExecutionStatus as EcpExecutionStatus
 
 from .enums import BackendName, LaneName
 from .execution import ExecutionRequest, ExecutionResult

--- a/src/operations_center/routing/client.py
+++ b/src/operations_center/routing/client.py
@@ -102,11 +102,20 @@ class StubLaneRoutingClient:
 def _decode_route_response(payload: dict) -> LaneDecision:
     """Decode SwitchBoard's /route response into an OC LaneDecision.
 
-    SwitchBoard emits the ECP v0.2 envelope (``contract_kind ==
-    "lane_decision"`` and ``schema_version == "0.2"``). Older deployments
-    may still emit OC's rich Pydantic shape; we accept both during the
-    wire-flip transition.
+    SwitchBoard emits the CxRP v0.2 envelope (``contract_kind ==
+    "lane_decision"``, ``schema_version`` starting with ``"0."``). The
+    transitional fallback to OC's rich Pydantic shape has been removed
+    now that the wire flip is complete; an unrecognised shape raises
+    ``ValueError`` rather than silently mis-parsing it.
     """
-    if payload.get("contract_kind") == "lane_decision" and payload.get("schema_version", "").startswith("0."):
+    if (
+        payload.get("contract_kind") == "lane_decision"
+        and payload.get("schema_version", "").startswith("0.")
+    ):
         return from_ecp_lane_decision(payload)
-    return LaneDecision.model_validate(payload)
+    raise ValueError(
+        "Unexpected /route response shape: expected CxRP LaneDecision "
+        "envelope (contract_kind='lane_decision', schema_version='0.x'). "
+        f"Got contract_kind={payload.get('contract_kind')!r}, "
+        f"schema_version={payload.get('schema_version')!r}."
+    )

--- a/tests/unit/contracts/test_ecp_mapper.py
+++ b/tests/unit/contracts/test_ecp_mapper.py
@@ -12,12 +12,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from ecp.contracts import (
+from cxrp.contracts import (
     ExecutionResult as EcpExecutionResult,
     TaskProposal as EcpTaskProposal,
 )
-from ecp.validation.json_schema import validate_contract, validate_payload
-from ecp.vocabulary.lane import LaneType
+from cxrp.validation.json_schema import validate_contract, validate_payload
+from cxrp.vocabulary.lane import LaneType
 
 from operations_center.contracts.common import (
     BranchPolicy,

--- a/tests/unit/routing/test_client.py
+++ b/tests/unit/routing/test_client.py
@@ -41,8 +41,25 @@ def _stub_decision(lane=LaneName.CLAUDE_CLI, backend=BackendName.KODO) -> LaneDe
     )
 
 
+def _stub_ecp_response(executor: str = "claude_cli", backend: str = "kodo") -> dict:
+    """Minimal CxRP v0.2 LaneDecision payload for /route mock responses."""
+    return {
+        "schema_version": "0.2",
+        "contract_kind": "lane_decision",
+        "decision_id": "dec-test-1",
+        "proposal_id": "prop-test-1",
+        "metadata": {"policy_rule_matched": "test_rule"},
+        "lane": "coding_agent",
+        "executor": executor,
+        "backend": backend,
+        "confidence": 0.9,
+        "rationale": "stub",
+        "alternatives": [],
+    }
+
+
 def test_http_client_satisfies_protocol() -> None:
-    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=_stub_decision().model_dump(mode="json")))
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=_stub_ecp_response()))
     client = HttpLaneRoutingClient("http://switchboard.local", transport=transport)
     try:
         assert isinstance(client, LaneRoutingClient)
@@ -60,7 +77,7 @@ def test_http_client_posts_to_route_endpoint() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured.append(request)
-        return httpx.Response(200, json=_stub_decision().model_dump(mode="json"))
+        return httpx.Response(200, json=_stub_ecp_response())
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx())
@@ -79,7 +96,7 @@ def test_http_client_serializes_canonical_proposal() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.update(json.loads(request.content.decode("utf-8")))
-        return httpx.Response(200, json=_stub_decision().model_dump(mode="json"))
+        return httpx.Response(200, json=_stub_ecp_response())
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx(task_id="TASK-9", project_id="proj-9"))
@@ -160,21 +177,22 @@ def test_http_client_decodes_ecp_shape_response() -> None:
     assert decision.alternatives_considered == [LaneName.CODEX_CLI]
 
 
-def test_http_client_still_accepts_legacy_oc_shape_response() -> None:
-    """Backward compatibility during the wire-flip transition: the client
-    accepts OC's rich Pydantic shape from older SwitchBoard deployments."""
+def test_http_client_rejects_legacy_oc_shape_response() -> None:
+    """The transitional fallback to OC's rich Pydantic shape was removed
+    after the wire flip; an unrecognised payload now raises ValueError
+    rather than silently mis-parsing."""
 
     def handler(request: httpx.Request) -> httpx.Response:
+        # OC's rich Pydantic dump — no schema_version/contract_kind keys.
         return httpx.Response(200, json=_stub_decision().model_dump(mode="json"))
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx())
     try:
-        decision = client.select_lane(proposal)
+        with pytest.raises(ValueError, match="CxRP LaneDecision envelope"):
+            client.select_lane(proposal)
     finally:
         client.close()
-
-    assert decision.selected_lane == LaneName.CLAUDE_CLI
 
 
 def test_connect_error_raises_switchboard_unavailable() -> None:

--- a/tests/unit/routing/test_service.py
+++ b/tests/unit/routing/test_service.py
@@ -172,16 +172,22 @@ def test_default_service_uses_real_routing():
 
 
 def test_http_backed_service_routes_over_switchboard_boundary():
-    decision = LaneDecision(
-        proposal_id="prop-http-1",
-        selected_lane=LaneName.AIDER_LOCAL,
-        selected_backend=BackendName.DIRECT_LOCAL,
-        confidence=0.95,
-        policy_rule_matched="http_rule",
-    )
+    cxrp_payload = {
+        "schema_version": "0.2",
+        "contract_kind": "lane_decision",
+        "decision_id": "dec-http-1",
+        "proposal_id": "prop-http-1",
+        "metadata": {"policy_rule_matched": "http_rule"},
+        "lane": "coding_agent",
+        "executor": "aider_local",
+        "backend": "direct_local",
+        "confidence": 0.95,
+        "rationale": "",
+        "alternatives": [],
+    }
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=decision.model_dump(mode="json"))
+        return httpx.Response(200, json=cxrp_payload)
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     service = PlanningService.with_client(client)


### PR DESCRIPTION
## Summary

- Migrates primary imports from \`ecp.*\` to \`cxrp.*\` (CxRP rename). The \`ecp\` shim still exists upstream but OC no longer relies on it.
- Drops the transitional fallback in \`HttpLaneRoutingClient\` that accepted OC's rich Pydantic shape from older SwitchBoard deployments. After SwitchBoard's wire flip (#NN), the only valid \`/route\` response is the CxRP envelope; unrecognised payloads now raise \`ValueError\`.
- Test mocks updated to return CxRP-shape JSON. \`test_http_client_still_accepts_legacy_oc_shape_response\` becomes \`test_http_client_rejects_legacy_oc_shape_response\`.

## Contract Impact

- [x] No contract change (refactor, docs, tests, tooling only)

## Testing

- [x] \`.venv/bin/python -m pytest tests/unit -q\` → 2050 passed
- [x] \`.venv/bin/ruff check\` → clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)