### PR TITLE
docs: mark recovery-subsystem-test-coverage spec cancelled

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -3,6 +3,8 @@
 _Chronological continuity log. Decisions, stop points, what changed and why._
 _Not a task tracker — that's backlog.md. Keep entries concise and dated._
 
+## 2026-05-17 — docs: mark recovery-subsystem-test-coverage spec cancelled
+
 ## 2026-05-15 — board_unblock: pre-dispatch memory check
 
 Added memory guard to board_unblock.py: skip all rules if MemAvailable < 1.7GB (pre-OOM).

--- a/docs/specs/recovery-subsystem-test-coverage.md
+++ b/docs/specs/recovery-subsystem-test-coverage.md
@@ -12,7 +12,7 @@ area_keywords:
   - recovery
   - recovery_policies
   - tests/unit
-status: active
+status: cancelled
 created_at: 2026-05-13T23:59:00Z
 ---
 


### PR DESCRIPTION
## Summary

- Sets `status: cancelled` on `docs/specs/recovery-subsystem-test-coverage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)