### PR TITLE
Wire CiCoordinator into board_worker improve_campaign call-site

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,14 @@
 # Log
 
+## 2026-05-21 — Wire CI coordinator into board_worker call-site
+
+board_worker/main.py: after planning, check bundle.proposal.continuous_improvement.
+If present and execution_mode==improve_campaign, delegate to _run_ci_loop() which
+drives CiCoordinator.run() with a per-attempt subprocess execute callable. Maps
+RefinementStatus to _handle_success/_handle_failure/_fail_task. CI status and
+attempt count added as Plane labels. Single-shot path unchanged when spec absent.
+6 new tests in tests/unit/entrypoints/test_board_worker_ci_wiring.py — all pass.
+
 ## 2026-05-21 — Fix ruff unused imports in ci_coordinator.py / ci_store.py
 
 Removed unused uuid, Callable imports from ci_coordinator.py; removed unused

--- a/src/operations_center/entrypoints/board_worker/main.py
+++ b/src/operations_center/entrypoints/board_worker/main.py
@@ -430,6 +430,28 @@ def _process_issue(issue: dict, role: str, config_path: Path, settings, client) 
         config_file = tmp / "ops.yaml"
         shutil.copy(config_path, config_file)
 
+        # CI branch: when the proposal carries ContinuousImprovementSpec and
+        # the task is an improve_campaign, delegate to the refinement loop.
+        ci_spec_raw = bundle.get("proposal", {}).get("continuous_improvement")
+        if ci_spec_raw and execution_mode == "improve_campaign":
+            return _run_ci_loop(
+                ci_spec_raw=ci_spec_raw,
+                client=client,
+                issue=issue,
+                role=role,
+                task_kind=task_kind,
+                task_id=task_id,
+                repo_key=repo_key,
+                settings=settings,
+                python=python,
+                oc_root=oc_root,
+                env=env,
+                bundle_file=bundle_file,
+                config_file=config_file,
+                tmp=tmp,
+                short_id=short_id,
+            )
+
         workspace = tmp / "workspace"
         workspace.mkdir()
         result_file = tmp / "result.json"
@@ -554,6 +576,156 @@ def _process_issue(issue: dict, role: str, config_path: Path, settings, client) 
 
 
 # ── Outcome handlers ──────────────────────────────────────────────────────────
