### PR TITLE
feat(phase-3): update OC imports from ExecutorRuntime → CoreRunner

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -3,6 +3,14 @@
 _Chronological continuity log. Decisions, stop points, what changed and why._
 _Not a task tracker — that's backlog.md. Keep entries concise and dated._
 
+## 2026-05-19 — ADR 0006 Phase 3: OC imports updated to CoreRunner
+
+- direct_local/adapter.py, aider_local/adapter.py, openclaw/invoke.py: executor_runtime → core_runner, ExecutorRuntime → CoreRunner.
+- _runtime_ref.py, contracts/execution.py, observability/trace.py, entrypoints/run_show/main.py: docstring/comment references updated.
+- pyproject.toml: executor-runtime dep → core-runner.
+- Installed core-runner from local ExecutorRuntime/src into .venv.
+- 3345 tests pass.
+
 ## 2026-05-19 — Removed remaining live kodo/archon references from src (final sweep)
 
 Renamed `kodo_exit_code` → `executor_exit_code` in validation.py dataclass + builder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "cxrp @ git+https://github.com/ProtocolWarden/CxRP.git@v0.3.1",
   "source-registry @ git+https://github.com/ProtocolWarden/SourceRegistry.git",
   "rxp @ git+https://github.com/ProtocolWarden/RxP.git",
-  "executor-runtime @ git+https://github.com/ProtocolWarden/ExecutorRuntime.git",
+  "core-runner @ git+https://github.com/ProtocolWarden/CoreRunner.git",
   "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.0.0",
 ]
 

--- a/src/operations_center/backends/_runtime_ref.py
+++ b/src/operations_center/backends/_runtime_ref.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 ProtocolWarden
 """Helper for building ``ExecutionResult.runtime_invocation_ref``.
 
-Adapters that delegate execution mechanics to ExecutorRuntime call
+Adapters that delegate execution mechanics to CoreRunner call
 ``runtime_invocation_ref(invocation, rxp_result)`` and pass the result
 into ``ExecutionResult(...)``. This is the canonical place where the OC
 ↔ RxP linkage is captured.

--- a/src/operations_center/backends/aider_local/adapter.py
+++ b/src/operations_center/backends/aider_local/adapter.py
@@ -17,7 +17,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from executor_runtime import ExecutorRuntime
+from core_runner import CoreRunner
 from rxp.contracts import RuntimeInvocation
 
 from operations_center.config.settings import AiderLocalSettings
@@ -37,16 +37,16 @@ class AiderLocalBackendAdapter:
     """Canonical adapter for the aider_local CPU execution backend.
 
     Phase 2 + 3 of the OC runtime extraction: subprocess invocation
-    is delegated to ``ExecutorRuntime`` (subprocess kind). Same pattern
+    is delegated to ``CoreRunner`` (subprocess kind). Same pattern
     as team_executor and direct_local.
     """
 
     def __init__(
         self,
         settings: AiderLocalSettings,
-        runtime: ExecutorRuntime | None = None,
+        runtime: CoreRunner | None = None,
     ) -> None:
-        self._runtime = runtime or ExecutorRuntime()
+        self._runtime = runtime or CoreRunner()
         self._settings = settings
 
     def execute(self, request: ExecutionRequest) -> ExecutionResult:
@@ -205,7 +205,7 @@ class _AiderLocalRunResult:
 
 
 def _read_capture(path: str | None) -> str:
-    """Read a captured stdout/stderr file produced by ExecutorRuntime."""
+    """Read a captured stdout/stderr file produced by CoreRunner."""
     if not path:
         return ""
     p = Path(path)

--- a/src/operations_center/backends/direct_local/adapter.py
+++ b/src/operations_center/backends/direct_local/adapter.py
@@ -7,9 +7,9 @@ This adapter runs the Aider CLI behind the canonical
 ExecutionRequest -> ExecutionResult contract for the local execution lane.
 
 Phase 2 + 3 of the OC runtime extraction: subprocess invocation is
-delegated to ``ExecutorRuntime`` (subprocess kind). The adapter
+delegated to ``CoreRunner`` (subprocess kind). The adapter
 constructs an RxP ``RuntimeInvocation``, hands it to
-``ExecutorRuntime.run``, reads stdout/stderr from the paths in the
+``CoreRunner.run``, reads stdout/stderr from the paths in the
 returned ``RuntimeResult``, and assembles the existing
 ``_DirectLocalRunResult`` for the adapter's downstream code.
 """
