### PR TITLE
ci: Custodian regression guard

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -324,3 +324,10 @@ OC findings: 364 → 73.
 - DC7: linked the upstream-patch-evaluation, routing-tuning, post-merge-hook,
   and execution-boundary ADR docs from docs/README.md.
 
+
+## 2026-05-08 — CI regression guard
+
+Added .github/workflows/custodian-audit.yml + .hooks/pre-push.
+Both run `custodian-multi --fail-on-findings`. CI is the source of
+truth; pre-push catches regressions before they hit GitHub.
+

--- a/.console/log.md
+++ b/.console/log.md
@@ -331,3 +331,6 @@ Added .github/workflows/custodian-audit.yml + .hooks/pre-push.
 Both run `custodian-multi --fail-on-findings`. CI is the source of
 truth; pre-push catches regressions before they hit GitHub.
 
+
+## 2026-05-08 — CI fix: Direct URL pip install syntax
+

--- a/.console/log.md
+++ b/.console/log.md
@@ -334,3 +334,10 @@ truth; pre-push catches regressions before they hit GitHub.
 
 ## 2026-05-08 — CI fix: Direct URL pip install syntax
 
+
+## 2026-05-08 — Drift cleanup caught by new CI guard
+
+run_show/main.py: split semicolon statements (E702), ensure_ascii=False on
+the JSON dump (C41). docs/README.md: linked the archon_workflow_registration
+doc (DC7).
+

--- a/.github/workflows/custodian-audit.yml
+++ b/.github/workflows/custodian-audit.yml
@@ -1,0 +1,37 @@
+# Custodian regression guard.
+# Runs on every push and PR to main. Fails CI on any new finding.
+# The repo is expected to be at zero findings on main; this guard
+# stops drift from creeping back in.
+name: custodian-audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Custodian
+        run: |
+          python -m pip install --upgrade pip
+          pip install "git+https://github.com/Velascat/Custodian.git@main#egg=custodian[tools]"
+          pip install ruff vulture ty
+
+      - name: Install repo (best-effort, for adapter passes)
+        run: |
+          if [ -f pyproject.toml ]; then
+            pip install -e . || true
+          fi
+
+      - name: Run Custodian audit
+        run: |
+          custodian-multi --repos . --fail-on-findings --no-color

--- a/.github/workflows/custodian-audit.yml
+++ b/.github/workflows/custodian-audit.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Custodian
         run: |
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/Velascat/Custodian.git@main#egg=custodian[tools]"
+          pip install "custodian[tools] @ git+https://github.com/Velascat/Custodian.git@main"
           pip install ruff vulture ty
 
       - name: Install repo (best-effort, for adapter passes)

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Custodian regression guard — pre-push hook.
+# Runs the same audit CI runs. Catches new findings before they hit GitHub.
+#
+# Install once per clone:
+#   git config core.hooksPath .hooks
+# Bypass intentionally: git push --no-verify
+set -e
+
+if ! command -v custodian-multi >/dev/null 2>&1; then
+    echo "[custodian-pre-push] custodian-multi not on PATH — skipping audit guard"
+    echo "    install with: pip install git+https://github.com/Velascat/Custodian.git@main"
+    exit 0
+fi
+
+echo "[custodian-pre-push] running audit guard..."
+custodian-multi --repos . --fail-on-findings --no-color

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ This directory holds OC-specific material.
 - [operator/manifest_authoring.md](operator/manifest_authoring.md) — How to author a `topology/project_manifest.yaml` for a project repo.
 - [operator/manifest_wiring.md](operator/manifest_wiring.md) — How OC picks up project + local manifests at runtime; the `platform_manifest:` settings block.
 - [operator/propagation/post-merge-hook.md](operator/propagation/post-merge-hook.md) — Post-merge propagation hook setup.
+- [operator/archon_workflow_registration.md](operator/archon_workflow_registration.md) — Archon workflow registration handshake.
 
 ## Backends
 

--- a/src/operations_center/entrypoints/run_show/main.py
+++ b/src/operations_center/entrypoints/run_show/main.py
@@ -96,7 +96,8 @@ def _print_trace(trace: dict) -> None:
     routing = trace.get("routing") or {}
     if routing:
         table = Table(title="SwitchBoard routing", show_header=True, header_style="bold")
-        table.add_column("field"); table.add_column("value")
+        table.add_column("field")
+        table.add_column("value")
         for field in (
             "decision_id", "selected_lane", "selected_backend",
             "policy_rule_matched", "rationale", "switchboard_version",
@@ -112,7 +113,8 @@ def _print_trace(trace: dict) -> None:
     ref = trace.get("runtime_invocation_ref")
     if ref:
         table = Table(title="RxP runtime invocation", show_header=True, header_style="bold")
-        table.add_column("field"); table.add_column("value")
+        table.add_column("field")
+        table.add_column("value")
         for field in ("invocation_id", "runtime_name", "runtime_kind",
                       "stdout_path", "stderr_path", "artifact_directory"):
             if field in ref:
@@ -167,7 +169,7 @@ def show(
     payload = json.loads(trace_path.read_text(encoding="utf-8"))
 
     if as_json:
-        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False))
         return
     _console.print(f"[dim]source: {trace_path}[/dim]\n")
     _print_trace(payload)


### PR DESCRIPTION
Adds CI + local pre-push hook running `custodian-multi --fail-on-findings`.

- `.github/workflows/custodian-audit.yml` — runs on push/PR to main; CI source of truth.
- `.hooks/pre-push` — local fast feedback (opt-in: `git config core.hooksPath .hooks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)