+
+def _run_ci_loop(
+    *,
+    ci_spec_raw: dict,
+    client,
+    issue: dict,
+    role: str,
+    task_kind: str,
+    task_id: str,
+    repo_key: str,
+    settings,
+    python: str,
+    oc_root: Path,
+    env: dict,
+    bundle_file: Path,
+    config_file: Path,
+    tmp: Path,
+    short_id: str,
+) -> bool:
+    """
+    Drive a ContinuousImprovementSpec refinement loop for an improve_campaign task.
+
+    Builds a CiRunContext, dispatches the CiCoordinator, and maps the
+    final RefinementStatus to _handle_success / _handle_failure.
+    Returns True on ACCEPTED, False otherwise.
+    """
+    from operations_center.contracts.ci import ContinuousImprovementSpec
+    from operations_center.contracts.enums import RefinementStatus
+    from operations_center.execution.ci_coordinator import CiCoordinator, CiRunContext
+    from operations_center.execution.ci_store import CiStore
+    from pydantic import ValidationError
+
+    try:
+        ci_spec = ContinuousImprovementSpec.model_validate(ci_spec_raw)
+    except (ValidationError, Exception) as exc:
+        logger.error(
+            "board_worker[%s]: task_id=%s invalid ContinuousImprovementSpec — %s",
+            role, task_id, exc,
+        )
+        _fail_task(client, task_id, role, f"invalid continuous_improvement spec: {exc}")
+        return False
+
+    repo_path = Path(_repo_local_path(settings, repo_key))
+    lineage_id = f"lin-{task_id[:12]}"
+    validation_commands = list(
+        ci_spec.evaluation.evaluation_command
+        and [] or []
+    )
+    # Prefer validation_commands from the repo config if available
+    repo_cfg = settings.repos.get(repo_key)
+    if repo_cfg and hasattr(repo_cfg, "validation_commands"):
+        validation_commands = list(getattr(repo_cfg, "validation_commands", []))
+
+    store_path = oc_root / "state" / "ci_lineage.json"
+    ctx = CiRunContext(
+        proposal_id=bundle_file.parent.name,  # tmp dir name as ephemeral ID
+        repo_path=repo_path,
+        lineage_id=lineage_id,
+        spec=ci_spec,
+        validation_commands=validation_commands,
+        store_path=store_path,
+        eval_output_dir=tmp / "eval_output",
+        timeout_seconds=120,
+    )
+
+    last_attempt_result: dict = {}
+
+    def execute(*, attempt_number: int, strategy, proposal_id: str):
+        attempt_workspace = tmp / f"workspace-ci-{attempt_number}"
+        attempt_workspace.mkdir(exist_ok=True)
+        attempt_result_file = tmp / f"result-ci-{attempt_number}.json"
+
+        exec_cmd = [
+            python, "-m", "operations_center.entrypoints.execute.main",
+            "--config",         str(config_file),
+            "--bundle",         str(bundle_file),
+            "--workspace-path", str(attempt_workspace),
+            "--task-branch",    f"{role}/{short_id}-ci{attempt_number}",
+            "--output",         str(attempt_result_file),
+            "--source",         f"board_worker_{role}_ci_{attempt_number}",
+        ]
+
+        logger.info(
+            "board_worker[%s]: CI attempt %d for task_id=%s",
+            role, attempt_number, task_id,
+        )
+        subprocess.run(exec_cmd, cwd=oc_root, env=env, capture_output=True, text=True)
+
+        run_id = f"ci-{task_id[:8]}-attempt-{attempt_number}"
+        changed_files: list[str] = []
+        success = False
+
+        if attempt_result_file.exists():
+            try:
+                attempt_outcome = json.loads(attempt_result_file.read_text(encoding="utf-8"))
+                r = attempt_outcome.get("result", {})
+                success = r.get("success", False)
+                run_id = r.get("run_id", run_id)
+                changed_files = [f["path"] for f in r.get("changed_files", []) if "path" in f]
+                last_attempt_result.update(r)
+            except Exception as exc:
+                logger.warning(
+                    "board_worker[%s]: CI attempt %d result parse failed — %s",
+                    role, attempt_number, exc,
+                )
+
+        return run_id, changed_files, success
+
+    try:
+        coordinator = CiCoordinator(store=CiStore(path=store_path))
+        ci_result = coordinator.run(ctx, execute)
+    except Exception as exc:
+        logger.error(
+            "board_worker[%s]: CI coordinator failed task_id=%s — %s",
+            role, task_id, exc,
+        )
+        _fail_task(client, task_id, role, f"CI coordinator error: {exc}")
+        return False
+
+    logger.info(
+        "board_worker[%s]: CI loop done task_id=%s status=%s attempts=%d",
+        role, task_id, ci_result.final_status.value, ci_result.total_attempts,
+    )
+
+    _add_label(client, issue, f"ci-status: {ci_result.final_status.value}")
+    _add_label(client, issue, f"ci-attempts: {ci_result.total_attempts}")
+
+    if ci_result.final_status == RefinementStatus.ACCEPTED:
+        _handle_success(client, issue, role, task_kind, False, settings)
+        return True
+
+    if ci_result.final_status == RefinementStatus.ESCALATED:
+        _fail_task(
+            client, task_id, role,
+            f"CI loop escalated after {ci_result.total_attempts} attempt(s) — "
+            "inconclusive outcome requires operator decision",
+        )
+        return False
+
+    # BUDGET_EXHAUSTED or ABANDONED
+    failure_result = dict(last_attempt_result)
+    failure_result.setdefault("status", ci_result.final_status.value)
+    failure_result.setdefault(
+        "failure_reason",
+        f"CI refinement loop ended with status={ci_result.final_status.value} "
+        f"after {ci_result.total_attempts} attempt(s)",
+    )
+    _handle_failure(client, issue, role, task_kind, failure_result, settings)
+    return False
+
 
 def _fail_task(client, task_id: str, role: str, reason: str) -> None:
     try:

