### PR TITLE
feat(loop): session-boundary hydrate/capture for codex/aider

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -11288,3 +11288,7 @@ Cross-cycle repeating patterns:
 ## 2026-05-24 — Hook hard-requires CL_ANCHOR (rollout)
 
 - .claude/hooks/{pre_tool_use,stop}.sh: resolve .context under CL_ANCHOR (manifest anchor), no CWD fallback. pre_tool_use blocks if unset; stop skips gracefully. CL_ANCHOR supplied by panes + loop (cl session start).
+
+## 2026-05-24 — Loop session-boundary hydrate/capture for codex/aider
+
+- tools/loop/controller.py: run_session now wraps non-claude (codex/aider) sessions with `cl context hydrate` (prepends prior context to the prompt) + `cl context capture` (records exit/log), gated on CL_ANCHOR. claude skipped (per-tool hooks handle it). Stable lineage oc-loop. Gated/no-op if unanchored or cl missing. Tests extended.

--- a/tools/loop/controller.py
+++ b/tools/loop/controller.py
@@ -151,6 +151,63 @@ def _anchor_via_cl(env: dict[str, str]) -> None:
             env[key.strip()] = val.strip().strip("'\"")
 
 
+# Stable lineage for this loop's session-boundary cognition (resumes across runs
+# within an anchored session).
+_CL_LINEAGE = "oc-loop"
+
+
+def _cl_session_boundary(backend: str, env: dict[str, str]) -> bool:
+    """True for backends that need session-boundary CL (no per-tool hooks).
+
+    claude runs the ContextGuard hooks per tool call, so it does NOT use the
+    boundary hydrate/capture path. codex (PostToolUse-only, no live PreToolUse)
+    and aider (no hooks) DO. Gated on an active anchor.
+    """
+    return backend != "claude" and bool(env.get("CL_ANCHOR"))
+
+
+def _cl_hydrate(backend: str, env: dict[str, str], iteration: int, prompt: str) -> str:
+    """Prepend prior ContextLifecycle context to the prompt for non-hook backends.
+
+    No-op for claude, when unanchored, or if `cl` is unavailable.
+    """
+    if not _cl_session_boundary(backend, env):
+        return prompt
+    work_item = json.dumps({"loop": "oc", "iteration": iteration, "backend": backend})
+    try:
+        out = subprocess.run(
+            ["cl", "context", "hydrate", "--lineage", _CL_LINEAGE, "--work-item", work_item],
+            cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return prompt
+    if out.returncode != 0 or not out.stdout.strip():
+        return prompt
+    return (
+        "# Prior session context (ContextLifecycle hydrate)\n```json\n"
+        + out.stdout.strip()
+        + "\n```\n\n"
+        + prompt
+    )
+
+
+def _cl_capture(backend: str, env: dict[str, str], iteration: int, exit_code: int, log_path: Path) -> None:
+    """Capture the session result into ContextLifecycle for non-hook backends. No-op otherwise."""
+    if not _cl_session_boundary(backend, env):
+        return
+    result = json.dumps(
+        {"loop": "oc", "iteration": iteration, "backend": backend,
+         "exit_code": exit_code, "log": str(log_path)}
+    )
+    try:
+        subprocess.run(
+            ["cl", "context", "capture", "--lineage", _CL_LINEAGE, "--result", result],
+            cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
 def _session_env(backend: str) -> dict[str, str]:
     env = os.environ.copy()
     _anchor_via_cl(env)
@@ -452,8 +509,9 @@ def get_delay() -> int:
 def run_session(iteration: int, backend: str = "claude") -> tuple[int, Path]:
     """Spawn one bounded agent session. Returns (exit_code, session_log_path)."""
     prompt = load_session_prompt()
-    cmd = _session_command(backend, prompt)
     env = _session_env(backend)
+    prompt = _cl_hydrate(backend, env, iteration, prompt)
+    cmd = _session_command(backend, prompt)
 
     SESSION_LOG_DIR.mkdir(parents=True, exist_ok=True)
     session_log = _session_log_path(iteration, backend)
@@ -488,8 +546,10 @@ def run_session(iteration: int, backend: str = "claude") -> tuple[int, Path]:
                 f"killed (likely hung subprocess, e.g. self-referential pgrep loop). "
                 f"Log: {session_log.name}"
             )
+            _cl_capture(backend, env, iteration, -1, session_log)
             return -1, session_log
 
+    _cl_capture(backend, env, iteration, proc.returncode, session_log)
     return proc.returncode, session_log
 
 

--- a/tools/loop/test_anchor.py
+++ b/tools/loop/test_anchor.py
@@ -45,3 +45,30 @@ def test_anchor_noop_when_cl_missing(monkeypatch):
     env: dict[str, str] = {}
     controller._anchor_via_cl(env)
     assert env == {}
+
+
+# --- session-boundary hydrate/capture (codex/aider; claude uses hooks) ---
+
+def test_session_boundary_gating():
+    assert controller._cl_session_boundary("claude", {"CL_ANCHOR": "/m"}) is False
+    assert controller._cl_session_boundary("codex", {"CL_ANCHOR": "/m"}) is True
+    assert controller._cl_session_boundary("codex", {}) is False
+
+
+def test_hydrate_prepends_for_codex(monkeypatch):
+    monkeypatch.setattr(controller.subprocess, "run", lambda *a, **k: _Result(0, '{"capsule": {}}'))
+    out = controller._cl_hydrate("codex", {"CL_ANCHOR": "/m"}, 1, "BASE")
+    assert "ContextLifecycle hydrate" in out and out.endswith("BASE")
+
+
+def test_hydrate_noop_for_claude():
+    assert controller._cl_hydrate("claude", {"CL_ANCHOR": "/m"}, 1, "BASE") == "BASE"
+
+
+def test_capture_runs_for_codex_only(monkeypatch):
+    calls = []
+    monkeypatch.setattr(controller.subprocess, "run", lambda *a, **k: calls.append(a[0]) or _Result(0, ""))
+    import pathlib
+    controller._cl_capture("codex", {"CL_ANCHOR": "/m"}, 1, 0, pathlib.Path("/x.log"))
+    controller._cl_capture("claude", {"CL_ANCHOR": "/m"}, 1, 0, pathlib.Path("/x.log"))
+    assert len(calls) == 1 and "capture" in calls[0]


### PR DESCRIPTION
The OC loop now wraps non-claude backends (codex/aider — no per-tool hooks) with `cl context hydrate` (prepend prior cognition to the prompt) + `cl context capture` (record result), gated on CL_ANCHOR. claude is skipped (its ContextGuard hooks do this per tool). No-op when unanchored or cl unavailable. 7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)