### PR TITLE
fix(watch,review): role guard for start_watch_role + 406 diff-too-large fallback

### DIFF
--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -286,6 +286,11 @@ start_watch_role() {
     propose) poll_interval="${OPERATIONS_CENTER_WATCH_INTERVAL_PROPOSE_SECONDS:-${OPERATIONS_CENTER_PROPOSE_POLL_SECONDS:-120}}" ;;
     review) poll_interval="${OPERATIONS_CENTER_WATCH_INTERVAL_REVIEW_SECONDS:-60}" ;;
     spec) poll_interval="${OPERATIONS_CENTER_WATCH_INTERVAL_SPEC_SECONDS:-120}" ;;
+    intake) ;; # handled separately below
+    *)
+      echo "start_watch_role: unknown role '${role}' (valid: goal, test, improve, propose, review, spec, intake)" >&2
+      return 1
+      ;;
   esac
   local pid_file
   pid_file="$(watch_pid_file "${role}")"

--- a/src/operations_center/adapters/github_pr.py
+++ b/src/operations_center/adapters/github_pr.py
@@ -280,7 +280,9 @@ class GitHubPRClient:
         """Return the unified diff for a pull request as a string.
 
         Uses the GitHub ``diff`` media type on the pulls endpoint.
-        Returns an empty string on any error.
+        On 406 (diff too large for the API), falls back to a file-list
+        summary so the review watcher can still process the PR.
+        Returns an empty string only when both methods fail.
         """
         try:
             diff_headers = dict(self._headers)
@@ -291,8 +293,35 @@ class GitHubPRClient:
                 timeout=30,
                 follow_redirects=True,
             )
+            if resp.status_code == 406:
+                return self._pr_diff_too_large_summary(owner, repo, pr_number)
             resp.raise_for_status()
             return resp.text
+        except Exception:
+            return ""
+
+    def _pr_diff_too_large_summary(self, owner: str, repo: str, pr_number: int) -> str:
+        """Return a file-list summary when the full diff exceeds GitHub's API limit."""
+        try:
+            resp = self._request(
+                "GET",
+                f"{self._API}/repos/{owner}/{repo}/pulls/{pr_number}/files",
+                params={"per_page": 100},
+            )
+            resp.raise_for_status()
+            files = resp.json()
+            lines = [
+                f"[DIFF_TOO_LARGE — showing {len(files)} changed files only]\n"
+            ]
+            for f in files:
+                if not isinstance(f, dict):
+                    continue
+                status = f.get("status", "modified")
+                path = f.get("filename", "")
+                adds = f.get("additions", 0)
+                dels = f.get("deletions", 0)
+                lines.append(f"{status:8s} {path} (+{adds}/-{dels})")
+            return "\n".join(lines)
         except Exception:
             return ""
 

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -658,6 +658,11 @@ def _phase1(
     if not diff:
         logger.warning("pr_review_watcher: empty diff PR #%d, skipping", pr_number)
         return
+    if diff.startswith("[DIFF_TOO_LARGE"):
+        logger.warning(
+            "pr_review_watcher: PR #%d diff exceeds GitHub API limit — reviewing file list only",
+            pr_number,
+        )
 
     diff_excerpt = diff[:8000] + ("\n...[diff truncated]" if len(diff) > 8000 else "")
     title = pr_data.get("title", "")


### PR DESCRIPTION
## Summary

Two clean fixes cherry-picked onto main (649cf31e), rebased from oc-watchdog/20260601-2155-fix-watch-role-guard:

- **fix(watch): reject unknown roles in `start_watch_role` to prevent crash loops** — `scripts/operations-center.sh`: adds validation guard; unknown roles now emit diagnostic and return 1 instead of restarting every 30s. Root cause: `watch-all` invoked with role="all", ran crash loop 5+ hours (333+ restart cycles).
- **fix(review): handle HTTP 406 diff-too-large in `get_pr_diff`** — `github_pr.py`: falls back to `_pr_diff_too_large_summary()` using files API when GitHub returns 406. `pr_review_watcher/main.py`: adds distinct WARNING log for oversized diffs to prevent "empty diff" misclassification.

## Custodian

0 findings (confirmed by pre-push hook).

## Test plan

- [ ] `tests/unit/er000_phase0_golden/`: 15/15 passed
- [ ] `scripts/operations-center.sh watch-all-status`: no role="all" crash loop
- [ ] Review watcher correctly logs DIFF_TOO_LARGE for oversized PRs (no "skipping empty diff" for #216+ sized PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)