### PR TITLE
chore: purge ECP legacy (rename ecp_mapper → cxrp_mapper)

### DIFF
--- a/src/operations_center/contracts/__init__.py
+++ b/src/operations_center/contracts/__init__.py
@@ -1,19 +1,19 @@
 """
-contracts — OperationsCenter's internal subtype of the ECP envelope.
+contracts — OperationsCenter's internal subtype of the CxRP envelope.
 
 The canonical cross-repo wire contract is **CxRP**
 (``cxrp.contracts``). The classes here are OperationsCenter's *internal*
 Pydantic representation: they layer narrower types (``LaneName``,
 ``BackendName``, structured ``TaskTarget``/``BranchPolicy``/
-``ValidationProfile``) on top of ECP's open envelope so adapters and
+``ValidationProfile``) on top of CxRP's open envelope so adapters and
 policy can rely on stricter shapes within OC.
 
 At repo boundaries (HTTP between OC ↔ SwitchBoard, JSON written for
-OperatorConsole, run artifacts) these models are translated to ECP shape
-via ``operations_center.contracts.ecp_mapper``. The wire format is ECP;
+OperatorConsole, run artifacts) these models are translated to CxRP shape
+via ``operations_center.contracts.cxrp_mapper``. The wire format is CxRP;
 this module is the OC-internal subtype.
 
-Canonical wire format:  ECP v0.2 (https://github.com/Velascat/CxRP)
+Canonical wire format:  CxRP v0.2 (https://github.com/Velascat/CxRP)
 Internal owner:         OperationsCenter (Pydantic; this package)
 """
 

--- a/src/operations_center/contracts/cxrp_mapper.py
+++ b/src/operations_center/contracts/cxrp_mapper.py
@@ -1,25 +1,25 @@
 """Bidirectional mappers between OperationsCenter's internal Pydantic
-contracts and the canonical ECP v0.2 envelope.
+contracts and the canonical CxRP v0.2 envelope.
 
-OC's internal types (Pydantic) carry richer constraints than ECP's wire
+OC's internal types (Pydantic) carry richer constraints than CxRP's wire
 envelope: typed enums, structured ``TaskTarget``/``BranchPolicy``/
-``ValidationProfile`` objects, etc. ECP defines the *envelope* — abstract
+``ValidationProfile`` objects, etc. CxRP defines the *envelope* — abstract
 ``lane`` category plus open-string ``executor``/``backend`` and free-form
 ``input_payload``. These mappers translate at the wire boundary so that
-inter-repo communication uses ECP shape.
+inter-repo communication uses CxRP shape.
 
 Mapping conventions:
 
-* OC ``selected_lane`` (e.g. ``claude_cli``) → ECP ``executor``
-* OC ``selected_backend`` (e.g. ``kodo``)   → ECP ``backend``
-* ECP abstract ``lane`` is derived from the OC lane name.
+* OC ``selected_lane`` (e.g. ``claude_cli``) → CxRP ``executor``
+* OC ``selected_backend`` (e.g. ``kodo``)   → CxRP ``backend``
+* CxRP abstract ``lane`` is derived from the OC lane name.
 * OC's rich ``ExecutionArtifact`` (id, label, content, size) collapses
-  to ECP ``Artifact`` (kind, uri, description, metadata) — id/label/size
+  to CxRP ``Artifact`` (kind, uri, description, metadata) — id/label/size
   travel in ``metadata``.
 * OC's ``ValidationSummary``/``ChangedFileRef`` lists travel in
   ``ExecutionResult.diagnostics``.
 
-Inverse helpers (``from_ecp_*``) are intentionally minimal — only the
+Inverse helpers (``from_cxrp_*``) are intentionally minimal — only the
 fields downstream OC needs at the consume boundary are reconstructed.
 """
 
