### PR TITLE
CI schema: record operator decisions for §12 open questions

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,14 @@
 # Log
 
+## 2026-05-21 — Record operator decisions in CI schema design (§12)
+
+All 5 open questions resolved: OC owns evaluation command derivation; guardrails
+are closed enum (EnforcedGuardrail) + advisory custom_checks; lineage is CLP-native
+in .context/capsules/ indexed by OC via OcLineageIndexEntry, archived by Warehouse;
+CI spec stays OC-internal (not in CxRP wire); no new ExecutionMode unless routing
+diverges. Updated design.md §12 and draft_schema.py with EvaluationCommandSource
+enum, OcLineageIndexEntry type, and closed EnforcedGuardrail enum.
+
 ## 2026-05-21 — Fix Custodian DC7/K1/OC8 in CI design doc
 
 Linked design.md from docs/README.md; unquoted worker_scope field name.

--- a/docs/design/continuous-improvement/design.md
+++ b/docs/design/continuous-improvement/design.md
@@ -1,6 +1,6 @@
 # Continuous Improvement Schema Extension — Design
 
-**Status:** DRAFT  
+**Status:** DRAFT — decisions recorded (2026-05-21); pending implementation  
 **Date:** 2026-05-21  
 **Scope:** Platform work-item schema extension  
 **Primary contract:** `OcPlanningProposal` + new `ContinuousImprovementSpec` block  
@@ -623,19 +623,61 @@ continuous_improvement:
 
 ---
 
-## 12. Open Questions (for operator decision)
+## 12. Decisions
 
-These require explicit decisions before production implementation:
+**Status:** All five questions resolved (2026-05-21). Schema updated in `draft_schema.py`.
 
-1. **Evaluation command ownership:** Who writes and validates the `evaluation_command`? Is it provided by the Proposer, by OC, or derived from validation_profile?
+---
 
-2. **Guardrail extensibility:** Should guardrails be a closed enum or open strings? Open strings are flexible but reduce automated enforcement. Closed enum allows ContextGuard integration per guardrail.
+**Q1 — Evaluation command ownership**
 
-3. **Lineage storage:** Should lineage live in the repo's `.context/capsules/` (CLP-native) or in OC's run store? The design assumes `.context/` for now; Warehouse archival happens post-resolution.
+> *OC owns command derivation.*
 
-4. **CxRP wire extension:** Does `ContinuousImprovementSpec` need to appear in the CxRP wire contract, or is it OC-internal? The current design keeps it OC-internal (not in CxRP `TaskProposal`), consistent with how `LifecycleMetadata` is handled.
+`evaluation_command` is OC-derived, resolved from `validation_profile`. The Proposer may supply an `evaluation_command_hint` (advisory only). OC validates and canonicalizes before execution. Source is tracked via `EvaluationCommandSource` enum: `OC_DERIVED`, `PROPOSER_SUGGESTED`, `VALIDATION_PROFILE`.
 
-5. **ExecutionMode entry:** Should a new `ExecutionMode.IMPROVE_CAMPAIGN_CI` distinguish CI-backed improve_campaign from the existing `improve_campaign`? Or is the presence of `continuous_improvement` block sufficient?
+---
+
+**Q2 — Guardrail extensibility**
+
+> *Guardrails are a closed enum + optional advisory custom notes.*
+
+`guardrails: list[EnforcedGuardrail]` is a closed enum with automated enforcement:
+- `NO_LOST_ESCALATIONS`
+- `CUSTODIAN_CLEAN`
+- `NO_ARCHITECTURE_VIOLATIONS`
+- `REGRESSION_FIXTURES_PASS`
+- `NO_RUNTIME_POLICY_WIDENING`
+
+Advisory, non-blocking notes go in `custom_checks: list[str]`. ContextGuard can integrate per-guardrail enforcement without open-ended string parsing.
+
+---
+
+**Q3 — Lineage storage**
+
+> *Lineage is CLP-native in `.context`, indexed by OC, archived by Warehouse.*
+
+Three-tier model:
+1. **Primary/canonical:** `.context/capsules/<lineage_id>/lineage.json` — CLP-native, written during execution
+2. **OC index:** `OcLineageIndexEntry` in the run store — lightweight pointer for routing and status queries
+3. **Archive:** Warehouse archives post-resolution via `warehouse_archive_id`
+
+OC never duplicates the full lineage object; it holds only the index entry pointing to the CLP artifact.
+
+---
+
+**Q4 — CxRP wire extension**
+
+> *CI spec stays OC-internal initially.*
+
+`ContinuousImprovementSpec` is not added to the CxRP `TaskProposal` wire contract. Consistent with how `LifecycleMetadata` is handled: OC enriches internally, CxRP sees only the core task shape. Revisit if cross-system CI coordination is needed.
+
+---
+
+**Q5 — ExecutionMode entry**
+
+> *No new ExecutionMode unless routing semantics actually diverge.*
+
+Presence of the `continuous_improvement` block is sufficient to opt into the CI lifecycle. `execution_mode: improve_campaign` is reused. A new `IMPROVE_CAMPAIGN_CI` mode would be added only if the routing path or capability requirements diverge from the existing improve_campaign lane.
 
 ---
 

