### PR TITLE
fix: check run dedup + review watcher no-verdict escalation

### DIFF
--- a/src/operations_center/adapters/github_pr.py
+++ b/src/operations_center/adapters/github_pr.py
@@ -214,8 +214,17 @@ class GitHubPRClient:
         except Exception:
             return []
         ignored = [s.lower() for s in (ignored_checks or [])]
-        failed = []
+        # Deduplicate by name: when multiple runs exist for the same check (e.g.
+        # after a force-push triggers two CI runs on the same HEAD SHA), keep only
+        # the most recent run per name so a stale failure doesn't block a PR that
+        # has since been fixed. GitHub IDs are monotonically increasing.
+        latest: dict[str, dict] = {}
         for cr in check_runs:
+            name = cr.get("name", "unknown")
+            if cr.get("id", 0) > latest.get(name, {}).get("id", 0):
+                latest[name] = cr
+        failed = []
+        for cr in latest.values():
             if cr.get("conclusion") in ("failure", "timed_out", "cancelled"):
                 name = cr.get("name", "unknown")
                 if ignored and any(pat in name.lower() for pat in ignored):

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -407,7 +407,52 @@ def _phase1(
     state["self_review_loops"] += 1
 
     if verdict is None:
-        logger.warning("pr_review_watcher: no verdict PR #%d — will retry next poll", pr_number)
+        if state["self_review_loops"] >= reviewer.max_self_review_loops:
+            state["phase"]             = "human_review"
+            state["phase2_entered_at"] = datetime.now(UTC).isoformat()
+            escalation_body = (
+                f"{reviewer.bot_comment_marker}\n"
+                f"**Escalated to human review** — review pipeline produced no verdict "
+                f"after {state['self_review_loops']} attempt(s).\n\n"
+                "Reply `/lgtm` or add a 👍 reaction to approve and merge.\n"
+                "Leave a comment to request specific changes."
+            )
+            try:
+                gh_client.post_comment(owner, repo, pr_number, escalation_body)
+            except Exception as exc:
+                logger.warning(
+                    "pr_review_watcher: failed to post no-verdict escalation comment PR #%d — %s",
+                    pr_number, exc,
+                )
+            plane_task_id = state.get("task_id")
+            if plane_task_id:
+                try:
+                    from operations_center.adapters.plane import PlaneClient
+                    pc = PlaneClient(
+                        base_url=settings.plane.base_url,
+                        api_token=settings.plane_token(),
+                        workspace_slug=settings.plane.workspace_slug,
+                        project_id=settings.plane.project_id,
+                    )
+                    try:
+                        issue = pc.fetch_issue(plane_task_id)
+                        existing = [
+                            (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
+                            for lab in issue.get("labels", [])
+                        ]
+                        existing = [n for n in existing if n]
+                        if "lifecycle: escalated" not in existing:
+                            pc.update_issue_labels(plane_task_id, existing + ["lifecycle: escalated"])
+                    finally:
+                        pc.close()
+                except Exception as exc:
+                    logger.warning("pr_review_watcher: failed to label Plane task escalated — %s", exc)
+            logger.info(
+                "pr_review_watcher: PR #%d no-verdict escalated to human review loop=%d",
+                pr_number, state["self_review_loops"],
+            )
+        else:
+            logger.warning("pr_review_watcher: no verdict PR #%d — will retry next poll", pr_number)
         _save_state(state_path, state)
         return
 

--- a/tests/spec_author/test_spec_trigger.py
+++ b/tests/spec_author/test_spec_trigger.py
@@ -4,8 +4,6 @@
 """Unit tests for spec_trigger queue_drain suppression logic."""
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/entrypoints/test_board_worker_desc_text.py
+++ b/tests/unit/entrypoints/test_board_worker_desc_text.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from operations_center.entrypoints.board_worker.main import _desc_text, _extract_goal
 

--- a/tests/unit/entrypoints/test_github_pr_diff_redirect.py
+++ b/tests/unit/entrypoints/test_github_pr_diff_redirect.py
@@ -8,7 +8,6 @@ response body, causing the review watcher to skip all PRs ("empty diff").
 """
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from operations_center.adapters.github_pr import GitHubPRClient
 


### PR DESCRIPTION
## Summary

- **fix(github-pr):** deduplicate check runs by name in `get_failed_checks()` — keeps only the highest GitHub run ID (most recent) per check name. Prevents force-push CI re-runs from leaving stale failures that block auto-merge.
- **fix(review-watcher):** escalate no-verdict loops at `max_self_review_loops`. The `verdict is None` path was returning early before the gate check, creating an infinite retry loop. PR #186 reached loop=64 without escalating. Now both the CONCERNS and None paths share the same escalation gate.

## Context

These commits were cherry-picked from `oc-watchdog/20260529-1635-fix-check-run-dedup` which diverged from main when the testing branch was merged. Both fixes were validated in prior cycles (15/15 golden tests + targeted tests).

## Test plan

- [x] 15/15 `er000_phase0_golden` tests pass
- [x] 48/48 `pr_review` tests pass
- [x] 3/3 `github_pr`-targeted tests pass
- [x] Custodian: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)