### PR TITLE
refactor: rename ECP → CxRP (URLs and proper noun)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "PyYAML>=6.0",
   "httpx>=0.27",
   "typer>=0.12",
-  "cxrp @ git+https://github.com/Velascat/ExecutionContractProtocol.git",
+  "cxrp @ git+https://github.com/Velascat/CxRP.git",
 ]
 
 [project.scripts]

--- a/src/operations_center/contracts/__init__.py
+++ b/src/operations_center/contracts/__init__.py
@@ -1,7 +1,7 @@
 """
 contracts — OperationsCenter's internal subtype of the ECP envelope.
 
-The canonical cross-repo wire contract is **ExecutionContractProtocol**
+The canonical cross-repo wire contract is **CxRP**
 (``cxrp.contracts``). The classes here are OperationsCenter's *internal*
 Pydantic representation: they layer narrower types (``LaneName``,
 ``BackendName``, structured ``TaskTarget``/``BranchPolicy``/
@@ -13,7 +13,7 @@ OperatorConsole, run artifacts) these models are translated to ECP shape
 via ``operations_center.contracts.ecp_mapper``. The wire format is ECP;
 this module is the OC-internal subtype.
 
-Canonical wire format:  ECP v0.2 (https://github.com/Velascat/ExecutionContractProtocol)
+Canonical wire format:  ECP v0.2 (https://github.com/Velascat/CxRP)
 Internal owner:         OperationsCenter (Pydantic; this package)
 """
 


### PR DESCRIPTION
## Summary
- Update `pyproject.toml` git URL to `Velascat/CxRP.git`
- Update docstring in `contracts/__init__.py` to use the new repo name
- Package import (`cxrp`) and protocol abbreviation (`ECP`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)