### PR TITLE
Update ADR-0003 to reference continuous improvement schema

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,13 @@
 # Log
 
+## 2026-05-21 — Update ADR-0003 to reference CI design
+
+Added "Related" section to ADR-0003 documenting the relationship between
+tiered cognition and the continuous improvement schema: trace data compatibility
+(LineageAttempt.replay_metadata feeds cognition_summary), refinement as a
+bounded-cognition amortization strategy, and the explicit non-introduction of
+a CognitionTier enum (consistent with ADR-0003 D1 / ADR-0002 G1).
+
 ## 2026-05-21 — Wire CI coordinator into board_worker call-site
 
 board_worker/main.py: after planning, check bundle.proposal.continuous_improvement.

--- a/docs/architecture/adr/0003-tiered-cognition-experimental-rails.md
+++ b/docs/architecture/adr/0003-tiered-cognition-experimental-rails.md
@@ -260,6 +260,41 @@ Out of scope:
   cross-file reasoning, novel architecture decisions — frontier
   cognition continues to matter for those.
 
+## Related
+
+### Continuous improvement schema (2026-05-21)
+
+The continuous improvement extension (see
+[docs/design/continuous-improvement/design.md](../../design/continuous-improvement/design.md))
+introduces evaluation-driven refinement as a complementary axis to tiered
+cognition. Where tiered cognition asks *which model should run this node?*,
+the CI schema asks *did this execution improve the target metric, and should
+we retry with a variation?*
+
+The two interact in two concrete ways:
+
+**Trace data.** Each CI attempt produces a `LineageAttempt` with a
+`replay_metadata` dict that includes `runtime_binding_model`. This is exactly
+the per-invocation provenance that ADR-0003 D2 targets — it feeds directly into
+`cognition_summary.nodes_by_model` once that telemetry is landed. A CI run with
+`max_attempts=3` across two model tiers gives three comparable data points with
+consistent goal text and evaluation criteria, which is the paired-run evidence
+G4 requires before a routing rule is safe to write.
+
+**Refinement as a bounded-cognition strategy.** CI's `RefinementPolicy` is
+structurally similar to the "plan once, execute many" amortization pattern
+described in the Context section. A single OC evaluation run (strong model)
+sets the `EvaluationSpec` baseline and strategy; each attempt can use a cheaper
+or local model (`ImprovementStrategy.constraints` propagated into the
+WorkerHandoff). The scoring loop provides the feedback signal that lets
+bounded-cognition attempts improve without re-engaging frontier planning for
+every retry.
+
+The CI schema does not introduce a `CognitionTier` enum — consistent with
+ADR-0003 D1 and ADR-0002 G1. Tier selection remains a workflow-level concern;
+the CI spec carries `strategy.constraints` (policy) and the runtime binding
+carries the actual model used (observability).
+
 ## Why this ADR exists at all
 
 The architecture is unusually close to enabling tiered-cognition


### PR DESCRIPTION
## Summary

Adds a **Related** section to ADR-0003 documenting the relationship between tiered cognition and the continuous improvement schema.

Three connection points:

1. **Trace data** — `LineageAttempt.replay_metadata` includes `runtime_binding_model`, feeding directly into `cognition_summary.nodes_by_model` (ADR-0003 D2). A CI run with `max_attempts=3` gives paired data points with consistent evaluation criteria — exactly the evidence G4 requires before a routing rule is safe.

2. **Bounded-cognition amortization** — CI's `RefinementPolicy` mirrors the "plan once, execute many" pattern from ADR-0003 Context. Strong model sets the `EvaluationSpec` baseline once; cheap/local model executes attempts; scoring loop provides feedback.

3. **No `CognitionTier` enum** — explicitly noted, consistent with ADR-0003 D1 and ADR-0002 G1.

## Test plan

- [x] Doc renders correctly
- [x] Custodian pre-push guard: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)