### PR TITLE
feat(execution): probe-and-clear stale worker-backend cooldowns

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,45 @@
+## 2026-06-02 — Probe-and-clear for stale worker-backend cooldowns
+
+Worker-backend cooldowns carry an *estimated* `reset_at` and were never retracted
+on their own — only expiring when `reset_at` passed. When a limit lifted early
+(e.g. sonnet recovered before its guessed weekly reset), the cooldown lingered:
+status surfaces showed the model cooling, and when every model looked cooling the
+board_unblock gate deferred dispatch for no reason.
+
+Added a probe-and-clear path:
+- `UsageStore.clear_worker_backend_cooldown(worker_backend, model, ..., include_account_wide)`
+  retracts a model's active `model_weekly` cooldown (and, on request, account-wide
+  cooldowns — one model running disproves an all-models block); appends a
+  `worker_backend_cooldown_cleared` audit event.
+- `backends/worker_backend_probe.py` — `probe_model` runs a cheap `claude -p`/`codex
+  exec` against a model (mirrors the controller's invocation); `ok` only on exit 0
+  with no limit signal. `refresh_cooldowns` probes each *cooling* model and clears
+  the ones proven runnable. Probes never record cooldowns — a flaky probe can only
+  fail to clear, never falsely block.
+- New entrypoint `operations-center-worker-backend-probe` + `worker-backend-probe`
+  subcommand (safe to run on a schedule / cron).
+- Wired as a self-heal into `board_unblock._dispatch_cooldown_reason`: when every
+  allowed backend looks cooling, probe + re-read before deferring — turning a
+  would-be stale-cooldown deadlock into a self-heal. Injected for offline tests.
+
+Plus three hardening fixes:
+- Periodic self-heal: the watchdog hourly loop now runs `worker-backend-probe`
+  (--timeout 30) so stale cooldowns clear even when the board is idle (no-op when
+  nothing is cooling).
+- `record_worker_backend_cooldown` coalesces duplicates — drops any still-active
+  cooldown for the same (worker_backend, limit_kind, model) before appending, so
+  re-recording the same limit each cycle no longer piles up identical events
+  (observed: 12 identical sonnet rows).
+- The board_unblock gate bounds its probe to `_GATE_PROBE_TIMEOUT_SECONDS` (20s)
+  so a hung probe can't stall a board cycle; the standalone CLI/cron keeps the
+  90s default.
+
+Tests: clear primitive (per-model / account-wide / no-op), dedup-on-record,
+probe module (fake runner: ok/limit-signal/nonzero/timeout; refresh clears only
+runnable models; account-wide cleared on first success; no-op when nothing
+cooling), CLI smoke, and the board_unblock self-heal. Verified end-to-end against
+the live claude CLI.
+
 ## 2026-06-01 — Stage 4 FINAL: Documentation and Deployment Complete
 
 **Status**: ✅ **COMPLETE** — Coverage gating mechanism fully documented and committed to main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ operations-center-run-memory        = "operations_center.run_memory.cli:app"
 # from execution_trace.json alone. Hardening arc item 3.
 operations-center-run-show          = "operations_center.entrypoints.run_show.main:main"
 operations-center-worker-backend-status = "operations_center.entrypoints.worker_backend_status.main:main"
+operations-center-worker-backend-probe = "operations_center.entrypoints.worker_backend_probe.main:main"
 # ADR 0007 Phase A — spec_hygiene watcher. Non-LLM hygiene + active.json
 # projection rebuild extracted from spec_director. Single writer of
 # state/campaigns/active.json.

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -158,6 +158,7 @@ Usage:
   scripts/operations-center.sh tune-autonomy [--window N] [--apply]
   scripts/operations-center.sh promote-backlog [--family FAMILY] [--execute]
   scripts/operations-center.sh worker-backend-status [--json]
+  scripts/operations-center.sh worker-backend-probe [--json] [--timeout N]
   scripts/operations-center.sh watchdog-loop-acquire
   scripts/operations-center.sh watchdog-loop-release
   scripts/operations-center.sh watchdog-loop-status
@@ -513,6 +514,10 @@ start_watchdog() {
       printf '{\"role\":\"watchdog\",\"at\":\"%s\",\"status\":\"idle\"}\n' \
         \$(date -u +%Y-%m-%dT%H:%M:%S+00:00) \
         > '${WATCH_DIR}/heartbeat_watchdog.json'
+      # Periodic probe-and-clear (~hourly): retract worker-backend cooldowns whose
+      # limit lifted before the estimated reset, so status surfaces self-heal even
+      # when the board is idle. No-op when nothing is cooling.
+      '${ROOT_DIR}/scripts/operations-center.sh' worker-backend-probe --timeout 30 >/dev/null 2>&1 || true
       _slept=0
       while [[ \$_slept -lt 3600 && -f '${pid_file}' ]]; do
         sleep 300
@@ -618,7 +623,7 @@ shift || true
 cd "${ROOT_DIR}"
 # Skip janitor for read-only / stop commands — they're fast and don't need it.
 case "${cmd}" in
-  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|plane-status|providers-status|doctor|status|worker-backend-status|loop-start|loop-stop|loop-status|loop-log) ;;
+  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|plane-status|providers-status|doctor|status|worker-backend-status|worker-backend-probe|loop-start|loop-stop|loop-status|loop-log) ;;
   *) run_janitor ;;
 esac
 
