### PR TITLE
feat(reviewer): verdict-gate merges + auto-fix loop — never ship half-finished

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,31 @@
+## 2026-06-02 — Reviewer: verdict-gated merges + auto-fix loop (operator-directed)
+
+**Status**: ✅ Implemented on branch `feat/verdict-gated-fix-loop` (worktree).
+
+**Why**: The self-review track re-reviewed an unchanged diff up to
+`max_self_review_loops` then merged regardless of verdict
+(`self_review_auto_merge` / `no_verdict_auto_merge`) — PR #215 shipped
+half-finished this way. Reviews never fixed anything.
+
+**What changed** (`entrypoints/pr_review_watcher/main.py`, `board_worker/dispatch.py`,
+`config/settings.py`):
+- LGTM is now the ONLY merge path; CONCERNS never merges.
+- On CONCERNS, dispatch a fix pass that resolves concerns on the PR's own head
+  branch and pushes (PR updates in place), then re-review. Loop up to
+  `reviewer.max_fix_attempts` (new setting, default 6).
+- On exhaustion (fix cap / repeated no-verdict), close the PR + re-queue the
+  issue (`STATE_READY`), bounded by `_MAX_REQUEUES`=3 → then `STATE_BLOCKED`
+  + `needs-human`. Never merge half-finished.
+- `no_verdict_passes` tracked separately from `self_review_loops`.
+- First-pass depth: `_append_definition_of_done` requires the initial pass to
+  fully implement + run tests/linters green before the PR opens.
+
+**Tests**: rewrote merge-on-CONCERNS/no-verdict tests → assert close+requeue;
+added fix-pass dispatch, bounded re-queue (Ready vs Blocked), and DoD coverage.
+341 passed (-k settings/config/reviewer/dispatch). ruff clean.
+
+---
+
 ## 2026-06-02 — Stage 3 FINAL: Spec Compliance Validation and Readiness Confirmation
 
 **Status**: ✅ **COMPLETE** — Queue-drain spec validated for full compliance and production readiness

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -280,8 +280,16 @@ class ReviewerSettings(BaseModel):
     bot_logins: list[str] = Field(default_factory=list)
     # If non-empty, only comments from these logins trigger human revisions
     allowed_reviewer_logins: list[str] = Field(default_factory=list)
-    # Max self-review+revision cycles before auto-merging (no human escalation)
+    # Max self-review passes that produce no parseable verdict before the PR is
+    # closed and the issue re-queued. NOT a merge cap — a stuck PR is never
+    # merged on CONCERNS; LGTM is the only merge path.
     max_self_review_loops: int = 3