--- a/docs/design/continuous-improvement/draft_schema.py
+++ b/docs/design/continuous-improvement/draft_schema.py
@@ -15,6 +15,13 @@ CLP artifact paths are carried as string references only — no live imports
 from ContextLifecycleProtocol. Paths are relative to the target repo root.
 
 Design doc: docs/design/continuous-improvement/design.md
+
+Open questions resolved (2026-05-21):
+  Q1 evaluation_command ownership → OC derives from validation_profile; proposer may suggest
+  Q2 guardrail extensibility → closed EnforcedGuardrail enum + advisory custom_checks list
+  Q3 lineage storage → .context/capsules/ (CLP-native); OC indexes; Warehouse archives
+  Q4 CxRP wire extension → stay OC-internal; not in TaskProposal yet
+  Q5 ExecutionMode → no new entry; improve_campaign + CI block presence is sufficient
 """
 
 from __future__ import annotations
@@ -34,10 +41,10 @@ class RefinementStatus(str, Enum):
     """Overall status of the refinement lifecycle for this work item."""
     NOT_STARTED = "not_started"
     IN_PROGRESS = "in_progress"
-    ACCEPTED = "accepted"         # an attempt met all guardrails and was proposed
+    ACCEPTED = "accepted"                # an attempt met all guardrails; proposed for merge
     BUDGET_EXHAUSTED = "budget_exhausted"  # max_attempts reached without acceptance
-    ABANDONED = "abandoned"       # explicitly halted (policy block, invariant violation)
-    ESCALATED = "escalated"       # requires operator decision
+    ABANDONED = "abandoned"              # explicitly halted (hard invariant violation)
+    ESCALATED = "escalated"             # requires operator decision
 
 
 class RefinementDecision(str, Enum):
@@ -50,11 +57,11 @@ class RefinementDecision(str, Enum):
 
 class EvaluationOutcome(str, Enum):
     """Coarse evaluation result for a single attempt."""
-    IMPROVED = "improved"         # primary metric improved, all guardrails passed
-    NEUTRAL = "neutral"           # no regression, no improvement
-    REGRESSED = "regressed"       # primary metric worsened
+    IMPROVED = "improved"                  # primary metric improved, all guardrails passed
+    NEUTRAL = "neutral"                    # no regression, no improvement
+    REGRESSED = "regressed"               # primary metric worsened
     GUARDRAIL_VIOLATED = "guardrail_violated"  # hard gate failed
-    INCONCLUSIVE = "inconclusive" # not enough evidence to score
+    INCONCLUSIVE = "inconclusive"         # not enough evidence to score
 
 
 class LineageBranchReason(str, Enum):
@@ -63,6 +70,39 @@ class LineageBranchReason(str, Enum):
     RETRY_AFTER_FAILURE = "retry_after_failure"
     STRATEGY_VARIATION = "strategy_variation"
     OPERATOR_RESTART = "operator_restart"
+
+
+class EnforcedGuardrail(str, Enum):
+    """
+    Closed enum of guardrails that ContextGuard and Custodian can enforce automatically.
+
+    Q2 decision: closed enum for machine-enforceable gates. Each value maps to a
+    concrete check OC runs post-execution. Advisory notes go in custom_checks.
+
+    Enforcement mapping:
+      NO_LOST_ESCALATIONS       → compare escalation count before/after attempt
+      CUSTODIAN_CLEAN           → run Custodian; require 0 findings on result diff
+      NO_ARCHITECTURE_VIOLATIONS → run Custodian X2/B1 boundary checks
+      REGRESSION_FIXTURES_PASS  → re-run validation_profile.commands on result branch
+      NO_RUNTIME_POLICY_WIDENING → static check: forbidden_paths unchanged, no policy file edits
+    """
+    NO_LOST_ESCALATIONS = "no_lost_escalations"
+    CUSTODIAN_CLEAN = "custodian_clean"
+    NO_ARCHITECTURE_VIOLATIONS = "no_architecture_violations"
+    REGRESSION_FIXTURES_PASS = "regression_fixtures_pass"
+    NO_RUNTIME_POLICY_WIDENING = "no_runtime_policy_widening"
+
+
+class EvaluationCommandSource(str, Enum):
+    """
+    How the evaluation_command was determined.
+
+    Q1 decision: OC derives the command from validation_profile; proposer may suggest
+    one but OC validates/normalizes it before use.
+    """
+    OC_DERIVED = "oc_derived"               # OC built the command from validation_profile
+    PROPOSER_SUGGESTED = "proposer_suggested"  # proposer suggested; OC validated
+    VALIDATION_PROFILE = "validation_profile"  # taken directly from validation_profile.commands
 
 
 # ---------------------------------------------------------------------------
@@ -74,17 +114,17 @@ class ImprovementStrategy(BaseModel):
     Describes the semantic approach the worker should use.
 
     ``principle`` is a one-sentence description of the improvement heuristic.
-    ``constraints`` are OC-enforced hard limits on what the worker may change.
-    These must be a subset of the originating proposal's constraints.
+    ``constraints`` are hard limits propagated directly into WorkerHandoff.worker_scope
+    and enforced by ContextGuard — not advisory.
     """
     principle: str = Field(
-        description="One-sentence improvement heuristic, e.g. 'fingerprint repeated failures and apply cooldown'",
+        description="One-sentence improvement heuristic",
     )
     constraints: list[str] = Field(
         default_factory=list,
         description=(
-            "Hard limits on the improvement attempt. Must include at least 'fail_closed'. "
-            "Examples: fail_closed, preserve_existing_escalations, no_runtime_policy_widening"
+            "Hard limits on the attempt. Must include 'fail_closed'. "
+            "Propagated into WorkerHandoff worker_scope and enforced by ContextGuard."
         ),
     )
     variation_hint: Optional[str] = Field(
@@ -110,22 +150,33 @@ class ScoringMetric(BaseModel):
     )
     target_delta: Optional[float] = Field(
         default=None,
-        description="Minimum required improvement to pass this metric",
+        description="Minimum required improvement delta to pass this metric",
     )