@@ -901,6 +906,11 @@ PYEOF
     ensure_venv
     load_env_file
     "${VENV_DIR}/bin/python" -m operations_center.entrypoints.worker_backend_status.main "$@"
+    ;;
+  worker-backend-probe)
+    ensure_venv
+    load_env_file
+    "${VENV_DIR}/bin/python" -m operations_center.entrypoints.worker_backend_probe.main "$@"
     ;;
   plane-doctor)
     ensure_venv

--- a/src/operations_center/backends/worker_backend_probe.py
+++ b/src/operations_center/backends/worker_backend_probe.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Probe live worker-backend models and retract stale cooldowns.
+
+A worker-backend cooldown (see :mod:`operations_center.backends.limit_classifier`)
+is recorded with an *estimated* ``reset_at`` parsed from a CLI limit message, and
+is never retracted on its own — it only expires when ``reset_at`` passes. When the
+underlying limit lifts *earlier* than the estimate (a model recovers, a weekly
+window rolls over sooner than guessed), the cooldown lingers: status surfaces show
+the model as cooling and, when every model looks cooling, dispatch is deferred for
+no reason.
+
+This module closes that gap by *probing* — running a trivial, cheap request against
+each cooling model's real CLI. A success proves the model is runnable again, so the
+matching cooldown is cleared via
+:meth:`UsageStore.clear_worker_backend_cooldown`. Probes never *record* cooldowns:
+a probe failure is treated as "still limited / unknown" and left untouched, so a
+flaky probe can only ever fail to clear, never falsely block.
+
+The probe command mirrors the controller's session invocation
+(``tools/loop/controller.py``) so it exercises the same binary and flags the
+executor would use.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Callable
+
+from operations_center.backends.limit_classifier import (
+    MODEL_WEEKLY,
+    WORKER_BACKEND_MODELS,
+    classify_limit,
+)
+
+# A cheap prompt: one token of output, no tools, no side effects.
+PROBE_PROMPT = "Reply with exactly: ok"
+DEFAULT_PROBE_TIMEOUT_SECONDS = 90
+
+# claude model aliases accepted by the CLI's --model flag.
+_CLAUDE_MODEL_ALIASES = {"sonnet", "opus", "haiku"}
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of probing one (worker_backend, model)."""
+
+    worker_backend: str
+    model: str
+    ok: bool
+    detail: str
+
+
+def _resolve(command: str) -> str | None:
+    """Resolve a CLI binary, mirroring the controller's PATH fallbacks."""
+    resolved = shutil.which(command)
+    if resolved:
+        return resolved
+    home = Path.home()
+    candidates = [home / ".local" / "bin" / command, home / "bin" / command]
+    if command == "codex":
+        candidates.extend(sorted((home / ".nvm" / "versions" / "node").glob("*/bin/codex")))
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def _probe_command(worker_backend: str, model: str) -> list[str] | None:
+    """Build the probe command for a (worker_backend, model), or None if unsupported."""
+    if worker_backend == "claude_code":
+        if model not in _CLAUDE_MODEL_ALIASES:
+            return None
+        executable = _resolve("claude")
+        if executable is None:
+            return None
+        return [
+            executable,
+            "-p",
+            PROBE_PROMPT,
+            "--model",
+            model,
+            "--dangerously-skip-permissions",
+            "--output-format",
+            "text",
+        ]
+    if worker_backend == "codex_cli":
+        executable = _resolve("codex")
+        if executable is None:
+            return None
+        return [
+            executable,
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            PROBE_PROMPT,
+        ]
+    return None
+
+
+def probe_model(
+    worker_backend: str,
+    model: str,
+    *,
+    timeout: int = DEFAULT_PROBE_TIMEOUT_SECONDS,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> ProbeResult:
+    """Run a live probe; ``ok`` only when the model clearly answered without a limit.
+
+    ``ok`` requires exit code 0 *and* no limit signal in the combined output —
+    some CLIs print a rate-limit notice and still exit 0. A missing binary,
+    timeout, or any error yields ``ok=False`` (never clears a cooldown).
+    """
+    command = _probe_command(worker_backend, model)
+    if command is None:
+        return ProbeResult(worker_backend, model, False, "cli unavailable or unsupported model")
+    try:
+        proc = runner(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return ProbeResult(worker_backend, model, False, f"probe timed out after {timeout}s")
+    except (OSError, subprocess.SubprocessError) as exc:
+        return ProbeResult(worker_backend, model, False, f"probe error: {exc}")
+    combined = f"{proc.stdout or ''}\n{proc.stderr or ''}"
+    limit_kind, _ = classify_limit(combined)
+    if proc.returncode != 0:
+        return ProbeResult(worker_backend, model, False, f"exit {proc.returncode}")
+    if limit_kind is not None:
+        return ProbeResult(worker_backend, model, False, f"limit signal ({limit_kind})")
+    return ProbeResult(worker_backend, model, True, "runnable")
+
+
+def _models_to_probe(
+    details: list[dict[str, object]], worker_backend: str
+) -> tuple[set[str], bool]:
+    """From a backend's cooldown detail list, return (models_to_probe, account_wide_active)."""
+    account_wide = False
+    per_model: set[str] = set()
+    for cd in details:
+        if cd.get("limit_kind") == MODEL_WEEKLY and cd.get("model"):
+            per_model.add(str(cd["model"]))
+        else:
+            account_wide = True
+    if account_wide:
+        # An account-wide cooldown blocks every model; probe them all so we learn
+        # which to mark runnable once the account-wide block is disproven.
+        per_model.update(WORKER_BACKEND_MODELS.get(worker_backend, ()))
+    return per_model, account_wide
+
+
+def refresh_cooldowns(
+    usage_store,
+    *,
+    now: datetime | None = None,
+    backends: tuple[str, ...] = ("claude_code", "codex_cli"),
+    probe: Callable[..., ProbeResult] | None = None,
+    timeout: int = DEFAULT_PROBE_TIMEOUT_SECONDS,
+    logger: Callable[[str], None] | None = None,
+) -> dict[str, dict[str, bool]]:
+    """Probe each cooling model and clear cooldowns proven stale. Returns a report.
+
+    Only models with an *active* cooldown are probed (no cost when nothing is
+    cooling). For each backend, a successful probe clears that model's
+    ``model_weekly`` cooldown; the first success also clears any account-wide
+    cooldown for the backend (one model running disproves an all-models block).
+    """
+    current = now or datetime.now(UTC)
+    # Resolve the probe by module-global name at call time so callers (and tests)
+    # can monkeypatch ``probe_model`` without rebinding a default argument.
+    probe = probe or probe_model
+    report: dict[str, dict[str, bool]] = {}
+    try:
+        snapshot = usage_store.current_worker_backend_cooldowns(now=current)
+    except Exception:
+        return report
+    for backend in backends:
+        status = snapshot.get(backend, {})
+        details = status.get("cooldowns") or []
+        if not status.get("cooling_down") and not details:
+            continue
+        models, account_wide = _models_to_probe(details, backend)
+        if not models:
+            continue
+        backend_report: dict[str, bool] = {}
+        for model in sorted(models):
+            result = probe(backend, model, timeout=timeout)
+            backend_report[model] = result.ok
+            if result.ok:
+                removed = usage_store.clear_worker_backend_cooldown(
+                    worker_backend=backend,
+                    model=model,
+                    now=current,
+                    include_account_wide=account_wide,
+                )
+                if logger is not None:
+                    logger(
+                        f"probe: {backend}/{model} runnable — cleared {removed} stale "
+                        f"cooldown event(s)"
+                    )
+                # Account-wide cleared on first success; later models only clear
+                # their own per-model entry.
+                account_wide = False
+            elif logger is not None:
+                logger(f"probe: {backend}/{model} still limited ({result.detail})")
+        report[backend] = backend_report
+    return report

--- a/src/operations_center/entrypoints/maintenance/board_unblock.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock.py
@@ -105,7 +105,7 @@ import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from operations_center.adapters.plane import PlaneClient
 from operations_center.config import load_settings
@@ -155,7 +155,16 @@ def _allowed_worker_backends() -> set[str]:
     return backends or {"claude_code"}
 
 
-def _dispatch_cooldown_reason(usage_store: UsageStore, *, now: datetime) -> str | None:
+# Gate-path probe timeout: bounded so a hung probe can't stall a board cycle.
+_GATE_PROBE_TIMEOUT_SECONDS = 20
+
+
+def _dispatch_cooldown_reason(
+    usage_store: UsageStore,
+    *,
+    now: datetime,
+    refresh: Callable[..., object] | None = None,
+) -> str | None:
     """Return a skip reason when every *allowed* worker backend is cooling down.
 
     When the only worker backend(s) the executor may use are all in a known
@@ -166,6 +175,13 @@ def _dispatch_cooldown_reason(usage_store: UsageStore, *, now: datetime) -> str 
     churns the board across cycles.  Returning a reason here lets the promotion
     rules defer until the cooldown resets, at which point the board self-heals.
 
+    Cooldowns carry an *estimated* reset that is never retracted on its own, so a
+    backend can read as cooling long after its limit actually lifted.  Before
+    deferring, if every allowed backend looks cooling, ``refresh`` (when supplied)
+    probes the live backends and clears any cooldown a probe proves stale — turning
+    a would-be deadlock into a self-heal.  ``refresh`` is injected so tests stay
+    offline; ``main`` wires the real probe.
+
     Returns ``None`` (no gating) when at least one allowed backend is free, or on
     any error reading cooldown state — board-unblock must never harden into a
     deadlock because the usage store was momentarily unreadable.
@@ -175,6 +191,16 @@ def _dispatch_cooldown_reason(usage_store: UsageStore, *, now: datetime) -> str 
         snapshot = usage_store.current_worker_backend_cooldowns(now=now)
     except Exception:
         return None
+    if (
+        refresh is not None
+        and allowed
+        and all(snapshot.get(b, {}).get("cooling_down") for b in allowed)
+    ):
+        try:
+            refresh(usage_store, now=now)
+            snapshot = usage_store.current_worker_backend_cooldowns(now=now)
+        except Exception:
+            pass
     cooling: list[str] = []
     for backend in sorted(allowed):
         status = snapshot.get(backend, {})
@@ -672,7 +698,18 @@ def main() -> int:
 
     now = datetime.now(UTC)
     try:
-        cooldown_skip_reason = _dispatch_cooldown_reason(UsageStore(), now=now)
+        from operations_center.backends.worker_backend_probe import refresh_cooldowns
+
+        # Bound the gate-path probe: a successful probe returns in seconds, but a
+        # hung one must not stall the board cycle. Tighter than the standalone
+        # CLI/cron default.
+        cooldown_skip_reason = _dispatch_cooldown_reason(
+            UsageStore(),
+            now=now,
+            refresh=lambda store, *, now: refresh_cooldowns(
+                store, now=now, timeout=_GATE_PROBE_TIMEOUT_SECONDS
+            ),
+        )
     except Exception:
         cooldown_skip_reason = None
     actions = _apply_rules(

--- a/src/operations_center/entrypoints/worker_backend_probe/__init__.py
+++ b/src/operations_center/entrypoints/worker_backend_probe/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/src/operations_center/entrypoints/worker_backend_probe/main.py
+++ b/src/operations_center/entrypoints/worker_backend_probe/main.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""CLI entry point: ``operations-center-worker-backend-probe``.
+
+Probe each cooling worker-backend model and retract cooldowns that a live probe
+proves stale (the limit lifted before its estimated reset). Safe to run on a
+schedule — it does nothing when no backend is cooling, and a probe can only ever
+clear a cooldown, never record one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from operations_center.backends.worker_backend_probe import (
+    DEFAULT_PROBE_TIMEOUT_SECONDS,
+    refresh_cooldowns,
+)
+from operations_center.execution.usage_store import UsageStore
+
+app = typer.Typer(
+    help="Probe cooling worker-backend models and clear stale cooldowns.",
+    add_completion=False,
+)
+
+_console = Console()
+
+
+@app.command()
+def _command(
+    usage_path: Path | None = typer.Option(
+        None,
+        "--usage-path",
+        help="Override the execution usage store path.",
+    ),
+    timeout: int = typer.Option(
+        DEFAULT_PROBE_TIMEOUT_SECONDS,
+        "--timeout",
+        help="Per-probe timeout in seconds.",
+    ),
+    as_json: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the probe report as JSON.",
+    ),
+) -> None:
+    now = datetime.now(UTC)
+    store = UsageStore(path=usage_path) if usage_path is not None else UsageStore()
+    report = refresh_cooldowns(
+        store,
+        now=now,
+        timeout=timeout,
+        logger=None if as_json else (lambda msg: _console.print(f"  {msg}")),
+    )
+    if as_json:
+        typer.echo(
+            json.dumps(
+                {"observed_at": now.isoformat(), "report": report, "usage_path": str(store.path)},
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=False,
+            )
+        )
+        return
+    if not report:
+        _console.print("[dim]No worker backends cooling — nothing to probe.[/dim]")
+        return
+    cleared = sum(1 for b in report.values() for ok in b.values() if ok)
+    _console.print(
+        f"[bold]Probe complete[/bold] — {cleared} model(s) confirmed runnable and cleared."
+    )
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    app()

--- a/src/operations_center/execution/usage_store.py
+++ b/src/operations_center/execution/usage_store.py
@@ -461,6 +461,20 @@ class UsageStore:
         """
         with self._exclusive():
             data = self.load()
+            # Coalesce: drop any still-active cooldown for the same
+            # (worker_backend, limit_kind, model) so re-recording the same limit
+            # each cycle doesn't pile up duplicate events (observed: 12 identical
+            # sonnet rows). The newest record supersedes — latest estimate wins.
+            events = [
+                ev
+                for ev in data.get("events", [])
+                if not (
+                    self._is_active_cooldown_for(ev, worker_backend, now=now)
+                    and ev.get("limit_kind") == limit_kind
+                    and ev.get("model") == model
+                )
+            ]
+            data["events"] = events
             event = {
                 "kind": "worker_backend_cooldown",
                 "worker_backend": worker_backend,
@@ -633,6 +647,91 @@ class UsageStore:
                 "cooldowns": self.worker_backend_cooldown_details(worker_backend, now=now),
             }
         return snapshot
+
+    def clear_worker_backend_cooldown(
+        self,
+        *,
+        worker_backend: str,
+        model: str | None,
+        now: datetime,
+        include_account_wide: bool = True,
+        reason: str = "probe",
+    ) -> int:
+        """Retract active worker-backend cooldowns proven stale (e.g. by a probe).
+
+        A recorded cooldown carries an *estimated* ``reset_at`` and is otherwise
+        never retracted, so a model that recovers before its estimate keeps
+        reading as cooling — misleading the status surfaces and, when every model
+        looks cooling, falsely deferring dispatch. When a live probe confirms
+        ``model`` is runnable again, drop its active (future) cooldown events:
+
+          * the ``model_weekly`` cooldown for ``model`` (if any); and
+          * when ``include_account_wide`` — every account-wide cooldown for the
+            backend (``session_5h`` / ``global_weekly`` / unattributed), since a
+            single model running disproves a block that was meant to stop all.
+
+        Other models' ``model_weekly`` cooldowns are preserved. Returns the count
+        of removed events and appends a ``worker_backend_cooldown_cleared`` audit
+        event recording what was retracted and why.
+        """
+        with self._exclusive():
+            data = self.load()
+            events = list(data.get("events", []))
+            removed = 0
+            kept: list[dict[str, Any]] = []
+            for event in events:
+                if not self._is_active_cooldown_for(event, worker_backend, now=now):
+                    kept.append(event)
+                    continue
+                is_model_weekly = (
+                    event.get("limit_kind") == MODEL_WEEKLY and event.get("model") is not None
+                )
+                if is_model_weekly:
+                    drop = event.get("model") == model
+                else:
+                    # Account-wide / unattributed cooldown.
+                    drop = include_account_wide
+                if drop:
+                    removed += 1
+                else:
+                    kept.append(event)
+            data["events"] = kept
+            if removed:
+                self._append_event(
+                    data,
+                    {
+                        "kind": "worker_backend_cooldown_cleared",
+                        "worker_backend": worker_backend,
+                        "model": model,
+                        "include_account_wide": include_account_wide,
+                        "reason": reason,
+                        "removed": removed,
+                        "timestamp": now.isoformat(),
+                    },
+                    now=now,
+                )
+            else:
+                # Nothing to retract — still persist the pruned list so a no-op
+                # clear can't leave duplicate stale events behind.
+                self.save(data, now=now)
+            return removed
+
+    @staticmethod
+    def _is_active_cooldown_for(
+        event: dict[str, Any], worker_backend: str, *, now: datetime
+    ) -> bool:
+        """True if ``event`` is a future (still-active) cooldown for the backend."""
+        if event.get("kind") != "worker_backend_cooldown":
+            return False
+        if event.get("worker_backend") != worker_backend:
+            return False
+        reset_raw = event.get("reset_at")
+        if not isinstance(reset_raw, str):
+            return False
+        try:
+            return datetime.fromisoformat(reset_raw) > now
+        except ValueError:
+            return False
 
     # ---------------------------------------------------------------------------
     # S6-2: Per-repo execution budget

--- a/tests/test_execution_controls.py
+++ b/tests/test_execution_controls.py
@@ -529,6 +529,98 @@ def test_account_wide_limit_blocks_backend(monkeypatch, tmp_path: Path) -> None:
     assert store.current_worker_backend_cooldowns(now=now)["claude_code"]["cooling_down"] is True
 
 
+def test_clear_worker_backend_cooldown_retracts_one_model(monkeypatch, tmp_path: Path) -> None:
+    # A probe proves sonnet is runnable again before its estimated reset; clearing
+    # it must drop sonnet's cooldown while leaving opus's untouched.
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
+    store = UsageStore()
+    now = datetime(2026, 5, 31, 8, tzinfo=UTC)
+    for model in ("sonnet", "opus"):
+        store.record_worker_backend_cooldown(
+            worker_backend="claude_code",
+            reset_at=now + timedelta(days=3),
+            now=now,
+            limit_kind="model_weekly",
+            model=model,
+        )
+
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model="sonnet", now=now
+    )
+
+    assert removed == 1
+    models = {c["model"] for c in store.worker_backend_cooldown_details("claude_code", now=now)}
+    assert models == {"opus"}
+
+
+def test_clear_worker_backend_cooldown_drops_account_wide(monkeypatch, tmp_path: Path) -> None:
+    # One model running disproves an account-wide block → clearing any model also
+    # retracts the session/account-wide cooldown so the backend frees up.
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
+    store = UsageStore()
+    now = datetime(2026, 5, 31, 8, tzinfo=UTC)
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=now + timedelta(hours=5),
+        now=now,
+        limit_kind="session_5h",
+        model=None,
+    )
+
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model="sonnet", now=now, include_account_wide=True
+    )
+
+    assert removed == 1
+    assert store.worker_backend_blocked_until("claude_code", now=now) is None
+
+
+def test_clear_worker_backend_cooldown_noop_when_nothing_active(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
+    store = UsageStore()
+    now = datetime(2026, 5, 31, 8, tzinfo=UTC)
+    assert (
+        store.clear_worker_backend_cooldown(worker_backend="claude_code", model="sonnet", now=now)
+        == 0
+    )
+
+
+def test_record_worker_backend_cooldown_coalesces_duplicates(monkeypatch, tmp_path: Path) -> None:
+    # Re-recording the same (backend, kind, model) limit each cycle must not pile
+    # up duplicate active events — the newest record supersedes.
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
+    store = UsageStore()
+    now = datetime(2026, 5, 31, 8, tzinfo=UTC)
+    for i in range(5):
+        store.record_worker_backend_cooldown(
+            worker_backend="claude_code",
+            reset_at=now + timedelta(days=3),
+            now=now + timedelta(minutes=i),
+            limit_kind="model_weekly",
+            model="sonnet",
+        )
+
+    data = store.load()
+    active = [
+        e
+        for e in data["events"]
+        if e.get("kind") == "worker_backend_cooldown" and e.get("model") == "sonnet"
+    ]
+    assert len(active) == 1
+    # A different model still records its own distinct event.
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=now + timedelta(days=1),
+        now=now,
+        limit_kind="model_weekly",
+        model="opus",
+    )
+    details = {c["model"] for c in store.worker_backend_cooldown_details("claude_code", now=now)}
+    assert details == {"sonnet", "opus"}
+
+
 def test_circuit_breaker_uses_backend_version_only(monkeypatch, tmp_path: Path) -> None:
     """Mixed-version window blocks the breaker; single-version triggers it.
 

--- a/tests/unit/backends/test_worker_backend_probe.py
+++ b/tests/unit/backends/test_worker_backend_probe.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from operations_center.backends.worker_backend_probe import (
+    ProbeResult,
+    probe_model,
+    refresh_cooldowns,
+)
+from operations_center.execution.usage_store import UsageStore
+
+_NOW = datetime(2026, 5, 31, 8, tzinfo=UTC)
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_probe_model_ok_on_clean_exit():
+    runner = lambda *a, **k: _FakeProc(0, stdout="ok\n")  # noqa: E731
+    res = probe_model("claude_code", "sonnet", runner=runner)
+    assert res.ok is True
+
+
+def test_probe_model_not_ok_on_limit_signal_despite_exit0():
+    # Some CLIs print a rate-limit notice and still exit 0 — must not read as runnable.
+    runner = lambda *a, **k: _FakeProc(0, stdout="You've hit your weekly limit")  # noqa: E731
+    res = probe_model("claude_code", "sonnet", runner=runner)
+    assert res.ok is False
+    assert "limit signal" in res.detail
+
+
+def test_probe_model_not_ok_on_nonzero_exit():
+    runner = lambda *a, **k: _FakeProc(1, stderr="boom")  # noqa: E731
+    res = probe_model("claude_code", "sonnet", runner=runner)
+    assert res.ok is False
+
+
+def test_probe_model_not_ok_on_timeout():
+    def runner(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="claude", timeout=1)
+
+    res = probe_model("claude_code", "sonnet", runner=runner)
+    assert res.ok is False
+    assert "timed out" in res.detail
+
+
+def _store(tmp_path: Path) -> UsageStore:
+    return UsageStore(path=tmp_path / "usage.json")
+
+
+def test_refresh_clears_only_runnable_models(tmp_path: Path):
+    store = _store(tmp_path)
+    for model in ("sonnet", "opus"):
+        store.record_worker_backend_cooldown(
+            worker_backend="claude_code",
+            reset_at=_NOW + timedelta(days=3),
+            now=_NOW,
+            limit_kind="model_weekly",
+            model=model,
+        )
+
+    # sonnet recovered, opus still limited.
+    def fake_probe(backend, model, *, timeout):
+        return ProbeResult(backend, model, model == "sonnet", "x")
+
+    report = refresh_cooldowns(store, now=_NOW, probe=fake_probe, backends=("claude_code",))
+
+    assert report["claude_code"] == {"sonnet": True, "opus": False}
+    remaining = {c["model"] for c in store.worker_backend_cooldown_details("claude_code", now=_NOW)}
+    assert remaining == {"opus"}
+
+
+def test_refresh_noop_when_nothing_cooling(tmp_path: Path):
+    store = _store(tmp_path)
+    calls = []
+
+    def fake_probe(backend, model, *, timeout):
+        calls.append((backend, model))
+        return ProbeResult(backend, model, True, "x")
+
+    report = refresh_cooldowns(store, now=_NOW, probe=fake_probe)
+    assert report == {}
+    assert calls == []  # never probes when no cooldown is active
+
+
+def test_refresh_account_wide_cleared_on_first_success(tmp_path: Path):
+    store = _store(tmp_path)
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=_NOW + timedelta(hours=5),
+        now=_NOW,
+        limit_kind="session_5h",
+        model=None,
+    )
+
+    def fake_probe(backend, model, *, timeout):
+        return ProbeResult(backend, model, True, "x")
+
+    refresh_cooldowns(store, now=_NOW, probe=fake_probe, backends=("claude_code",))
+
+    assert store.worker_backend_blocked_until("claude_code", now=_NOW) is None

--- a/tests/unit/entrypoints/maintenance/test_board_unblock.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock.py
@@ -308,6 +308,42 @@ def test_dispatch_cooldown_reason_none_when_nothing_cooling(monkeypatch):
     assert _dispatch_cooldown_reason(store, now=_NOW) is None
 
 
+class _RefreshableFakeUsageStore(_FakeUsageStore):
+    """Fake store whose snapshot a refresh callback can flip to runnable."""
+
+    def set_runnable(self, backend: str) -> None:
+        self._snapshot[backend] = {"cooling_down": False, "reset_at": None}
+
+
+def test_dispatch_cooldown_reason_self_heals_via_refresh(monkeypatch):
+    # All allowed backends look cooling, but a probe proves one is runnable: the
+    # injected refresh clears it, the gate re-reads, and dispatch is no longer
+    # deferred. This is the probe-and-clear self-heal at the dispatch boundary.
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _RefreshableFakeUsageStore(
+        {"claude_code": {"cooling_down": True, "reset_at": "2026-06-03T13:00:00+00:00"}}
+    )
+    calls: list[str] = []
+
+    def fake_refresh(s, *, now):
+        calls.append("refreshed")
+        s.set_runnable("claude_code")
+
+    assert _dispatch_cooldown_reason(store, now=_NOW, refresh=fake_refresh) is None
+    assert calls == ["refreshed"]
+
+
+def test_dispatch_cooldown_reason_still_blocks_when_refresh_finds_nothing(monkeypatch):
+    # Refresh runs but the limit is genuinely still active → gate still defers.
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _RefreshableFakeUsageStore(
+        {"claude_code": {"cooling_down": True, "reset_at": "2026-06-03T13:00:00+00:00"}}
+    )
+    reason = _dispatch_cooldown_reason(store, now=_NOW, refresh=lambda s, *, now: None)
+    assert reason is not None
+    assert "claude_code" in reason
+
+
 def test_rule7_goal_backlog_promote_skips_thin_goal():
     """GOAL_BACKLOG_PROMOTE must NOT fire for Backlog goal tasks carrying thin-goal."""
     parent = _issue(

--- a/tests/unit/entrypoints/test_worker_backend_probe.py
+++ b/tests/unit/entrypoints/test_worker_backend_probe.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from operations_center.entrypoints.worker_backend_probe.main import app
+from operations_center.execution.usage_store import UsageStore
+
+
+def test_probe_cli_noop_when_nothing_cooling(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
+    result = CliRunner().invoke(app, ["--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["report"] == {}
+
+
+def test_probe_cli_clears_stale_cooldown(monkeypatch, tmp_path: Path) -> None:
+    # Force the probe to report runnable so the CLI clears a stale cooldown end-to-end.
+    usage_path = tmp_path / "usage.json"
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(usage_path))
+    now = datetime.now(UTC)
+    UsageStore().record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=now + timedelta(days=3),
+        now=now,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+
+    from operations_center.backends import worker_backend_probe as mod
+
+    monkeypatch.setattr(
+        mod,
+        "probe_model",
+        lambda backend, model, *, timeout: mod.ProbeResult(backend, model, True, "stub"),
+    )
+
+    result = CliRunner().invoke(app, ["--json"])
+    assert result.exit_code == 0, result.output
+
+    remaining = UsageStore().worker_backend_cooldown_details("claude_code", now=now)
+    assert remaining == []


### PR DESCRIPTION
## Problem
Worker-backend cooldowns carry an *estimated* `reset_at` and were never retracted on their own — they only expired when `reset_at` passed. When a limit lifted early (e.g. sonnet recovered before its guessed weekly reset), the cooldown lingered: status surfaces showed the model cooling, and when every allowed model looked cooling the `board_unblock` gate deferred dispatch for no reason. Observed live: a stale `claude_code/sonnet/model_weekly` cooldown persisting for days after sonnet recovered.

## Change
- **`UsageStore.clear_worker_backend_cooldown`** — retract a model's active `model_weekly` cooldown (and, on request, account-wide cooldowns, since one model running disproves an all-models block); appends a `worker_backend_cooldown_cleared` audit event.
- **`backends/worker_backend_probe.py`** — `probe_model` runs a cheap `claude -p` / `codex exec` (mirrors the controller's invocation); `ok` only on exit 0 with no limit signal. `refresh_cooldowns` probes each *cooling* model and clears those proven runnable. **Probes never record cooldowns** — a flaky probe can only fail to clear, never falsely block.
- **New entrypoint** `operations-center-worker-backend-probe` + `worker-backend-probe` subcommand (safe to run on a schedule).
- **Self-heal** wired into `board_unblock._dispatch_cooldown_reason`: when every allowed backend looks cooling, probe + re-read before deferring (bounded to 20s). Refresh is dependency-injected so tests stay offline.
- **Periodic self-heal**: the watchdog hourly loop runs `worker-backend-probe` so stale cooldowns clear even when the board is idle.
- **Dedup on record**: `record_worker_backend_cooldown` coalesces duplicates for the same `(worker_backend, limit_kind, model)` so re-recording a limit each cycle no longer piles up identical events.

## Tests
Clear primitive (per-model / account-wide / no-op), dedup-on-record, probe module (fake runner: ok / limit-signal-despite-exit-0 / nonzero / timeout; refresh clears only runnable models; account-wide cleared on first success; no-op when idle), CLI smoke, and the `board_unblock` self-heal. Verified end-to-end against the live `claude` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)