### PR TITLE
fix: remove Cognition Lifecycle section from CLAUDE.md

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -3,6 +3,12 @@
 _Chronological continuity log. Decisions, stop points, what changed and why._
 _Not a task tracker — that's backlog.md. Keep entries concise and dated._
 
+## 2026-05-21 — Remove Cognition Lifecycle section from CLAUDE.md
+
+OperatorConsole's context injector rewrites CLAUDE.md on session start, stripping anything
+after its managed block. Moved CLP lifecycle content to .context/README.md (already there).
+CLAUDE.md is now OC-managed-only to avoid dirty diffs.
+
 ## 2026-05-21 — Custodian violation fixes (pre-existing)
 
 **C29:** workspace.py was 501 lines. Condensed logger.info call to bring under limit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,30 +18,3 @@ The context file contains your current task, guidelines, backlog, log, and runti
 
 After meaningful progress, update `.console/backlog.md` and `.console/log.md`.
 Do not edit `.console/.context` directly — it is regenerated at each launch.
-
-## Cognition Lifecycle
-
-OC uses [ContextLifecycleProtocol](https://github.com/ProtocolWarden/ContextLifecycleProtocol) for bounded, resumable agent sessions.
-
-| Surface       | Purpose                                                      |
-|---------------|--------------------------------------------------------------|
-| `.console/`   | Operational truth — task, guidelines, backlog, log           |
-| `.context/`   | Durable cognition — capsules, checkpoints, handoffs, leases  |
-| `.claude/`    | Claude Code adapter — ContextGuard hooks                     |
-
-**Orchestrator lifecycle:**
-
-```
-wake → read .context/checkpoints/<latest>.yaml
-     → read active capsule refs
-     → classify state
-     → dispatch bounded worker if needed
-     → write updated checkpoint
-     → update .console/log.md
-     → terminate or compact
-```
-
-**On session start:** Check `.context/active/` for any active capsules. Check `.context/checkpoints/` for the latest checkpoint.  
-**On session end:** Write a LoopCheckpoint. Update any active capsule's `handoff_notes` and `next_actions`.  
-**Templates:** `.context/templates/`  
-**Config:** `.context/config.yaml`


### PR DESCRIPTION
## Summary

- Removes the custom "Cognition Lifecycle" section from `CLAUDE.md`
- OperatorConsole's context injector rewrites `CLAUDE.md` on every session start, stripping anything after its managed `<!-- console-context -->` block — causing a permanent dirty diff
- The CLP lifecycle content is already documented in `.context/README.md` and `.context/config.yaml`, so nothing is lost

## Test plan

- [ ] Open OC session via OperatorConsole — no dirty diff on `CLAUDE.md` afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)