-    unit: Optional[str] = Field(default=None, description="Unit for reporting, e.g. 'count', 'percent'")
+    unit: Optional[str] = Field(default=None, description="Unit for reporting")
 
 
 class EvaluationSpec(BaseModel):
     """
     Defines how an improvement attempt will be evaluated.
 
-    ``baseline`` is a reference to the behavior being compared against.
-    ``primary_scoring`` defines the improvement target.
-    ``guardrails`` are conditions that must ALL pass; violating any single
-    guardrail is grounds for ABANDON regardless of primary score.
+    Guardrail policy (Q2):
+      ``guardrails`` is a closed list of EnforcedGuardrail values that OC and
+      ContextGuard/Custodian can enforce automatically. All must pass; any
+      violation → ABANDON regardless of primary score.
+
+      ``custom_checks`` carries advisory notes or manual verification steps that
+      an operator should inspect but that are not machine-enforced. Failures here
+      do not trigger automatic ABANDON.
+
+    Evaluation command policy (Q1):
+      ``evaluation_command`` is set by OC, not the proposer. Proposers may put
+      a suggestion in ``evaluation_command_hint``; OC validates, normalizes, and
+      either adopts it or derives from validation_profile. The resolved command
+      is stored in ``evaluation_command`` with its source in
+      ``evaluation_command_source``.
     """
     baseline_description: str = Field(
-        description="Human-readable description of the baseline behavior, e.g. 'current_watchdog_behavior'",
+        description="Human-readable description of baseline behavior",
     )
     baseline_artifact_path: Optional[str] = Field(
         default=None,
@@ -138,19 +189,40 @@ class EvaluationSpec(BaseModel):
         default_factory=list,
         description="Additional metrics tracked but not required for acceptance",
     )