@@ -22,7 +22,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from executor_runtime import ExecutorRuntime
+from core_runner import CoreRunner
 from rxp.contracts import RuntimeInvocation
 
 from operations_center.config.settings import AiderSettings
@@ -44,10 +44,10 @@ class DirectLocalBackendAdapter:
     def __init__(
         self,
         settings: AiderSettings,
-        runtime: ExecutorRuntime | None = None,
+        runtime: CoreRunner | None = None,
     ) -> None:
         self._settings = settings
-        self._runtime = runtime or ExecutorRuntime()
+        self._runtime = runtime or CoreRunner()
 
     def execute(self, request: ExecutionRequest) -> ExecutionResult:
         repo_path = Path(request.workspace_path)
@@ -205,7 +205,7 @@ class _DirectLocalRunResult:
 
 
 def _read_capture(path: str | None) -> str:
-    """Read a captured stdout/stderr file produced by ExecutorRuntime."""
+    """Read a captured stdout/stderr file produced by CoreRunner."""
     if not path:
         return ""
     p = Path(path)

--- a/src/operations_center/backends/openclaw/invoke.py
+++ b/src/operations_center/backends/openclaw/invoke.py
@@ -8,7 +8,7 @@ Subclass it to provide a real implementation; use StubOpenClawRunner or a
 MagicMock(spec=OpenClawRunner) in tests.
 
 OpenClawBackendInvoker constructs an RxP ``RuntimeInvocation`` and hands
