### PR TITLE
config: D11 exclusions for typological similarity

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -345,3 +345,6 @@ run_show/main.py: split semicolon statements (E702), ensure_ascii=False on
 the JSON dump (C41). docs/README.md: linked the archon_workflow_registration
 doc (DC7).
 
+
+## 2026-05-08 — D11 exclusions for backend + entrypoint typologies
+

--- a/.console/log.md
+++ b/.console/log.md
@@ -348,3 +348,6 @@ doc (DC7).
 
 ## 2026-05-08 — D11 exclusions for backend + entrypoint typologies
 
+
+## 2026-05-08 — Link ADR 0002+0003; common_words for ADR 0002 vocabulary
+

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -193,6 +193,10 @@ audit:
       # Campaign + usage stores share record_* event-emit pattern (event-
       # log typology). Real refactor would centralise the writer.
       - "src/operations_center/execution/**"
+      # mini_regression + slice_replay are sibling audit subsystems with
+      # parallel report-loading and check-functions. Typology by class.
+      - "src/operations_center/mini_regression/**"
+      - "src/operations_center/slice_replay/**"
     T8:
       # Architecture-guard + lock-store-concurrency tests don't import the
       # code under audit — they probe via subprocess + filesystem.

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -507,6 +507,9 @@ audit:
     - _run_with_claude_fallback
     - is_quota_exhausted
     - visibility
+    # ADR 0002 backend card axis vocabulary (orchestration / mechanism labels).
+    - local_subprocess
+    - single_agent
 
   # F3-exempt field names: schema/documentation fields never accessed by dot
   # notation because they're serialized to JSON and consumed by external readers,

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,10 @@ This directory holds OC-specific material.
 - [architecture/adr/](architecture/adr/) — OC architecture decision records.
   - [architecture/adr/0001-execution-boundary-operationscenter.md](architecture/adr/0001-execution-boundary-operationscenter.md) —
     Decision to make OperationsCenter the execution boundary.
+  - [architecture/adr/0002-backend-card-axis-expansion.md](architecture/adr/0002-backend-card-axis-expansion.md) —
+    Backend card axis expansion (orchestration + mechanism).
+  - [architecture/adr/0003-tiered-cognition-experimental-rails.md](architecture/adr/0003-tiered-cognition-experimental-rails.md) —
+    Tiered cognition + experimental rails.
 
 ### Managed-repo audit contracts
 


### PR DESCRIPTION
Custodian's new D11 detector flags duplicate function bodies. Adds per-repo exclusions for paths where pattern-similarity is intentional (CRUD trios, sync/async pairs, strategy patterns, sibling adapter families).

D11 retains coverage everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)