-    guardrails: list[str] = Field(
+
+    # Q2: closed enum for enforced guardrails
+    guardrails: list[EnforcedGuardrail] = Field(
         description=(
-            "Hard-stop conditions. Any violation → ABANDON. "
-            "Examples: no_lost_escalations, custodian_clean, no_architecture_violations, "
-            "regression_fixtures_pass"
+            "Machine-enforceable hard gates. All must pass; any violation → ABANDON. "
+            "OC and ContextGuard/Custodian run these automatically."
+        ),
+    )
+    custom_checks: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Advisory human-readable checks not enforced automatically. "
+            "Operator should review before accepting. Failures do not trigger ABANDON."
+        ),
+    )
+
+    # Q1: OC owns the resolved evaluation command
+    evaluation_command_hint: Optional[str] = Field(
+        default=None,
+        description=(
+            "Proposer-supplied evaluation command suggestion. "
+            "OC validates and normalizes before use; may override entirely."
         ),
     )
     evaluation_command: Optional[str] = Field(
         default=None,
         description=(
-            "Optional deterministic command to produce evaluation evidence. "
-            "Must be runnable from target repo root."
+            "Resolved evaluation command. Set by OC (not proposer) from validation_profile "
+            "or by validating evaluation_command_hint. Must be runnable from target repo root."
         ),
+    )
+    evaluation_command_source: Optional[EvaluationCommandSource] = Field(
+        default=None,
+        description="How evaluation_command was determined. Set by OC at dispatch time.",
     )
 
 
@@ -163,29 +235,29 @@ class RefinementPolicy(BaseModel):
     Governs retry and refinement behavior.
 
     ``max_attempts`` counts total executions including the initial attempt.
-    ``requires_checkpoint_between_attempts`` forces a CLP checkpoint before
-    each retry — the operator can inspect and intervene between attempts.
+    ``requires_checkpoint_between_attempts`` forces a CLP LoopCheckpoint before
+    each retry — operator can inspect and intervene between attempts.
     ``failure_penalty`` applies a budget deduction when an attempt fails a
-    non-primary guardrail — prevents cheap retries on bad attempts.
+    hard guardrail — prevents degenerate retries on bad attempts.
     """
     enabled: bool = Field(default=True)
     max_attempts: int = Field(default=3, ge=1, le=10)
     requires_checkpoint_between_attempts: bool = Field(
         default=True,
-        description="If true, a LoopCheckpoint must be written and inspectable before each retry",
+        description="LoopCheckpoint must be written and inspectable before each retry",
     )
     vary_strategy_on_retry: bool = Field(
         default=False,
-        description="If true, the worker may vary strategy.variation_hint between attempts",
+        description="OC may update strategy.variation_hint between attempts",
     )
     failure_penalty: int = Field(
         default=0,
         ge=0,
-        description="Additional attempts consumed when a hard guardrail fails. Prevents degenerate retries.",
+        description="Extra attempts consumed when a hard guardrail fails.",
     )
     accept_on_neutral: bool = Field(
         default=False,
-        description="If true, a NEUTRAL evaluation outcome (no regression, no improvement) counts as acceptance",
+        description="NEUTRAL outcome (no regression, no improvement) counts as acceptance",
     )
 
 
@@ -195,31 +267,42 @@ class RefinementPolicy(BaseModel):
 
 class ClpBinding(BaseModel):
     """
