### PR TITLE
feat(loop): anchor OC loop sessions via cl session start

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -11122,3 +11122,7 @@ Cross-cycle repeating patterns:
 ### KNOWN OPEN ISSUES (carry forward)
 - Campaign 10c50210 CANCELLED.
 - HYGIENE: `.baseline-validation.json` tracked on OC main (operationally neutralized by cycle-28 reorder).
+
+## 2026-05-24 — OC loop anchors via cl session start (Phase 4)
+
+- tools/loop/controller.py: _session_env now calls _anchor_via_cl, which runs `cl session start` (RepoGraph resolves OC→PlatformManifest) and merges CL_ANCHOR/CL_SESSION_ID into the loop session env. No-op if unhooked / cl missing (cl_wrap stays a no-op). Matches CLAUDE.md "every session targeting OC must cl session start". Test: tools/loop/test_anchor.py (3).

--- a/tools/loop/controller.py
+++ b/tools/loop/controller.py
@@ -124,8 +124,36 @@ def _command_available(command: str) -> bool:
     return _resolve_command(command) is not None
 
 
+def _anchor_via_cl(env: dict[str, str]) -> None:
+    """Anchor the loop's session at this repo's owning manifest via CL.
+
+    Runs `cl session start` (no arg → RepoGraph resolves cwd→manifest) and merges
+    its exported CL_ANCHOR/CL_SESSION_ID into ``env``. No-op if the repo isn't
+    hooked to a manifest or `cl` is unavailable — the loop then runs unanchored,
+    exactly as before, so cl_wrap stays a no-op.
+    """
+    try:
+        out = subprocess.run(
+            ["cl", "session", "start"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return
+    if out.returncode != 0:
+        return
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("export ") and "=" in line:
+            key, _, val = line[len("export "):].partition("=")
+            env[key.strip()] = val.strip().strip("'\"")
+
+
 def _session_env(backend: str) -> dict[str, str]:
     env = os.environ.copy()
+    _anchor_via_cl(env)
     executable = _resolve_command(backend)
     if executable is None:
         return env

--- a/tools/loop/test_anchor.py
+++ b/tools/loop/test_anchor.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Proprietary
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the loop controller's ContextLifecycle anchoring."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import controller  # noqa: E402
+
+
+class _Result:
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_anchor_merges_cl_exports(monkeypatch):
+    monkeypatch.setattr(
+        controller.subprocess,
+        "run",
+        lambda *a, **k: _Result(0, "export CL_ANCHOR=/x/PlatformManifest\nexport CL_SESSION_ID=sid-1\n"),
+    )
+    env: dict[str, str] = {}
+    controller._anchor_via_cl(env)
+    assert env["CL_ANCHOR"] == "/x/PlatformManifest"
+    assert env["CL_SESSION_ID"] == "sid-1"
+
+
+def test_anchor_noop_when_unhooked(monkeypatch):
+    # cl session start exits non-zero (repo not hooked to a manifest)
+    monkeypatch.setattr(controller.subprocess, "run", lambda *a, **k: _Result(1, ""))
+    env: dict[str, str] = {}
+    controller._anchor_via_cl(env)
+    assert env == {}
+
+
+def test_anchor_noop_when_cl_missing(monkeypatch):
+    def _raise(*a, **k):
+        raise OSError("cl not found")
+
+    monkeypatch.setattr(controller.subprocess, "run", _raise)
+    env: dict[str, str] = {}
+    controller._anchor_via_cl(env)
+    assert env == {}


### PR DESCRIPTION
The loop controller's `_session_env` now anchors at OC's owning manifest (PlatformManifest) via `cl session start`, merging CL_ANCHOR/CL_SESSION_ID into the loop's session env — so loop-launched claude/codex sessions are manifest-anchored like the OperatorConsole panes. No-op when unhooked or cl missing. 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)