@@ -28,16 +28,16 @@ from __future__ import annotations
 from typing import Any
 
 from cxrp.contracts import (
-    Artifact as EcpArtifact,
-    ExecutionLimits as EcpExecutionLimits,
-    ExecutionRequest as EcpExecutionRequest,
-    ExecutionResult as EcpExecutionResult,
-    LaneAlternative as EcpLaneAlternative,
-    LaneDecision as EcpLaneDecision,
-    TaskProposal as EcpTaskProposal,
+    Artifact as CxrpArtifact,
+    ExecutionLimits as CxrpExecutionLimits,
+    ExecutionRequest as CxrpExecutionRequest,
+    ExecutionResult as CxrpExecutionResult,
+    LaneAlternative as CxrpLaneAlternative,
+    LaneDecision as CxrpLaneDecision,
+    TaskProposal as CxrpTaskProposal,
 )
 from cxrp.vocabulary.lane import LaneType
-from cxrp.vocabulary.status import ExecutionStatus as EcpExecutionStatus
+from cxrp.vocabulary.status import ExecutionStatus as CxrpExecutionStatus
 
 from .enums import BackendName, LaneName
 from .execution import ExecutionRequest, ExecutionResult
@@ -58,15 +58,15 @@ def _category_for(oc_lane_value: str) -> LaneType:
     return _OC_LANE_TO_ECP_CATEGORY.get(oc_lane_value, LaneType.CODING_AGENT)
 
 
-def to_ecp_task_proposal(oc: TaskProposal) -> EcpTaskProposal:
-    """Translate an OC TaskProposal into the ECP v0.2 envelope."""
+def to_cxrp_task_proposal(oc: TaskProposal) -> CxrpTaskProposal:
+    """Translate an OC TaskProposal into the CxRP v0.2 envelope."""
     target_payload: dict[str, Any] = {
         "$payload_schema": CODING_AGENT_TARGET_SCHEMA_ID,
         "repo_key": oc.target.repo_key,
         "clone_url": oc.target.clone_url,
         "base_branch": oc.target.base_branch,
     }