-    References to CLP artifacts that provide continuity across refinement attempts.
+    References to CLP artifacts providing continuity across refinement attempts.
 
-    All paths are relative to the target repo root (.context/).
-    These are path references only — not live objects.
-    The worker loads them on resume via standard CLP schema.
+    Q3 decision: primary lineage lives in .context/capsules/<lineage_id>/ (CLP-native).
+    OC run store keeps index/status. Warehouse archives after resolution.
+
+    All paths are relative to the target repo root. Path references only —
+    the worker loads artifacts at runtime via standard CLP schema.
     """
     investigation_capsule_path: Optional[str] = Field(
         default=None,
-        description="Path to active InvestigationCapsule, e.g. '.context/active/inv-<id>.yaml'",
+        description="Active InvestigationCapsule, e.g. '.context/active/inv-<id>.yaml'",
     )
     loop_checkpoint_path: Optional[str] = Field(
         default=None,
-        description="Path to latest LoopCheckpoint, e.g. '.context/checkpoints/chk-<id>.yaml'",
+        description="Latest LoopCheckpoint, e.g. '.context/checkpoints/chk-<id>.yaml'",
     )
     worker_handoff_path: Optional[str] = Field(
         default=None,
-        description="Path to active WorkerHandoff, e.g. '.context/handoffs/handoff-<id>.yaml'",
+        description="Active WorkerHandoff, e.g. '.context/handoffs/handoff-<id>.yaml'",
     )
     worker_scope_path: Optional[str] = Field(
         default=None,
-        description="Path to scope definition (within the handoff or separately stored)",
+        description="Scope definition path (within the handoff or separately stored)",
     )
     lease_expires_at: Optional[datetime] = Field(
         default=None,
         description="Copied from active lease for quick expiry checks without loading YAML",
+    )
+    # Q3: lineage canonical location
+    lineage_artifact_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to ImprovementLineage JSON, e.g. "
+            "'.context/capsules/<lineage_id>/lineage.json'. "
+            "Canonical CLP-native location; OC indexes this path in run store."
+        ),
     )
 
 
@@ -235,12 +318,20 @@ class EvaluationScore(BaseModel):
         description="Value relative to baseline (negative = improvement for lower_is_better)",
     )
     secondary_metrics: dict[str, float] = Field(default_factory=dict)
-    guardrails_passed: list[str] = Field(default_factory=list)
-    guardrails_failed: list[str] = Field(default_factory=list)
+    guardrails_passed: list[EnforcedGuardrail] = Field(default_factory=list)
+    guardrails_failed: list[EnforcedGuardrail] = Field(default_factory=list)
+    custom_checks_notes: Optional[str] = Field(
+        default=None,
+        description="Operator-facing notes on advisory custom_checks results",
+    )
     outcome: EvaluationOutcome = EvaluationOutcome.INCONCLUSIVE
     evidence_paths: list[str] = Field(
         default_factory=list,
         description="Paths to evaluation evidence artifacts",
+    )
+    evaluation_command_used: Optional[str] = Field(
+        default=None,
+        description="The resolved evaluation_command that produced this score",
     )
     evaluation_notes: Optional[str] = Field(default=None)
 
@@ -249,8 +340,9 @@ class LineageAttempt(BaseModel):
     """
     Complete record of a single refinement attempt.
 
