### PR TITLE
add loop-start/stop/status to operations-center.sh

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## 2026-05-21 — Add loop-start/stop/status to operations-center.sh
+
+Added loop_start, loop_stop, loop_status functions and case entries to
+scripts/operations-center.sh. loop-start/stop/status skip the janitor.
+Mirrors existing watchdog-loop-* pattern.
+
 ## 2026-05-21 — Add loop controller (replace /loop + ScheduleWakeup)
 
 tools/loop/controller.py spawns a fresh claude -p session per watchdog cycle.

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -160,6 +160,9 @@ Usage:
   scripts/operations-center.sh watchdog-loop-acquire
   scripts/operations-center.sh watchdog-loop-release
   scripts/operations-center.sh watchdog-loop-status
+  scripts/operations-center.sh loop-start
+  scripts/operations-center.sh loop-stop
+  scripts/operations-center.sh loop-status
 
 Environment:
   OPERATIONS_CENTER_CONFIG   Override config path (default: ${CONFIG_PATH})
@@ -230,6 +233,26 @@ check_watchdog_loop_lock() {
     cat "${WATCHDOG_LOOP_LOCK}"
     return 2
   fi
+}
+
+LOOP_CONTROLLER_LOCK="${LOG_DIR}/loop_controller.lock"
+LOOP_STOP_FLAG="${LOG_DIR}/loop_stop.flag"
+LOOP_LOG="${LOG_DIR}/loop_controller.log"
+
+loop_start() {
+  rm -f "${LOOP_STOP_FLAG}"
+  nohup python3 "${ROOT_DIR}/tools/loop/controller.py" > /dev/null 2>&1 &
+  sleep 1
+  python3 "${ROOT_DIR}/tools/loop/controller.py" --status
+  echo "Log: ${LOOP_LOG}"
+}
+
+loop_stop() {
+  python3 "${ROOT_DIR}/tools/loop/controller.py" --stop
+}
+
+loop_status() {
+  python3 "${ROOT_DIR}/tools/loop/controller.py" --status
 }
 
 watch_pid_file() {
@@ -561,7 +584,7 @@ shift || true
 cd "${ROOT_DIR}"
 # Skip janitor for read-only / stop commands — they're fast and don't need it.
 case "${cmd}" in
-  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|plane-status|providers-status|doctor|status) ;;
+  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|plane-status|providers-status|doctor|status|loop-start|loop-stop|loop-status) ;;
   *) run_janitor ;;
 esac
 
@@ -876,6 +899,15 @@ PYEOF
     ;;
   watchdog-loop-status)
     check_watchdog_loop_lock
+    ;;
+  loop-start)
+    loop_start
+    ;;
+  loop-stop)
+    loop_stop
+    ;;
+  loop-status)
+    loop_status
     ;;
   *)
     usage


### PR DESCRIPTION
## Summary
- Adds `loop-start`, `loop-stop`, `loop-status` subcommands to `scripts/operations-center.sh`
- Wraps `tools/loop/controller.py` (landed in PR #163)
- All three skip the janitor (fast path, same as `watch-all-status` etc.)

## Usage
```bash
scripts/operations-center.sh loop-start   # start controller in background
scripts/operations-center.sh loop-stop    # graceful stop (current session finishes)
scripts/operations-center.sh loop-status  # show lock state + last schedule
```

## Test plan
- [ ] `loop-status` → "No lock file" when controller not running
- [ ] `loop-start` → shows ACTIVE status after 1s delay
- [ ] `loop-stop` → prints stop flag message
- [ ] `loop-start` while already running → shows existing ACTIVE pid (controller handles the lock conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)