### PR TITLE
fix: add closing fence to console-context block in CLAUDE.md

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,10 @@
 # Log
 
+## 2026-05-21 — Add closing fence to console-context block
+
+Added <!-- /console-context --> end marker so OperatorConsole only replaces its
+managed block and leaves repo-owned content below it untouched.
+
 _Chronological continuity log. Decisions, stop points, what changed and why._
 _Not a task tracker — that's backlog.md. Keep entries concise and dated._
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,31 @@ The context file contains your current task, guidelines, backlog, log, and runti
 
 After meaningful progress, update `.console/backlog.md` and `.console/log.md`.
 Do not edit `.console/.context` directly — it is regenerated at each launch.
+<!-- /console-context -->
+
+## Cognition Lifecycle
+
+OC uses [ContextLifecycleProtocol](https://github.com/ProtocolWarden/ContextLifecycleProtocol) for bounded, resumable agent sessions.
+
+| Surface       | Purpose                                                      |
+|---------------|--------------------------------------------------------------|
+| `.console/`   | Operational truth — task, guidelines, backlog, log           |
+| `.context/`   | Durable cognition — capsules, checkpoints, handoffs, leases  |
+| `.claude/`    | Claude Code adapter — ContextGuard hooks                     |
+
+**Orchestrator lifecycle:**
+
+```
+wake → read .context/checkpoints/<latest>.yaml
+     → read active capsule refs
+     → classify state
+     → dispatch bounded worker if needed
+     → write updated checkpoint
+     → update .console/log.md
+     → terminate or compact
+```
+
+**On session start:** Check `.context/active/` for any active capsules. Check `.context/checkpoints/` for the latest checkpoint.
+**On session end:** Write a LoopCheckpoint. Update any active capsule's `handoff_notes` and `next_actions`.
+**Templates:** `.context/templates/`
+**Config:** `.context/config.yaml`


### PR DESCRIPTION
Adds `<!-- /console-context -->` end marker so OperatorConsole only replaces its managed block and leaves repo-owned content below it untouched. Part of ecosystem-wide migration.