-    One LineageAttempt is appended per execution. Together they form the
-    attempt history that OC and operators can inspect, replay, or audit.
+    One LineageAttempt is appended per execution. Stored in
+    .context/capsules/<lineage_id>/attempt-<n>/ alongside implementation
+    and evaluation artifacts.
     """
     attempt_number: int = Field(ge=1)
     run_id: str = Field(description="OcExecutionRequest.run_id for this attempt")
@@ -259,14 +351,14 @@ class LineageAttempt(BaseModel):
     started_at: datetime
     completed_at: Optional[datetime] = None
 
-    # Artifact references (all path-based; actual content in Warehouse or repo)
+    # Artifact references — all paths relative to target repo root
     implementation_artifact_path: Optional[str] = Field(
         default=None,
-        description="Path to the diff/patch produced by this attempt",
+        description="Diff/patch produced by this attempt",
     )
     evaluation_artifact_path: Optional[str] = Field(
         default=None,
-        description="Path to the evaluation evidence report",
+        description="Evaluation evidence report",
     )
     checkpoint_path: Optional[str] = Field(
         default=None,
@@ -282,13 +374,39 @@ class LineageAttempt(BaseModel):
     decision: Optional[RefinementDecision] = None
     decision_reason: Optional[str] = None
 
-    # Replay metadata — enough to reproduce this attempt deterministically
+    # Replay metadata
     replay_metadata: dict[str, Any] = Field(
         default_factory=dict,
         description=(
-            "Environment snapshot for replay: goal_hash, strategy_hash, "
-            "base_commit_sha, validation_command_hashes, etc."
+            "Environment snapshot for deterministic replay: base_commit_sha, "
+            "goal_text_hash, strategy_principle_hash, validation_command_hashes, "
+            "runtime_binding_kind, runtime_binding_model, evaluation_command_used, "
+            "clp_schema_version, oc_schema_version."
         ),
+    )
+
+
+class OcLineageIndexEntry(BaseModel):
+    """
+    OC run-store index record for a lineage.
+
+    Q3 decision: ImprovementLineage (full history) lives in CLP-native
+    .context/capsules/<lineage_id>/lineage.json. OC keeps this lightweight
+    index entry for fast status queries without loading the full lineage.
+    Warehouse receives the full lineage artifact post-resolution.
+    """
+    lineage_id: str
+    proposal_id: str
+    lineage_artifact_path: str = Field(
+        description="CLP-native path to full ImprovementLineage JSON",
+    )
+    status: RefinementStatus
+    current_attempt_number: int
+    accepted_attempt_number: Optional[int] = None
+    last_updated_at: datetime
+    warehouse_archive_id: Optional[str] = Field(
+        default=None,
+        description="Set by Warehouse after archival; null until resolved",
     )
 
 
@@ -296,14 +414,11 @@ class ImprovementLineage(BaseModel):
     """
     Full history of refinement attempts for this work item.
 
-    Append-only in normal operation. Each attempt produces one LineageAttempt.
-    ``current_attempt_number`` increments after each dispatch.
-    ``accepted_attempt_number`` is set when an attempt reaches ACCEPT decision.
+    Stored at: .context/capsules/<lineage_id>/lineage.json (CLP-native).
+    OC indexes via OcLineageIndexEntry. Warehouse archives post-resolution.
+
+    Append-only in normal operation.
     """
-    current_attempt_number: int = Field(default=0, ge=0)
-    accepted_attempt_number: Optional[int] = Field(default=None)
-    status: RefinementStatus = RefinementStatus.NOT_STARTED
-    attempts: list[LineageAttempt] = Field(default_factory=list)
     lineage_id: str = Field(
         description="Stable identifier for this lineage chain (survives retries)",
     )
@@ -311,6 +426,10 @@ class ImprovementLineage(BaseModel):
         default=None,
         description="If this lineage was forked from another, reference to the parent",
     )
+    status: RefinementStatus = RefinementStatus.NOT_STARTED
+    current_attempt_number: int = Field(default=0, ge=0)
+    accepted_attempt_number: Optional[int] = Field(default=None)
+    attempts: list[LineageAttempt] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -321,57 +440,55 @@ class ContinuousImprovementSpec(BaseModel):
     """
     Continuous improvement metadata for a work item.
 
-    Attach to OcPlanningProposal as::
-
+    Attach to OcPlanningProposal as:
         proposal.continuous_improvement: Optional[ContinuousImprovementSpec]
 
-    Presence of this block opts the work item into the CI lifecycle:
-    evaluation-driven iteration governed by OC, with CLP-backed continuity
-    and full artifact lineage.
+    Presence opts the work item into the CI lifecycle. Absence preserves
+    one-shot behavior with no change to existing proposals.
 
