### PR TITLE
chore(hooks): hard-require CL_ANCHOR in OC ContextGuard hooks

### DIFF
--- a/.claude/hooks/pre_tool_use.sh
+++ b/.claude/hooks/pre_tool_use.sh
@@ -8,7 +8,13 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# --- Require a manifest anchor: cognition ALWAYS anchors at a manifest, never CWD ---
+# CL_ANCHOR is exported by `cl session start <manifest>` (OC panes + loop do this).
+if [[ -z "${CL_ANCHOR:-}" ]]; then
+  echo '{"decision": "block", "reason": "ContextGuard: CL_ANCHOR is not set. Every session must be anchored at a manifest — run: cl session start <manifest>."}'
+  exit 2
+fi
+REPO_ROOT="${CL_ANCHOR}"
 CONFIG_FILE="${REPO_ROOT}/.context/config.yaml"
 
 # --- Session marker (created on first tool call; stop.sh uses it to detect fresh checkpoints) ---

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -9,7 +9,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# Manifest anchor: skip gracefully when unanchored (enforcement is in pre_tool_use).
+if [[ -z "${CL_ANCHOR:-}" ]]; then
+  echo "ContextGuard: CL_ANCHOR not set — no manifest anchor, skipping stop checks." >&2
+  exit 0
+fi
+REPO_ROOT="${CL_ANCHOR}"
 CONFIG_FILE="${REPO_ROOT}/.context/config.yaml"
 
 # --- Session marker (written by pre_tool_use.sh on first tool call this session) ---

--- a/.console/log.md
+++ b/.console/log.md
@@ -11284,3 +11284,7 @@ Cross-cycle repeating patterns:
 
 **Next**: Stage 1 (Add reverse transition tests), Stage 2 (Implement recovery/improvement insights)
 
+
+## 2026-05-24 — Hook hard-requires CL_ANCHOR (rollout)
+
+- .claude/hooks/{pre_tool_use,stop}.sh: resolve .context under CL_ANCHOR (manifest anchor), no CWD fallback. pre_tool_use blocks if unset; stop skips gracefully. CL_ANCHOR supplied by panes + loop (cl session start).


### PR DESCRIPTION
Resolve .context under CL_ANCHOR (no CWD fallback), matching canonical. Supplied by panes + loop. 🤖 Generated with [Claude Code](https://claude.com/claude-code)