-    return EcpTaskProposal(
+    return CxrpTaskProposal(
         proposal_id=oc.proposal_id,
         created_at=oc.proposed_at,
         metadata={
@@ -86,12 +86,12 @@ def to_ecp_task_proposal(oc: TaskProposal) -> EcpTaskProposal:
     )
 
 
-def to_ecp_lane_decision(
+def to_cxrp_lane_decision(
     oc: LaneDecision, *, extra_metadata: dict[str, Any] | None = None
-) -> EcpLaneDecision:
-    """Translate an OC LaneDecision into ECP envelope shape.
+) -> CxrpLaneDecision:
+    """Translate an OC LaneDecision into CxRP envelope shape.
 
-    Mirrors switchboard.adapters.ecp_mapper but lives here so OC's own
+    Mirrors switchboard.adapters.cxrp_mapper but lives here so OC's own
     audit/observability code can emit the same wire shape.
     """
     metadata: dict[str, Any] = {
@@ -100,7 +100,7 @@ def to_ecp_lane_decision(
     if extra_metadata:
         metadata.update(extra_metadata)
 
-    return EcpLaneDecision(
+    return CxrpLaneDecision(
         decision_id=oc.decision_id,
         proposal_id=oc.proposal_id,
         created_at=oc.decided_at,
@@ -111,17 +111,17 @@ def to_ecp_lane_decision(
         rationale=oc.rationale or "",
         confidence=oc.confidence,
         alternatives=[
-            EcpLaneAlternative(lane=_category_for(alt.value), executor=alt.value)
+            CxrpLaneAlternative(lane=_category_for(alt.value), executor=alt.value)
             for alt in oc.alternatives_considered
         ],
     )
 
 
-def from_ecp_lane_decision(payload: dict[str, Any]) -> LaneDecision:
-    """Reconstruct an OC ``LaneDecision`` from an ECP wire payload.
+def from_cxrp_lane_decision(payload: dict[str, Any]) -> LaneDecision:
+    """Reconstruct an OC ``LaneDecision`` from an CxRP wire payload.
 
     Used at the OC consume boundary (``HttpLaneRoutingClient``) to accept
-    SwitchBoard's ECP-shaped ``/route`` response. Narrows ECP's
+    SwitchBoard's CxRP-shaped ``/route`` response. Narrows CxRP's
     open-string ``executor``/``backend`` back into OC's ``LaneName``/
     ``BackendName`` ``Literal`` constraints; raises ``ValueError`` if the
     incoming executor or backend is not one OC recognises.
@@ -130,7 +130,7 @@ def from_ecp_lane_decision(payload: dict[str, Any]) -> LaneDecision:
     backend = payload.get("backend")
     if executor is None or backend is None:
         raise ValueError(
-            "ECP LaneDecision missing executor/backend; "
+            "CxRP LaneDecision missing executor/backend; "
             "OC requires both to narrow into LaneName/BackendName."
         )
     metadata = payload.get("metadata") or {}
@@ -150,13 +150,13 @@ def from_ecp_lane_decision(payload: dict[str, Any]) -> LaneDecision:
     )
 
 
-def to_ecp_execution_request(oc: ExecutionRequest, *, executor: str, backend: str) -> EcpExecutionRequest:
-    """Translate an OC ExecutionRequest into ECP shape.
+def to_cxrp_execution_request(oc: ExecutionRequest, *, executor: str, backend: str) -> CxrpExecutionRequest:
+    """Translate an OC ExecutionRequest into CxRP shape.
 
     OC's request is rich (workspace paths, branches, validation commands).
-    Those fields land in ECP's ``input_payload`` under the
+    Those fields land in CxRP's ``input_payload`` under the
     ``coding_agent_input/v0.2`` payload schema. Boundary-universal caps
-    (file count, timeout) become ECP ``limits``.
+    (file count, timeout) become CxRP ``limits``.
     """
     input_payload: dict[str, Any] = {
         "goal_text": oc.goal_text,
@@ -170,7 +170,7 @@ def to_ecp_execution_request(oc: ExecutionRequest, *, executor: str, backend: st
         "allowed_paths": list(oc.allowed_paths),
         "validation_commands": list(oc.validation_commands),
     }
-    return EcpExecutionRequest(
+    return CxrpExecutionRequest(
         request_id=oc.run_id,
         proposal_id=oc.proposal_id,
         lane_decision_id=oc.decision_id,
@@ -183,7 +183,7 @@ def to_ecp_execution_request(oc: ExecutionRequest, *, executor: str, backend: st
         input_payload=input_payload,
         input_payload_schema=CODING_AGENT_INPUT_SCHEMA_ID,
         constraints=[oc.constraints_text] if oc.constraints_text else [],
-        limits=EcpExecutionLimits(
+        limits=CxrpExecutionLimits(
             max_changed_files=oc.max_changed_files,
             timeout_seconds=oc.timeout_seconds,
             require_clean_validation=oc.require_clean_validation,
@@ -191,19 +191,19 @@ def to_ecp_execution_request(oc: ExecutionRequest, *, executor: str, backend: st
     )
 
 
-def _ecp_status_for(oc_status_value: str) -> EcpExecutionStatus:
-    return EcpExecutionStatus(oc_status_value)
+def _ecp_status_for(oc_status_value: str) -> CxrpExecutionStatus:
+    return CxrpExecutionStatus(oc_status_value)
 
 
-def to_ecp_execution_result(oc: ExecutionResult) -> EcpExecutionResult:
-    """Translate an OC ExecutionResult into ECP shape.
+def to_cxrp_execution_result(oc: ExecutionResult) -> CxrpExecutionResult:
+    """Translate an OC ExecutionResult into CxRP shape.
 
-    OC's rich ``ExecutionArtifact`` collapses to ECP ``Artifact``. Heavy
+    OC's rich ``ExecutionArtifact`` collapses to CxRP ``Artifact``. Heavy
     sub-objects (validation summary, changed-file refs, telemetry) move
     into ``diagnostics`` so the envelope stays small.
     """
-    artifacts: list[EcpArtifact] = [
-        EcpArtifact(
+    artifacts: list[CxrpArtifact] = [
+        CxrpArtifact(
             kind=art.artifact_type.value,
             uri=art.uri or "",
             description=art.label,
@@ -224,7 +224,7 @@ def to_ecp_execution_result(oc: ExecutionResult) -> EcpExecutionResult:
         "failure_reason": oc.failure_reason,
         "changed_files_count": len(oc.changed_files),
     }
-    return EcpExecutionResult(
+    return CxrpExecutionResult(
         result_id=oc.run_id,
         created_at=oc.completed_at,
         metadata={"proposal_id": oc.proposal_id, "decision_id": oc.decision_id},

--- a/src/operations_center/routing/client.py
+++ b/src/operations_center/routing/client.py
@@ -12,7 +12,7 @@ from typing import Protocol, runtime_checkable
 
 import httpx
 
-from operations_center.contracts.ecp_mapper import from_ecp_lane_decision
+from operations_center.contracts.cxrp_mapper import from_cxrp_lane_decision
 from operations_center.contracts.proposal import TaskProposal
 from operations_center.contracts.routing import LaneDecision
 
@@ -112,7 +112,7 @@ def _decode_route_response(payload: dict) -> LaneDecision:
         payload.get("contract_kind") == "lane_decision"
         and payload.get("schema_version", "").startswith("0.")
     ):
-        return from_ecp_lane_decision(payload)
+        return from_cxrp_lane_decision(payload)
     raise ValueError(
         "Unexpected /route response shape: expected CxRP LaneDecision "
         "envelope (contract_kind='lane_decision', schema_version='0.x'). "

--- a/tests/unit/contracts/test_cxrp_mapper.py
+++ b/tests/unit/contracts/test_cxrp_mapper.py
@@ -1,7 +1,7 @@
-"""Phase 3: OC's contracts produce wire payloads conforming to ECP v0.2.
+"""Phase 3: OC's contracts produce wire payloads conforming to CxRP v0.2.
 
-Tests assert each OC→ECP mapper emits a shape that validates against the
-canonical ECP JSON Schema, and that lane-specific payloads validate
+Tests assert each OC→CxRP mapper emits a shape that validates against the
+canonical CxRP JSON Schema, and that lane-specific payloads validate
 against the named per-lane payload schema.
 """
 
@@ -13,8 +13,8 @@ from pathlib import Path
 
 import pytest
 from cxrp.contracts import (
-    ExecutionResult as EcpExecutionResult,
-    TaskProposal as EcpTaskProposal,
+    ExecutionResult as CxrpExecutionResult,
+    TaskProposal as CxrpTaskProposal,
 )
 from cxrp.validation.json_schema import validate_contract, validate_payload
 from cxrp.vocabulary.lane import LaneType
@@ -26,12 +26,12 @@ from operations_center.contracts.common import (
     ValidationProfile,
     ValidationSummary,
 )
-from operations_center.contracts.ecp_mapper import (
+from operations_center.contracts.cxrp_mapper import (
     CODING_AGENT_INPUT_SCHEMA_ID,
-    to_ecp_execution_request,
-    to_ecp_execution_result,
-    to_ecp_lane_decision,
-    to_ecp_task_proposal,
+    to_cxrp_execution_request,
+    to_cxrp_execution_result,
+    to_cxrp_lane_decision,
+    to_cxrp_task_proposal,
 )
 from operations_center.contracts.enums import (
     ArtifactType,
@@ -50,7 +50,7 @@ from operations_center.contracts.routing import LaneDecision
 
 
 def _serialize_envelope(contract) -> dict:
-    """Render an ECP dataclass tree to a wire-shaped dict.
+    """Render an CxRP dataclass tree to a wire-shaped dict.
 
     Mirrors BaseContract.to_dict() but recursively unwraps nested
     dataclasses and Enum values so the result is JSON-shape compatible.
@@ -68,7 +68,7 @@ def _serialize_envelope(contract) -> dict:
     return payload
 
 
-def _serialize_result(result: EcpExecutionResult) -> dict:
+def _serialize_result(result: CxrpExecutionResult) -> dict:
     payload = result.to_dict()
     payload["status"] = (
         payload["status"].value if hasattr(payload["status"], "value") else payload["status"]
@@ -169,29 +169,29 @@ def _make_result(request: ExecutionRequest) -> ExecutionResult:
 # ----------------------------------------------------------------------
 
 
-def test_to_ecp_task_proposal_returns_ecp_envelope():
-    ecp = to_ecp_task_proposal(_make_proposal())
-    assert isinstance(ecp, EcpTaskProposal)
-    assert ecp.contract_kind == "task_proposal"
-    assert ecp.schema_version == "0.2"
+def test_to_cxrp_task_proposal_returns_ecp_envelope():
+    cxrp = to_cxrp_task_proposal(_make_proposal())
+    assert isinstance(cxrp, CxrpTaskProposal)
+    assert cxrp.contract_kind == "task_proposal"
+    assert cxrp.schema_version == "0.2"
 
 
 def test_ecp_task_proposal_validates_against_schema():
-    ecp = to_ecp_task_proposal(_make_proposal())
-    validate_contract("task_proposal", ecp.to_dict())
+    cxrp = to_cxrp_task_proposal(_make_proposal())
+    validate_contract("task_proposal", cxrp.to_dict())
 
 
 def test_ecp_task_proposal_carries_layered_vocabulary():
-    ecp = to_ecp_task_proposal(_make_proposal())
-    assert ecp.task_type == "bug_fix"
-    assert ecp.execution_mode == "goal"
-    assert ecp.priority == "normal"
-    assert ecp.risk_level == "low"
+    cxrp = to_cxrp_task_proposal(_make_proposal())
+    assert cxrp.task_type == "bug_fix"
+    assert cxrp.execution_mode == "goal"
+    assert cxrp.priority == "normal"
+    assert cxrp.risk_level == "low"
 
 
 def test_ecp_task_proposal_target_uses_well_known_payload_schema():
-    ecp = to_ecp_task_proposal(_make_proposal())
-    target = ecp.target
+    cxrp = to_cxrp_task_proposal(_make_proposal())
+    target = cxrp.target
     assert target is not None
     assert target["$payload_schema"] == "coding_agent_target/v0.2"
     assert target["repo_key"] == "velascat/api-service"
@@ -202,22 +202,22 @@ def test_ecp_task_proposal_target_uses_well_known_payload_schema():
 # ----------------------------------------------------------------------
 
 
-def test_to_ecp_lane_decision_separates_category_from_executor_backend():
-    ecp = to_ecp_lane_decision(_make_decision("p-1"))
-    assert ecp.lane == LaneType.CODING_AGENT
-    assert ecp.executor == "claude_cli"
-    assert ecp.backend == "kodo"
+def test_to_cxrp_lane_decision_separates_category_from_executor_backend():
+    cxrp = to_cxrp_lane_decision(_make_decision("p-1"))
+    assert cxrp.lane == LaneType.CODING_AGENT
+    assert cxrp.executor == "claude_cli"
+    assert cxrp.backend == "kodo"
 
 
 def test_ecp_lane_decision_validates_against_schema():
-    ecp = to_ecp_lane_decision(_make_decision("p-1"))
-    validate_contract("lane_decision", _serialize_envelope(ecp))
+    cxrp = to_cxrp_lane_decision(_make_decision("p-1"))
+    validate_contract("lane_decision", _serialize_envelope(cxrp))
 
 
 def test_ecp_lane_decision_alternatives_become_structured():
-    ecp = to_ecp_lane_decision(_make_decision("p-1"))
-    assert len(ecp.alternatives) == 1
-    assert ecp.alternatives[0].executor == "codex_cli"
+    cxrp = to_cxrp_lane_decision(_make_decision("p-1"))
+    assert len(cxrp.alternatives) == 1
+    assert cxrp.alternatives[0].executor == "codex_cli"
 
 
 # ----------------------------------------------------------------------
@@ -225,27 +225,27 @@ def test_ecp_lane_decision_alternatives_become_structured():
 # ----------------------------------------------------------------------
 
 
-def test_to_ecp_execution_request_validates_against_schema():
+def test_to_cxrp_execution_request_validates_against_schema():
     req = _make_request("p-1", "d-1")
-    ecp = to_ecp_execution_request(req, executor="claude_cli", backend="kodo")
-    payload = ecp.to_dict()
+    cxrp = to_cxrp_execution_request(req, executor="claude_cli", backend="kodo")
+    payload = cxrp.to_dict()
     payload["lane"] = payload["lane"].value if hasattr(payload["lane"], "value") else payload["lane"]
     validate_contract("execution_request", payload)
 
 
 def test_execution_request_input_payload_validates_against_lane_schema():
     req = _make_request("p-1", "d-1")
-    ecp = to_ecp_execution_request(req, executor="claude_cli", backend="kodo")
-    assert ecp.input_payload_schema == CODING_AGENT_INPUT_SCHEMA_ID
-    validate_payload(ecp.input_payload_schema, ecp.input_payload)
+    cxrp = to_cxrp_execution_request(req, executor="claude_cli", backend="kodo")
+    assert cxrp.input_payload_schema == CODING_AGENT_INPUT_SCHEMA_ID
+    validate_payload(cxrp.input_payload_schema, cxrp.input_payload)
 
 
 def test_execution_request_limits_are_universal():
-    ecp = to_ecp_execution_request(_make_request("p", "d"), executor="claude_cli", backend="kodo")
-    assert ecp.limits is not None
-    assert ecp.limits.max_changed_files == 25
-    assert ecp.limits.timeout_seconds == 600
-    assert ecp.limits.require_clean_validation is True
+    cxrp = to_cxrp_execution_request(_make_request("p", "d"), executor="claude_cli", backend="kodo")
+    assert cxrp.limits is not None
+    assert cxrp.limits.max_changed_files == 25
+    assert cxrp.limits.timeout_seconds == 600
+    assert cxrp.limits.require_clean_validation is True
 
 
 # ----------------------------------------------------------------------
@@ -253,25 +253,25 @@ def test_execution_request_limits_are_universal():
 # ----------------------------------------------------------------------
 
 
-def test_to_ecp_execution_result_validates_against_schema():
+def test_to_cxrp_execution_result_validates_against_schema():
     req = _make_request("p", "d")
     result = _make_result(req)
-    ecp = to_ecp_execution_result(result)
-    validate_contract("execution_result", _serialize_result(ecp))
+    cxrp = to_cxrp_execution_result(result)
+    validate_contract("execution_result", _serialize_result(cxrp))
 
 
 def test_ecp_execution_result_status_uses_canonical_spelling():
     req = _make_request("p", "d")
     result = _make_result(req)
-    ecp = to_ecp_execution_result(result)
-    assert ecp.status.value == "succeeded"
+    cxrp = to_cxrp_execution_result(result)
+    assert cxrp.status.value == "succeeded"
 
 
 def test_ecp_execution_result_artifact_kind_preserves_oc_vocabulary():
     req = _make_request("p", "d")
     result = _make_result(req)
-    ecp = to_ecp_execution_result(result)
-    kinds = {a.kind for a in ecp.artifacts}
+    cxrp = to_cxrp_execution_result(result)
+    kinds = {a.kind for a in cxrp.artifacts}
     assert "diff" in kinds
     assert "pr_url" in kinds
 
@@ -279,9 +279,9 @@ def test_ecp_execution_result_artifact_kind_preserves_oc_vocabulary():
 def test_ecp_execution_result_diagnostics_carry_validation_summary():
     req = _make_request("p", "d")
     result = _make_result(req)
-    ecp = to_ecp_execution_result(result)
-    assert ecp.diagnostics["validation_status"] == "passed"
-    assert ecp.diagnostics["branch_pushed"] is True
+    cxrp = to_cxrp_execution_result(result)
+    assert cxrp.diagnostics["validation_status"] == "passed"
+    assert cxrp.diagnostics["branch_pushed"] is True
 
 
 # ----------------------------------------------------------------------
@@ -289,10 +289,10 @@ def test_ecp_execution_result_diagnostics_carry_validation_summary():
 # ----------------------------------------------------------------------
 
 
-def test_ecp_mapper_does_not_invoke_adapters_or_execution():
+def test_cxrp_mapper_does_not_invoke_adapters_or_execution():
     """Boundary check: mapper module must be import-side-effect-free and
     must not pull in adapters/execution coordinators."""
-    import operations_center.contracts.ecp_mapper as mod
+    import operations_center.contracts.cxrp_mapper as mod
 
     forbidden = (
         "operations_center.adapters",
@@ -301,12 +301,12 @@ def test_ecp_mapper_does_not_invoke_adapters_or_execution():
     )
     src = Path(mod.__file__).read_text()
     for needle in forbidden:
-        assert needle not in src, f"ecp_mapper unexpectedly imports {needle}"
+        assert needle not in src, f"cxrp_mapper unexpectedly imports {needle}"
 
 
 @pytest.mark.parametrize("status_value", ["succeeded", "failed", "cancelled", "timed_out"])
 def test_ecp_status_round_trip_for_terminal_states(status_value):
-    """All OC ExecutionStatus values that ECP also defines must round-trip."""
+    """All OC ExecutionStatus values that CxRP also defines must round-trip."""
     req = _make_request("p", "d")
     oc = ExecutionResult(
         run_id=req.run_id,
@@ -316,5 +316,5 @@ def test_ecp_status_round_trip_for_terminal_states(status_value):
         success=(status_value == "succeeded"),
         validation=ValidationSummary(status=ValidationStatus.SKIPPED),
     )
-    ecp = to_ecp_execution_result(oc)
-    assert ecp.status.value == status_value
+    cxrp = to_cxrp_execution_result(oc)
+    assert cxrp.status.value == status_value

--- a/tests/unit/routing/test_client.py
+++ b/tests/unit/routing/test_client.py
@@ -41,7 +41,7 @@ def _stub_decision(lane=LaneName.CLAUDE_CLI, backend=BackendName.KODO) -> LaneDe
     )
 
 
-def _stub_ecp_response(executor: str = "claude_cli", backend: str = "kodo") -> dict:
+def _stub_cxrp_response(executor: str = "claude_cli", backend: str = "kodo") -> dict:
     """Minimal CxRP v0.2 LaneDecision payload for /route mock responses."""
     return {
         "schema_version": "0.2",
@@ -59,7 +59,7 @@ def _stub_ecp_response(executor: str = "claude_cli", backend: str = "kodo") -> d
 
 
 def test_http_client_satisfies_protocol() -> None:
-    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=_stub_ecp_response()))
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=_stub_cxrp_response()))
     client = HttpLaneRoutingClient("http://switchboard.local", transport=transport)
     try:
         assert isinstance(client, LaneRoutingClient)
@@ -77,7 +77,7 @@ def test_http_client_posts_to_route_endpoint() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured.append(request)
-        return httpx.Response(200, json=_stub_ecp_response())
+        return httpx.Response(200, json=_stub_cxrp_response())
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx())
@@ -96,7 +96,7 @@ def test_http_client_serializes_canonical_proposal() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.update(json.loads(request.content.decode("utf-8")))
-        return httpx.Response(200, json=_stub_ecp_response())
+        return httpx.Response(200, json=_stub_cxrp_response())
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx(task_id="TASK-9", project_id="proj-9"))
@@ -141,19 +141,19 @@ def test_stub_returns_fixed_decision() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_http_client_decodes_ecp_shape_response() -> None:
-    """SwitchBoard emits ECP v0.2 envelope; the client must deserialize it
+def test_http_client_decodes_cxrp_shape_response() -> None:
+    """SwitchBoard emits CxRP v0.2 envelope; the client must deserialize it
     back into the OC LaneDecision."""
-    ecp_payload = {
+    cxrp_payload = {
         "schema_version": "0.2",
         "contract_kind": "lane_decision",
-        "decision_id": "dec-ecp-1",
-        "proposal_id": "prop-ecp-1",
+        "decision_id": "dec-cxrp-1",
+        "proposal_id": "prop-cxrp-1",
         "metadata": {"policy_rule_matched": "test_rule"},
         "lane": "coding_agent",
         "executor": "claude_cli",
         "backend": "kodo",
-        "rationale": "ecp-shape decision",
+        "rationale": "cxrp-shape decision",
         "confidence": 0.88,
         "alternatives": [
             {"lane": "coding_agent", "executor": "codex_cli"}
@@ -161,7 +161,7 @@ def test_http_client_decodes_ecp_shape_response() -> None:
     }
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json=ecp_payload)
+        return httpx.Response(200, json=cxrp_payload)
 
     client = HttpLaneRoutingClient("http://switchboard.local", transport=httpx.MockTransport(handler))
     proposal = build_proposal(_ctx())


### PR DESCRIPTION
Renames the mapper module/functions/aliases/local variables and scrubs every ECP docstring mention. Tests: 2050 passed.