-    Absence of this block preserves one-shot behavior. No behavioral change
-    to existing proposals.
+    Q4: stays OC-internal. Not added to CxRP TaskProposal yet.
+    Q5: no new ExecutionMode. improve_campaign + this block's presence is sufficient.
     """
     strategy: ImprovementStrategy
     evaluation: EvaluationSpec
     refinement: RefinementPolicy = Field(default_factory=RefinementPolicy)
     clp: ClpBinding = Field(default_factory=ClpBinding)
 
-    # Lineage is initially None; populated by OC on first dispatch and
-    # updated after each attempt. Proposals are immutable, so lineage lives
-    # in the mutable execution state, not in the frozen proposal.
-    # This field exists here for schema documentation; in practice lineage
-    # is carried by OcContinuousImprovementState (see below).
-    _lineage_ref: Optional[str] = Field(
-        default=None,
-        description="Path to lineage artifact; populated by OC at dispatch time",
-    )
-
     model_config = {"frozen": True}
 
 
 # ---------------------------------------------------------------------------
-# Mutable execution-side state (separate from the frozen proposal)
+# Mutable execution-side state (separate from frozen proposal)
 # ---------------------------------------------------------------------------
 
 class OcContinuousImprovementState(BaseModel):
     """
-    Mutable continuous improvement execution state.
+    Mutable CI execution state managed by OC.
 
-    While ContinuousImprovementSpec (attached to the immutable proposal)
-    carries the policy, this object carries live execution state: lineage,
-    current attempt count, and OC-managed status.
+    While ContinuousImprovementSpec (frozen on the proposal) carries policy,
+    this object carries live execution state: lineage index, resolved evaluation
+    command, and current CLP artifact paths.
 
-    Stored alongside OcExecutionRequest/OcExecutionResult in the run store.
-    Not frozen — updated after each attempt by OC.
+    Stored in OC run store. Updated after each attempt.
+    Full lineage artifact lives at clp_binding.lineage_artifact_path.
     """
     proposal_id: str
-    lineage: ImprovementLineage
+    lineage_index: OcLineageIndexEntry
     spec_snapshot: ContinuousImprovementSpec = Field(
-        description="Snapshot of the spec at dispatch time (immutable reference)",
+        description="Snapshot of the spec at first dispatch (immutable reference)",
     )
     clp_binding: ClpBinding = Field(
         description="Live CLP artifact paths; updated as new artifacts are written",
+    )
+    resolved_evaluation_command: Optional[str] = Field(
+        default=None,
+        description=(
+            "The evaluation command OC resolved from validation_profile or "
+            "evaluation_command_hint. Stored here so retries use the same command."
+        ),
+    )
+    resolved_evaluation_command_source: Optional[EvaluationCommandSource] = Field(
+        default=None,
     )
     last_updated_at: datetime
     operator_override: Optional[str] = Field(


### PR DESCRIPTION
## Summary

- Updates `design.md` §12 from "open questions" to recorded decisions with rationale
- Updates `draft_schema.py` with `EvaluationCommandSource` enum, closed `EnforcedGuardrail` enum, `OcLineageIndexEntry` type, and updated `EvaluationSpec` / `OcContinuousImprovementState` / `ClpBinding`
- Status header updated to reflect decisions captured

## Decisions

| # | Question | Decision |
|---|----------|----------|
| Q1 | Evaluation command ownership | OC owns derivation; proposer hint is advisory; tracked via `EvaluationCommandSource` |
| Q2 | Guardrail extensibility | Closed `EnforcedGuardrail` enum + advisory `custom_checks: list[str]` |
| Q3 | Lineage storage | CLP-native `.context/capsules/` → `OcLineageIndexEntry` index → Warehouse archive |
| Q4 | CxRP wire extension | OC-internal only; not added to CxRP `TaskProposal` |
| Q5 | ExecutionMode entry | No new mode; `continuous_improvement` block presence is sufficient |

## Test plan

- [ ] `draft_schema.py` imports cleanly (no Pydantic validation errors)
- [ ] Design doc renders correctly
- [ ] No Custodian findings (confirmed clean above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)