-it to ``ExecutorRuntime`` (which routes ``runtime_kind="manual"`` to a
+it to ``CoreRunner`` (which routes ``runtime_kind="manual"`` to a
 ``ManualRunner`` registered with an openclaw-specific dispatcher),
 receives an RxP ``RuntimeResult`` back, and assembles the
 ``OpenClawRunCapture`` for the normalizer.
@@ -27,8 +27,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from executor_runtime import ExecutorRuntime
-from executor_runtime.runners import ManualRunner
+from core_runner import CoreRunner
+from core_runner.runners import ManualRunner
 from rxp.contracts import RuntimeInvocation, RuntimeResult
 
 from .models import OpenClawArtifactCapture, OpenClawRunCapture, OpenClawPreparedRun
@@ -63,15 +63,15 @@ class StubOpenClawRunner(OpenClawRunner):
 
 
 class OpenClawBackendInvoker:
-    """Invokes OpenClaw via ExecutorRuntime + ManualRunner."""
+    """Invokes OpenClaw via CoreRunner + ManualRunner."""
 
     def __init__(
         self,
         runner: OpenClawRunner,
-        runtime: ExecutorRuntime | None = None,
+        runtime: CoreRunner | None = None,
     ) -> None:
         self._runner = runner
-        self._runtime = runtime or ExecutorRuntime()
+        self._runtime = runtime or CoreRunner()
 
     def invoke(self, prepared: OpenClawPreparedRun) -> OpenClawRunCapture:
         started_at = _now()

--- a/src/operations_center/contracts/execution.py
+++ b/src/operations_center/contracts/execution.py
@@ -242,7 +242,7 @@ class OcExecutionResult(BaseModel):
     recovery: Optional["RecoveryMetadataSummary"] = None
 
     # G-V01 — pointer back to the RxP RuntimeInvocation/RuntimeResult that
-    # powered this run. Adapters that delegate to ExecutorRuntime populate
+    # powered this run. Adapters that delegate to CoreRunner populate
     # this so an OC ExecutionResult can be linked to RxP runtime artifacts
     # (stdout/stderr/artifact_directory). Adapters that do not invoke a
     # runtime (e.g. demo_stub) leave this None.
@@ -338,14 +338,14 @@ class RuntimeInvocationRef(BaseModel):
     """Link from an OC execution result to the RxP RuntimeInvocation/Result that produced it.
 
     Populated by adapters that delegate execution mechanics to
-    ExecutorRuntime. Carries the identity of the RuntimeInvocation
-    (``invocation_id``) plus the ExecutorRuntime-captured stdout/stderr
+    CoreRunner. Carries the identity of the RuntimeInvocation
+    (``invocation_id``) plus the CoreRunner-captured stdout/stderr
     paths and the per-call artifact directory, so audit/replay can reach
     the underlying RxP RuntimeResult artifacts from the OC result alone.
     """
 
     invocation_id: str = Field(description="RuntimeInvocation.invocation_id (matches RuntimeResult.invocation_id)")
-    runtime_name: str = Field(description="Logical runtime name passed to ExecutorRuntime, e.g. 'direct_local', 'team_executor'")
+    runtime_name: str = Field(description="Logical runtime name passed to CoreRunner, e.g. 'direct_local', 'team_executor'")
     runtime_kind: str = Field(description="RxP runtime kind, e.g. 'subprocess', 'http_async', 'manual'")
     stdout_path: Optional[str] = Field(default=None, description="RuntimeResult.stdout_path, if the runner captured it")
     stderr_path: Optional[str] = Field(default=None, description="RuntimeResult.stderr_path, if the runner captured it")

--- a/src/operations_center/entrypoints/run_show/main.py
+++ b/src/operations_center/entrypoints/run_show/main.py
@@ -138,7 +138,7 @@ def _print_trace(trace: dict) -> None:
                 table.add_row(field, rendered)
         _console.print(table)
     else:
-        _console.print("[dim](no runtime_invocation_ref — adapter did not invoke ExecutorRuntime)[/dim]")
+        _console.print("[dim](no runtime_invocation_ref — adapter did not invoke CoreRunner)[/dim]")
 
     warnings = trace.get("warnings") or []
     if warnings:

--- a/src/operations_center/observability/trace.py
+++ b/src/operations_center/observability/trace.py
@@ -71,7 +71,7 @@ class ExecutionTrace(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     backend_detail_refs: list[BackendDetailRef] = Field(default_factory=list)
     # G-V03 — forward the OC ↔ RxP linkage so a single trace has the full
-    # provenance chain. None for adapters that do not invoke ExecutorRuntime
+    # provenance chain. None for adapters that do not invoke CoreRunner
     # (e.g. demo_stub).
     runtime_invocation_ref: Optional[RuntimeInvocationRef] = None
     # G-V03 — forward SwitchBoard routing provenance from
@@ -185,7 +185,7 @@ class RunReportBuilder:
             warnings.append("no primary artifacts produced by this run")
         if record.result.failure_category == FailureReasonCategory.NO_CHANGES:
             warnings.append("run completed with no file changes")
-        # Artifact-path staleness — ExecutorRuntime writes stdout/stderr
+        # Artifact-path staleness — CoreRunner writes stdout/stderr
         # and an artifact_directory under tmp; if the dir was reaped
         # between the run and the trace build, surface a warning rather
         # than silently shipping a dead path. (We intentionally do NOT


### PR DESCRIPTION
## Summary
- Updates `direct_local`, `aider_local`, `openclaw` adapters: `executor_runtime` → `core_runner`, `ExecutorRuntime` → `CoreRunner`
- Updates `pyproject.toml`: `executor-runtime` → `core-runner` dependency
- Updates docstrings/comments in contracts, observability, entrypoints
- 3345 tests pass; custodian clean

## Test plan
- [x] `pytest tests/ -q` → 3345 passed, 5 skipped
- [x] Custodian pre-push → 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)