### PR TITLE
add --dangerously-skip-permissions to controller session spawn

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,5 +1,11 @@
 # Log
 
+## 2026-05-21 — Add --dangerously-skip-permissions to controller session spawn
+
+claude -p without this flag blocks tool calls that need interactive approval.
+The controller is a deliberate operator action; ContextGuard hooks still run.
+This gives the spawned session the same tool access as an interactive session.
+
 ## 2026-05-21 — Full session prompt with explicit authorization (loop controller)
 
 Replaced thin SESSION_PROMPT pointer with tools/loop/oc_session_prompt.txt —

--- a/tools/loop/controller.py
+++ b/tools/loop/controller.py
@@ -129,7 +129,7 @@ def get_delay() -> int:
 def run_session() -> int:
     """Spawn one bounded claude -p session. Returns exit code."""
     prompt = load_session_prompt()
-    cmd = ["claude", "-p", prompt, "--output-format", "text"]
+    cmd = ["claude", "-p", prompt, "--dangerously-skip-permissions", "--output-format", "text"]
     _log(f"Spawning session (prompt: {SESSION_PROMPT_FILE.name}, {len(prompt)} chars) ...")
     # Source env before spawning so the session inherits OC credentials
     env = os.environ.copy()


### PR DESCRIPTION
Same tool access as an interactive session. Hooks still run. Matches VF controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)