--- a/tests/unit/entrypoints/test_board_worker_ci_wiring.py
+++ b/tests/unit/entrypoints/test_board_worker_ci_wiring.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""
+Tests for the board_worker CI call-site wiring.
+
+Verifies that _run_ci_loop is invoked when the bundle proposal carries
+continuous_improvement, and that the single-shot path is unchanged when
+it does not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from operations_center.contracts.ci import (
+    ContinuousImprovementSpec,
+    EvaluationSpec,
+    ImprovementStrategy,
+    RefinementPolicy,
+    ScoringMetric,
+)
+from operations_center.contracts.enums import EnforcedGuardrail, RefinementStatus
+from operations_center.execution.ci_coordinator import CiRunResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ci_spec_dict() -> dict:
+    spec = ContinuousImprovementSpec(
+        strategy=ImprovementStrategy(
+            principle="Reduce false retry rate",
+            constraints=["fail_closed"],
+        ),
+        evaluation=EvaluationSpec(
+            baseline_description="18% false retry rate",
+            primary_scoring=ScoringMetric(
+                metric="false_retry_rate",
+                direction="lower_is_better",
+                baseline_value=0.18,
+                target_delta=-0.05,
+            ),
+            guardrails=[EnforcedGuardrail.CUSTODIAN_CLEAN],
+        ),
+        refinement=RefinementPolicy(max_attempts=3),
+    )
+    return json.loads(spec.model_dump_json())
+
+
+def _bundle_with_ci() -> dict:
+    return {
+        "proposal": {
+            "proposal_id": "prop-001",
+            "task_id": "task-001",
+            "execution_mode": "improve_campaign",
+            "continuous_improvement": _ci_spec_dict(),
+        },
+        "decision": {},
+    }
+
+
+def _bundle_without_ci() -> dict:
+    return {
+        "proposal": {
+            "proposal_id": "prop-002",
+            "task_id": "task-002",
+            "execution_mode": "improve_campaign",
+        },
+        "decision": {},
+    }
+
+
+def _mock_settings(tmp_path: Path):
+    settings = MagicMock()
+    settings.repos.get.return_value = MagicMock(
+        local_path=str(tmp_path / "repo"),
+        validation_commands=[],
+    )
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# _run_ci_loop unit tests (via module import)
+# ---------------------------------------------------------------------------
+
+class TestRunCiLoop:
+    def _call(self, tmp_path, ci_result, settings=None):
+        from operations_center.entrypoints.board_worker.main import _run_ci_loop
+
+        client = MagicMock()
+        issue = {"id": "task-001", "labels": [{"name": "repo: svc"}]}
+        if settings is None:
+            settings = _mock_settings(tmp_path)
+
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text("{}", encoding="utf-8")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("{}", encoding="utf-8")
+
+        with patch(
+            "operations_center.execution.ci_coordinator.CiCoordinator"
+        ) as MockCoord:
+            coord_instance = MagicMock()
+            coord_instance.run.return_value = ci_result
+            MockCoord.return_value = coord_instance
+
+            result = _run_ci_loop(
+                ci_spec_raw=_ci_spec_dict(),
+                client=client,
+                issue=issue,
+                role="improve",
+                task_kind="improve_campaign",
+                task_id="task-001",
+                repo_key="svc",
+                settings=settings,
+                python="python3",
+                oc_root=tmp_path,
+                env={},
+                bundle_file=bundle_file,
+                config_file=config_file,
+                tmp=tmp_path,
+                short_id="task001",
+            )
+        return result, client
+
+    def test_accepted_returns_true_and_calls_handle_success(self, tmp_path):
+        ci_result = CiRunResult(
+            lineage_id="lin-001",
+            final_status=RefinementStatus.ACCEPTED,
+            accepted_attempt_number=2,
+            total_attempts=2,
+            last_decision=None,
+            last_score=None,
+        )
+        with patch(
+            "operations_center.entrypoints.board_worker.main._handle_success"
+        ) as mock_success:
+            result, client = self._call(tmp_path, ci_result)
+
+        assert result is True
+        mock_success.assert_called_once()
+
+    def test_budget_exhausted_returns_false_and_calls_handle_failure(self, tmp_path):
+        ci_result = CiRunResult(
+            lineage_id="lin-001",
+            final_status=RefinementStatus.BUDGET_EXHAUSTED,
+            accepted_attempt_number=None,
+            total_attempts=3,
+            last_decision=None,
+            last_score=None,
+        )
+        with patch(
+            "operations_center.entrypoints.board_worker.main._handle_failure"
+        ) as mock_failure:
+            result, client = self._call(tmp_path, ci_result)
+
+        assert result is False
+        mock_failure.assert_called_once()
+
+    def test_abandoned_returns_false(self, tmp_path):
+        ci_result = CiRunResult(
+            lineage_id="lin-001",
+            final_status=RefinementStatus.ABANDONED,
+            accepted_attempt_number=None,
+            total_attempts=1,
+            last_decision=None,
+            last_score=None,
+        )
+        with patch("operations_center.entrypoints.board_worker.main._handle_failure"):
+            result, _ = self._call(tmp_path, ci_result)
+        assert result is False
+
+    def test_escalated_returns_false_and_calls_fail_task(self, tmp_path):
+        ci_result = CiRunResult(
+            lineage_id="lin-001",
+            final_status=RefinementStatus.ESCALATED,
+            accepted_attempt_number=None,
+            total_attempts=1,
+            last_decision=None,
+            last_score=None,
+        )
+        with patch(
+            "operations_center.entrypoints.board_worker.main._fail_task"
+        ) as mock_fail:
+            result, _ = self._call(tmp_path, ci_result)
+
+        assert result is False
+        mock_fail.assert_called_once()
+        call_args = mock_fail.call_args[0]
+        assert "escalated" in call_args[3].lower()
+
+    def test_ci_labels_added(self, tmp_path):
+        ci_result = CiRunResult(
+            lineage_id="lin-001",
+            final_status=RefinementStatus.ACCEPTED,
+            accepted_attempt_number=1,
+            total_attempts=1,
+            last_decision=None,
+            last_score=None,
+        )
+        with patch("operations_center.entrypoints.board_worker.main._handle_success"):
+            with patch(
+                "operations_center.entrypoints.board_worker.main._add_label"
+            ) as mock_add_label:
+                result, _ = self._call(tmp_path, ci_result)
+
+        labels_added = [c.args[2] for c in mock_add_label.call_args_list]
+        assert any("ci-status" in lbl for lbl in labels_added)
+        assert any("ci-attempts" in lbl for lbl in labels_added)
+
+    def test_invalid_ci_spec_calls_fail_task(self, tmp_path):
+        from operations_center.entrypoints.board_worker.main import _run_ci_loop
+
+        client = MagicMock()
+        issue = {"id": "task-bad", "labels": []}
+
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text("{}", encoding="utf-8")
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("{}", encoding="utf-8")
+
+        with patch(
+            "operations_center.entrypoints.board_worker.main._fail_task"
+        ) as mock_fail:
+            result = _run_ci_loop(
+                ci_spec_raw={"not": "a valid spec"},
+                client=client,
+                issue=issue,
+                role="improve",
+                task_kind="improve_campaign",
+                task_id="task-bad",
+                repo_key="svc",
+                settings=_mock_settings(tmp_path),
+                python="python3",
+                oc_root=tmp_path,
+                env={},
+                bundle_file=bundle_file,
+                config_file=config_file,
+                tmp=tmp_path,
+                short_id="taskbad",
+            )
+
+        assert result is False
+        mock_fail.assert_called_once()


### PR DESCRIPTION
## Summary

- `board_worker/main.py`: after planning, checks `bundle.proposal.continuous_improvement`
- If present and `execution_mode == improve_campaign`, calls `_run_ci_loop()` instead of the single-shot subprocess path
- `_run_ci_loop()` drives `CiCoordinator.run()` with a per-attempt execute callable that calls the existing `operations_center.entrypoints.execute.main` subprocess
- Maps `RefinementStatus` → `_handle_success` / `_handle_failure` / `_fail_task`
- Adds `ci-status: <value>` and `ci-attempts: <n>` labels to the Plane task
- Single-shot path is completely unchanged when `continuous_improvement` is absent

## Behaviour by final status

| Status | Board outcome |
|--------|--------------|
| `ACCEPTED` | `_handle_success` → Done / In Review |
| `BUDGET_EXHAUSTED` | `_handle_failure` → Blocked |
| `ABANDONED` | `_handle_failure` → Blocked |
| `ESCALATED` | `_fail_task` → Blocked with escalation message |

## Test plan

- [x] 6 new tests in `tests/unit/entrypoints/test_board_worker_ci_wiring.py` — all pass
- [x] 185 existing unit tests unaffected
- [x] Custodian pre-push guard: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)