+    # Max fix→review cycles on a CONCERNS verdict. Each CONCERNS dispatches a
+    # fix pass (worker addresses the concerns and pushes to the PR branch), then
+    # the next cycle re-reviews. Generous so genuine fixes have room; on
+    # exhaustion the PR is closed and the issue re-queued for a fresh attempt —
+    # never merged half-finished.
+    max_fix_attempts: int = 6
     # Unused — human_review phase removed. Kept for config-file compatibility.
     max_human_review_loops: int = 3
     human_review_timeout_seconds: int = 86400

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -79,6 +79,10 @@ def dispatch_issue(
 
     if role == "improve":
         goal_text = _append_improve_output_prompt(goal_text)
+    else:
+        # First-pass depth: require the initial pass to fully implement and
+        # self-verify before the PR opens, so the review loop has less to fix.
+        goal_text = _append_definition_of_done(goal_text)
 
     execution_mode = (
         task_kind if task_kind in {"goal", "test_campaign", "improve_campaign"} else task_kind
@@ -348,6 +352,27 @@ def _repo_local_path(settings, repo_key: str) -> str:
     if repo and repo.local_path:
         return repo.local_path
     return str(GITHUB_DIR / repo_key)
+
+
+def _append_definition_of_done(goal_text: str) -> str:
+    """Append an explicit definition-of-done so the first pass ships a complete,
+    self-verified change rather than a partial one the review loop must finish.
+
+    The downstream review loop only merges on an LGTM verdict and re-queues PRs
+    it can't get clean, so a thorough first pass directly reduces fix cycles."""
+    return (
+        f"{goal_text}\n\n"
+        "## Definition of done (complete ALL before finishing)\n"
+        "1. Implement the issue in its ENTIRETY — every acceptance criterion, every\n"
+        "   file the change implies (code, tests, and docs). Do not leave TODOs,\n"
+        "   stubs, or 'follow-up' gaps; a partial change will be rejected in review.\n"
+        "2. Add or update tests that prove the change works.\n"
+        "3. Run the repository's test suite and linters/formatters and make them\n"
+        "   pass locally. If anything fails, fix it before finishing — do not hand\n"
+        "   off a red build.\n"
+        "4. Only consider the task done when the full change is implemented AND\n"
+        "   verified green. The PR you open should be mergeable as-is.\n"
+    )
 
 
 def _append_improve_output_prompt(goal_text: str) -> str:

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -7,14 +7,18 @@ Phase 0 (ci_fix): when CI is failing on an autonomy PR, auto-fix the branch.
   - Retries up to max_ci_fix_attempts; then falls through to self_review.
 
 Phase 1 (self_review): executor reviews the diff and emits LGTM or CONCERNS.
-  - LGTM → auto-merge.
-  - No verdict (pipeline crash/timeout) → retry silently; auto-merge after
-    max_self_review_loops to avoid stalling indefinitely.
-  - CONCERNS → log, retry up to max_self_review_loops; auto-merge when
-    exhausted. OC figures it out — no human escalation.
+  - LGTM → merge. This is the ONLY merge path on the self-review track
+    (verdict-gated — a PR is never merged while concerns are unresolved).
+  - CONCERNS → dispatch a fix pass that resolves the concerns on the PR's own
+    branch (updating the open PR), then re-review next cycle. After
+    max_fix_attempts without reaching LGTM, the PR is CLOSED and the issue is
+    re-queued for a fresh attempt — a half-finished PR is never shipped.
+  - No verdict (pipeline crash/timeout) → retry; after max_self_review_loops
+    with no parseable verdict, close + re-queue rather than merge blind.
 
-There is no human_review phase. Human escalation is removed entirely.
-All PRs from autonomy branches resolve autonomously.
+Re-queuing is bounded by _MAX_REQUEUES; once exhausted the issue is left
+Blocked for a human. There is no human_review phase — autonomy PRs either reach
+LGTM and merge, or are closed and re-queued.
 
 State per PR persisted in state/pr_reviews/<repo_key>-<pr_number>.json.
 The state file is the single source of truth; Plane is updated after state is written.
@@ -156,8 +160,16 @@ def _run_pipeline(
     source: str,
     state_key: str,
     branch_suffix: str,
+    task_branch: str | None = None,
+    return_result: bool = False,
 ) -> dict | None:
-    """Run worker.main → execute.main and return verdict.json contents, or None."""
+    """Run worker.main → execute.main.
+
+    By default returns the parsed ``verdict.json`` (review pass). When
+    ``return_result`` is True, returns the parsed ``result.json`` execution
+    outcome instead (fix pass — no verdict is produced). ``task_branch``
+    overrides the branch the executor commits to; when None a throwaway
+    ``review/<suffix>`` branch is used. Returns None on failure."""
     python = _venv_python(oc_root)
     env = _build_env(oc_root)
     repo_cfg = settings.repos.get(repo_key)
@@ -229,7 +241,7 @@ def _run_pipeline(
             "--workspace-path",
             str(workspace),
             "--task-branch",
-            f"review/{branch_suffix}",
+            task_branch or f"review/{branch_suffix}",
             "--output",
             str(result_file),
             "--source",
@@ -257,6 +269,16 @@ def _run_pipeline(
                 state_key,
                 (exec_proc.stderr or exec_proc.stdout or "").strip()[-2000:],
             )
+
+        if return_result:
+            if result_file.exists():
+                try:
+                    return json.loads(result_file.read_text(encoding="utf-8"))
+                except Exception:
+                    logger.warning(
+                        "pr_review_watcher: malformed result.json for state_key=%s", state_key
+                    )
+            return None
 
         verdict_path = workspace / "verdict.json"
         if verdict_path.exists():
@@ -331,6 +353,156 @@ def _merge_and_done(
             )
 
     state_path.unlink(missing_ok=True)
+
+
+# ── Fix pass + close/re-queue ─────────────────────────────────────────────────
+
+# How many times an issue may be re-queued for a fresh attempt before it is
+# left Blocked for a human. Bounds the close→re-queue→new-PR cycle so an
+# unfixable issue can't loop forever, while still never merging half-finished.
+_MAX_REQUEUES = 3
+
+
+def _run_fix_pass(
+    oc_root: Path,
+    config_path: Path,
+    repo_key: str,
+    head_ref: str,
+    concerns: str,
+    settings,
+    *,
+    state_key: str,
+) -> bool:
+    """Dispatch a worker pass that resolves review concerns on the PR's own
+    branch and pushes (updating the open PR). Returns True if the pass reported
+    pushing changes — best-effort, used only for logging; the next review cycle
+    re-evaluates the actual diff regardless."""
+    goal_text = (
+        "A self-review of the currently open pull request raised the concerns "
+        "below. Resolve ALL of them by editing the code on the current branch, "
+        "then commit and push. Do NOT open a new pull request — push to the "
+        "existing branch so the open PR updates in place. Before finishing, run "
+        "the repository's tests and linters and make sure they pass.\n\n"
+        f"## Review concerns to resolve\n\n{concerns}"
+    )
+    outcome = _run_pipeline(
+        oc_root,
+        config_path,
+        repo_key,
+        goal_text,
+        settings,
+        source="reviewer_fix",
+        state_key=state_key,
+        branch_suffix=f"{state_key[:12]}",
+        task_branch=head_ref,
+        return_result=True,
+    )
+    if not isinstance(outcome, dict):
+        return False
+    result = outcome.get("result")
+    if not isinstance(result, dict):
+        result = outcome
+    return bool(result.get("branch_pushed") or result.get("success"))
+
+
+def _close_and_requeue(
+    state: dict,
+    state_path: Path,
+    _pr_data: dict,
+    gh_client,
+    owner: str,
+    repo: str,
+    settings,
+    *,
+    reason: str,
+    detail: str,
+) -> None:
+    """Close a PR WITHOUT merging and re-queue its issue for a fresh attempt.
+
+    The verdict gate's escape hatch: when a PR cannot reach LGTM, it is never
+    merged half-finished — it is closed and the originating issue is sent back
+    to the queue (bounded by ``_MAX_REQUEUES``)."""
+    pr_number = state["pr_number"]
+    marker = settings.reviewer.bot_comment_marker
+    try:
+        gh_client.post_comment(
+            owner,
+            repo,
+            pr_number,
+            f"{marker}\n**Closing without merge** (reason=`{reason}`). A PR is never "
+            f"merged with unresolved review concerns — re-queuing the issue for a "
+            f"fresh attempt.\n\n{detail}",
+        )
+    except Exception as exc:
+        logger.warning(
+            "pr_review_watcher: failed to comment before close PR #%d — %s", pr_number, exc
+        )
+    try:
+        gh_client.close_pr(owner, repo, pr_number)
+        logger.info("pr_review_watcher: closed PR #%d without merge (reason=%s)", pr_number, reason)
+    except Exception as exc:
+        logger.error("pr_review_watcher: failed to close PR #%d — %s", pr_number, exc)
+        return  # leave state file so the close is retried next cycle
+
+    plane_task_id = state.get("plane_task_id")
+    if plane_task_id:
+        _requeue_plane_task(settings, plane_task_id, pr_number=pr_number, reason=reason)
+
+    state_path.unlink(missing_ok=True)
+
+
+def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason: str) -> None:
+    """Send the issue back to the queue for a fresh attempt, bounded by
+    ``_MAX_REQUEUES``; once exhausted, leave it Blocked for a human."""
+    from operations_center.entrypoints.board_worker.labels import (
+        STATE_BLOCKED,
+        STATE_READY,
+        add_label,
+        increment_retry_count,
+        retry_count_from_labels,
+    )
+
+    try:
+        client = _plane_client(settings)
+    except Exception as exc:
+        logger.warning(
+            "pr_review_watcher: cannot open Plane client to re-queue task=%s — %s",
+            plane_task_id,
+            exc,
+        )
+        return
+    try:
+        issue = client.fetch_issue(plane_task_id)
+        attempts = retry_count_from_labels(issue.get("labels", []) or [])
+        if attempts >= _MAX_REQUEUES:
+            add_label(client, issue, "needs-human")
+            client.transition_issue(plane_task_id, STATE_BLOCKED)
+            client.comment_issue(
+                plane_task_id,
+                f"PR #{pr_number} closed ({reason}); re-queue limit "
+                f"({_MAX_REQUEUES}) reached — blocked for human review.",
+            )
+            logger.warning("pr_review_watcher: task=%s hit re-queue limit — Blocked", plane_task_id)
+        else:
+            increment_retry_count(client, issue)
+            client.transition_issue(plane_task_id, STATE_READY)
+            client.comment_issue(
+                plane_task_id,
+                f"PR #{pr_number} closed ({reason}); re-queued for a fresh attempt "
+                f"(#{attempts + 1} of {_MAX_REQUEUES}).",
+            )
+            logger.info(
+                "pr_review_watcher: re-queued task=%s to Ready (attempt %d)",
+                plane_task_id,
+                attempts + 1,
+            )
+    except Exception as exc:
+        logger.warning("pr_review_watcher: re-queue failed task=%s — %s", plane_task_id, exc)
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
 
 
 # ── Spec + Custodian context helpers ─────────────────────────────────────────
@@ -720,22 +892,22 @@ def _phase1(
     )
 
     state["self_review_loops"] += 1
+    state.setdefault("fix_attempts", 0)
+    state.setdefault("no_verdict_passes", 0)
 
     if verdict is None:
-        # Pipeline produced no verdict (crash/timeout/rate-limit).
-        # Retry silently up to max_self_review_loops, then auto-merge rather
-        # than stalling the queue. No comment posted — don't spam the PR.
-        logger.warning(
-            "pr_review_watcher: no verdict PR #%d (loop=%d/%d) — %s",
-            pr_number,
-            state["self_review_loops"],
-            reviewer.max_self_review_loops,
-            "will retry"
-            if state["self_review_loops"] < reviewer.max_self_review_loops
-            else "auto-merging",
-        )
-        if state["self_review_loops"] >= reviewer.max_self_review_loops:
-            _merge_and_done(
+        # Pipeline produced no verdict (crash/timeout/rate-limit). Retry a few
+        # times; if it never produces a parseable verdict, the PR is
+        # unreviewable — close it and re-queue rather than merging blind.
+        state["no_verdict_passes"] += 1
+        if state["no_verdict_passes"] >= reviewer.max_self_review_loops:
+            logger.warning(
+                "pr_review_watcher: PR #%d produced no verdict after %d passes — "
+                "closing and re-queuing (never auto-merge unreviewed)",
+                pr_number,
+                state["no_verdict_passes"],
+            )
+            _close_and_requeue(
                 state,
                 state_path,
                 pr_data,
@@ -743,48 +915,44 @@ def _phase1(
                 owner,
                 repo,
                 settings,
-                reason="no_verdict_auto_merge",
+                reason="no_verdict_exhausted",
+                detail="Self-review produced no parseable verdict after repeated passes.",
             )
         else:
+            logger.warning(
+                "pr_review_watcher: no verdict PR #%d (no_verdict_pass=%d/%d) — will retry",
+                pr_number,
+                state["no_verdict_passes"],
+                reviewer.max_self_review_loops,
+            )
             _save_state(state_path, state)
         return
 
+    state["no_verdict_passes"] = 0  # a verdict was produced
     result = (verdict.get("result") or "CONCERNS").upper()
     summary = verdict.get("summary", "(no summary)")
 
     logger.info("pr_review_watcher: PR #%d self-review verdict=%s", pr_number, result)
 
     if result == "LGTM":
+        # The ONLY merge path on the self-review track — verdict-gated.
         _merge_and_done(
             state, state_path, pr_data, gh_client, owner, repo, settings, reason="self_review_lgtm"
         )
         return
 
-    # CONCERNS — post once on the first pass, then retry silently.
-    # Auto-merge when loops exhausted rather than escalating to humans.
-    if state["self_review_loops"] == 1:
-        concern_body = (
-            f"{reviewer.bot_comment_marker}\n"
-            f"**Self-review concerns (will auto-merge after {reviewer.max_self_review_loops} passes):**\n\n{summary}"
-        )
-        try:
-            gh_client.post_comment(owner, repo, pr_number, concern_body)
-        except Exception as exc:
-            logger.warning(
-                "pr_review_watcher: failed to post concern comment PR #%d — %s", pr_number, exc
-            )
-    else:
-        logger.info(
-            "pr_review_watcher: PR #%d still CONCERNS on loop %d — %s",
+    # CONCERNS — never merge. Dispatch a fix pass that resolves the concerns on
+    # the PR's own branch (updating the PR), then re-review next cycle. After
+    # max_fix_attempts without reaching LGTM, close the PR and re-queue the
+    # issue for a fresh attempt — a half-finished PR is never shipped.
+    if state["fix_attempts"] >= reviewer.max_fix_attempts:
+        logger.warning(
+            "pr_review_watcher: PR #%d still CONCERNS after %d fix attempts — "
+            "closing and re-queuing",
             pr_number,
-            state["self_review_loops"],
-            "retrying"
-            if state["self_review_loops"] < reviewer.max_self_review_loops
-            else "auto-merging",
+            state["fix_attempts"],
         )
-
-    if state["self_review_loops"] >= reviewer.max_self_review_loops:
-        _merge_and_done(
+        _close_and_requeue(
             state,
             state_path,
             pr_data,
@@ -792,10 +960,72 @@ def _phase1(
             owner,
             repo,
             settings,
-            reason="self_review_auto_merge",
+            reason="fix_attempts_exhausted",
+            detail=(
+                f"Could not resolve review concerns after {state['fix_attempts']} "
+                f"fix attempts. Last concerns:\n\n{summary}"
+            ),
         )
         return
 
+    # Post the concerns once, on the first CONCERNS pass.
+    if state["fix_attempts"] == 0:
+        concern_body = (
+            f"{reviewer.bot_comment_marker}\n"
+            f"**Self-review concerns** — auto-fixing (up to {reviewer.max_fix_attempts} "
+            f"attempts; re-queued if still unresolved):\n\n{summary}"
+        )
+        try:
+            gh_client.post_comment(owner, repo, pr_number, concern_body)
+        except Exception as exc:
+            logger.warning(
+                "pr_review_watcher: failed to post concern comment PR #%d — %s", pr_number, exc
+            )
+
+    head_ref = (pr_data.get("head") or {}).get("ref") or ""
+    if not head_ref:
+        logger.error(
+            "pr_review_watcher: PR #%d has no head ref — cannot dispatch fix pass; "
+            "closing and re-queuing",
+            pr_number,
+        )
+        _close_and_requeue(
+            state,
+            state_path,
+            pr_data,
+            gh_client,
+            owner,
+            repo,
+            settings,
+            reason="no_head_ref",
+            detail="The PR head branch could not be determined, so concerns cannot be auto-fixed.",
+        )
+        return
+
+    logger.info(
+        "pr_review_watcher: PR #%d CONCERNS — dispatching fix pass %d/%d on branch %s",
+        pr_number,
+        state["fix_attempts"] + 1,
+        reviewer.max_fix_attempts,
+        head_ref,
+    )
+    pushed = _run_fix_pass(
+        oc_root,
+        config_path,
+        repo_key,
+        head_ref,
+        summary,
+        settings,
+        state_key=state_key,
+    )
+    state["fix_attempts"] += 1
+    if not pushed:
+        logger.warning(
+            "pr_review_watcher: fix pass for PR #%d pushed no changes (attempt %d/%d)",
+            pr_number,
+            state["fix_attempts"],
+            reviewer.max_fix_attempts,
+        )
     _save_state(state_path, state)
 
 

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -28,6 +28,7 @@ REVIEWER_CFG = MagicMock(
     bot_logins=[],
     allowed_reviewer_logins=[],
     max_self_review_loops=2,
+    max_fix_attempts=2,
     bot_comment_marker="<!-- operations-center:bot -->",
 )
 
@@ -39,7 +40,12 @@ SETTINGS = MagicMock(
 
 
 def _pr_data(*, draft: bool = False, title: str = "My PR") -> dict[str, Any]:
-    return {"number": PR_NUMBER, "title": title, "draft": draft}
+    return {
+        "number": PR_NUMBER,
+        "title": title,
+        "draft": draft,
+        "head": {"ref": f"goal/{PR_NUMBER}"},
+    }
 
 
 def _make_state(tmp_path: Path, **overrides: Any) -> tuple[dict, Path]:
@@ -175,9 +181,31 @@ def test_phase1_concerns_stays_in_phase1_below_max_loops(tmp_path: Path) -> None
     assert loaded["self_review_loops"] == 1
 
 
-def test_phase1_concerns_auto_merges_at_max_loops(tmp_path: Path) -> None:
-    # max_self_review_loops=2, already at loop 1 — this call pushes to 2 → auto-merge
-    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1)
+def test_phase1_concerns_dispatches_fix_pass_below_cap(tmp_path: Path) -> None:
+    # CONCERNS below the fix cap → dispatch a fix pass, never merge.
+    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=0, fix_attempts=0)
+    gh = _make_gh()
+
+    with (
+        patch.object(
+            watcher, "_run_pipeline", return_value={"result": "CONCERNS", "summary": "issues"}
+        ),
+        patch.object(watcher, "_run_fix_pass", return_value=True) as mock_fix,
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    mock_fix.assert_called_once()
+    mock_merge.assert_not_called()
+    loaded = watcher._load_state(sp)
+    assert loaded["fix_attempts"] == 1
+
+
+def test_phase1_concerns_closes_and_requeues_at_fix_cap(tmp_path: Path) -> None:
+    # max_fix_attempts=2, already at 2 — CONCERNS must close+requeue, NOT merge.
+    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1, fix_attempts=2)
     gh = _make_gh()
 
     with (
@@ -185,13 +213,15 @@ def test_phase1_concerns_auto_merges_at_max_loops(tmp_path: Path) -> None:
             watcher, "_run_pipeline", return_value={"result": "CONCERNS", "summary": "still broken"}
         ),
         patch.object(watcher, "_merge_and_done") as mock_merge,
+        patch.object(watcher, "_close_and_requeue") as mock_requeue,
     ):
         watcher._phase1(
             state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
         )
 
-    mock_merge.assert_called_once()
-    assert mock_merge.call_args[1]["reason"] == "self_review_auto_merge"
+    mock_merge.assert_not_called()
+    mock_requeue.assert_called_once()
+    assert mock_requeue.call_args[1]["reason"] == "fix_attempts_exhausted"
 
 
 def test_phase1_no_verdict_retries_next_poll(tmp_path: Path) -> None:
@@ -210,21 +240,24 @@ def test_phase1_no_verdict_retries_next_poll(tmp_path: Path) -> None:
     gh.post_comment.assert_not_called()
 
 
-def test_phase1_no_verdict_auto_merges_at_max_loops(tmp_path: Path) -> None:
-    # No verdict at max loops → auto-merge rather than stalling
-    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1)
+def test_phase1_no_verdict_closes_and_requeues_at_max_loops(tmp_path: Path) -> None:
+    # No parseable verdict at the retry cap → close+requeue, never merge blind.
+    # max_self_review_loops=2; pre-seed one prior no-verdict pass so this is the 2nd.
+    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1, no_verdict_passes=1)
     gh = _make_gh()
 
     with (
         patch.object(watcher, "_run_pipeline", return_value=None),
         patch.object(watcher, "_merge_and_done") as mock_merge,
+        patch.object(watcher, "_close_and_requeue") as mock_requeue,
     ):
         watcher._phase1(
             state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
         )
 
-    mock_merge.assert_called_once()
-    assert mock_merge.call_args[1]["reason"] == "no_verdict_auto_merge"
+    mock_merge.assert_not_called()
+    mock_requeue.assert_called_once()
+    assert mock_requeue.call_args[1]["reason"] == "no_verdict_exhausted"
 
 
 def test_phase1_skips_empty_diff(tmp_path: Path) -> None:
@@ -266,6 +299,53 @@ def test_merge_and_done_transitions_plane_task(tmp_path: Path) -> None:
 
     mock_client.transition_issue.assert_called_once_with("task-abc", "Done")
     mock_client.comment_issue.assert_called_once()
+
+
+# ── close + re-queue (verdict gate's escape hatch) ─────────────────────────────
+
+
+def test_close_and_requeue_closes_without_merge(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, plane_task_id=None)
+    gh = _make_gh()
+
+    watcher._close_and_requeue(
+        state,
+        sp,
+        _pr_data(),
+        gh,
+        "owner",
+        "repo",
+        SETTINGS,
+        reason="fix_attempts_exhausted",
+        detail="nope",
+    )
+
+    gh.close_pr.assert_called_once_with("owner", "repo", PR_NUMBER)
+    gh.merge_pr.assert_not_called()
+    assert not sp.exists()
+
+
+def test_requeue_plane_task_below_cap_goes_ready(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.fetch_issue.return_value = {"id": "t1", "labels": [{"name": "retry-count: 0"}]}
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+
+    mock_client.transition_issue.assert_called_once_with("t1", "Ready for AI")
+
+
+def test_requeue_plane_task_at_cap_goes_blocked(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.fetch_issue.return_value = {
+        "id": "t1",
+        "labels": [{"name": f"retry-count: {watcher._MAX_REQUEUES}"}],
+    }
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+
+    mock_client.transition_issue.assert_called_once_with("t1", "Blocked")
 
 
 def test_merge_and_done_keeps_state_on_merge_failure(tmp_path: Path) -> None:

--- a/tests/unit/entrypoints/test_board_worker_definition_of_done.py
+++ b/tests/unit/entrypoints/test_board_worker_definition_of_done.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""The first-pass definition-of-done appended to worker goals."""
+
+from __future__ import annotations
+
+from operations_center.entrypoints.board_worker.dispatch import _append_definition_of_done
+
+
+def test_definition_of_done_preserves_goal_and_demands_completeness() -> None:
+    out = _append_definition_of_done("Implement feature X")
+
+    # Original goal is preserved verbatim at the top.
+    assert out.startswith("Implement feature X")
+    # The contract demands full implementation + local verification before the PR.
+    assert "Definition of done" in out
+    lowered = out.lower()
+    assert "entirety" in lowered
+    assert "test" in lowered
+    assert "lint" in lowered or "linter" in lowered
+    # No partial / stub hand-offs.
+    assert "todo" in lowered and "stub" in lowered


### PR DESCRIPTION
## Why
The self-review track re-reviewed an **unchanged** diff up to `max_self_review_loops`, then merged regardless of verdict (`self_review_auto_merge` / `no_verdict_auto_merge`). Reviews were forbidden from pushing, so concerns were never fixed — PRs (e.g. #215) merged half-finished at the cap.

## What changed
Completeness — not a cycle count — now gates the merge.

**`pr_review_watcher/main.py`**
- **LGTM is the only merge path.** A CONCERNS verdict never merges.
- On CONCERNS → dispatch a **fix pass**: a worker run that resolves the concerns on the PR's own head branch and pushes. The open PR updates in place (`create_task_branch` checks out the existing remote branch; the redundant `create_pr` 422s harmlessly). Next cycle re-reviews the updated diff. Loops up to `max_fix_attempts` (default **6**).
- On exhaustion (fix cap, or repeated no-verdict passes) → **close the PR + re-queue the issue** for a fresh attempt. Re-queue bounded by `_MAX_REQUEUES`=3; then left `Blocked` + `needs-human`. Never merges.
- `no_verdict_passes` tracked separately from `self_review_loops` so a transient crash after real progress doesn't trip close+requeue early.

**`board_worker/dispatch.py`** — first-pass depth
- `_append_definition_of_done` requires the initial pass to implement the issue in full, add/adjust tests, and run tests+linters green **before** the PR opens — so the first PR is mergeable as-is.

**`config/settings.py`**
- New `reviewer.max_fix_attempts` (default 6). `max_self_review_loops` is now the no-verdict retry cap, not a merge cap.

## Tests
Rewrote the merge-on-CONCERNS / no-verdict tests to assert close+requeue; added coverage for fix-pass dispatch, the close+requeue escape hatch, bounded re-queue (Ready vs Blocked), and the definition-of-done. **341 passed** (`-k settings/config/reviewer/dispatch`), ruff clean.

## Rollout note
This changes live autonomous merge behavior. The reviewer watcher picks it up on its next restart; in-flight PR state files (which now also carry `fix_attempts`/`no_verdict_passes`, defaulted via `setdefault`) remain compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)