### PR TITLE
feat(reviewer): CI-green is a merge precondition, not an auto-merge trigger

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,21 @@
+## 2026-06-02 — Reviewer: CI-green is a precondition, not an auto-merge (operator-directed)
+
+**Status**: ✅ Implemented on `feat/ci-green-requires-lgtm`. Closes the bypass left
+by the verdict-gate work (#224): every managed repo has
+`auto_merge_on_ci_green: true`, which merged autonomy PRs the instant CI was
+green — *before* the new verdict gate ran. Green CI ≠ complete (missing docs etc.
+pass CI), so PRs could still ship half-finished.
+
+**Change** (`pr_review_watcher/main.py _phase1` fast path): CI-green is now a
+PRECONDITION. While CI is red the PR defers (no expensive self-review). Once CI
+is green it falls through to the verdict-gated self-review — LGTM is still the
+only merge path. Stale `operations_center.example.yaml` reviewer docs updated
+(removed human-review phase, surfaced `max_fix_attempts`, documented the
+precondition). Tests: ci-green-requires-LGTM + ci-red-defers-without-review.
+108 passed; ruff clean.
+
+---
+
 ## 2026-06-02 — Reviewer: verdict-gated merges + auto-fix loop (operator-directed)
 
 **Status**: ✅ Implemented on branch `feat/verdict-gated-fix-loop` (worktree).

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -108,13 +108,19 @@ repos:
 #     # Per-repo GitHub token override (must match token_env in this block):
 #     token_env: GITHUB_TOKEN_FRONTEND
 #
-#     # PR review loop: create PR and enter a two-phase review loop before merging.
-#     # Phase 1 (automatic): executor self-reviews its own diff. LGTM → merge.
-#     # CONCERNS → executor revises and re-reviews (up to reviewer.max_self_review_loops times).
-#     # Phase 2 (escalated): if self-review can't resolve, posts a comment for human review.
-#     # Human 👍 on PR or bot reply → merge. Human comment → executor revision pass (max 3).
-#     # No action after 1 day → merge automatically (timeout fallback).
+#     # PR review loop: open a PR and run a verdict-gated self-review before merge.
+#     # Self-review emits LGTM or CONCERNS.
+#     #   LGTM     → merge. This is the ONLY merge path.
+#     #   CONCERNS → a fix pass resolves the concerns on the PR branch and pushes,
+#     #              then re-reviews; up to reviewer.max_fix_attempts cycles.
+#     #   Exhausted (or no parseable verdict) → close the PR and re-queue the
+#     #              issue for a fresh attempt. A PR is never merged half-finished.
 #     await_review: true
+#
+#     # Green CI is a PRECONDITION for merge, not a merge trigger: while CI is red
+#     # the PR waits; once green it still must pass the verdict-gated self-review
+#     # above (green CI alone does not prove the issue is complete).
+#     auto_merge_on_ci_green: true
 #
 #     # Include this repo in idle-board proposer scans (default: true).
 #     propose_enabled: true
@@ -134,10 +140,14 @@ repos:
 # reviewer:
 #   # GitHub logins whose comments are always ignored (CI bots, integration accounts, etc.)
 #   bot_logins: []
-#   # If non-empty, only comments from these logins trigger human-phase revisions.
-#   # Leave empty to accept comments from any non-bot login.
+#   # If non-empty, only comments from these logins are honored. Empty = any non-bot.
 #   allowed_reviewer_logins: []
-#   # Max executor self-review + revision cycles before escalating to human review (default: 2).
+#   # Max fix→review cycles on a CONCERNS verdict before the PR is closed and the
+#   # issue re-queued for a fresh attempt (default: 6). Never a merge cap — only
+#   # an LGTM verdict merges.
+#   max_fix_attempts: 6
+#   # Retry cap for passes that produce NO parseable verdict (crash/timeout); after
+#   # this many the PR is closed + re-queued rather than merged blind (default: 2).
 #   max_self_review_loops: 2
 #   # HTML marker appended to every bot-posted comment — prevents re-processing own comments.
 #   bot_comment_marker: "<!-- operations-center:bot -->"

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -783,10 +783,13 @@ def _phase1(
     state_key = state["state_key"]
     reviewer = settings.reviewer
 
-    # ── auto-merge-on-CI-green (fast path) ───────────────────────────────────
-    # For autonomy PRs on repos that opt in, skip the self-review pipeline
-    # entirely and merge the moment CI is green.  Self-review is expensive and
-    # fragile; CI + ci_fix phase is the primary quality gate.
+    # ── CI-green precondition ────────────────────────────────────────────────
+    # For autonomy PRs on repos that opt in, green CI is a PRECONDITION for
+    # merge — not a merge trigger. While CI is red we defer (ci_fix / CI will
+    # resolve it) rather than burning an expensive self-review. Once CI is
+    # green we fall through to the verdict-gated self-review below: LGTM is the
+    # only thing that merges, so a PR is never shipped on green CI alone (green
+    # CI does not prove the issue is complete — e.g. missing docs pass CI).
     repo_cfg = settings.repos.get(repo_key)
     if repo_cfg and getattr(repo_cfg, "auto_merge_on_ci_green", False):
         head_ref = ((pr_data.get("head") or {}).get("ref") or "").lower()
@@ -801,27 +804,19 @@ def _phase1(
                     pr_data=pr_data,
                     ignored_checks=ignored,
                 )
-                if not failed:
+                if failed:
                     logger.info(
-                        "pr_review_watcher: PR #%d auto-merging — CI green, "
-                        "auto_merge_on_ci_green=True",
+                        "pr_review_watcher: PR #%d CI not green (%d failed) — deferring "
+                        "self-review until CI is green",
                         pr_number,
+                        len(failed),
                     )
-                    _merge_and_done(
-                        state,
-                        state_path,
-                        pr_data,
-                        gh_client,
-                        owner,
-                        repo,
-                        settings,
-                        reason="auto_merge_on_ci_green",
-                    )
+                    _save_state(state_path, state)
                     return
-                logger.debug(
-                    "pr_review_watcher: PR #%d CI not green (%d failed) — proceeding to self-review",
+                logger.info(
+                    "pr_review_watcher: PR #%d CI green — proceeding to verdict-gated "
+                    "self-review (LGTM required to merge)",
                     pr_number,
-                    len(failed),
                 )
             except Exception as exc:
                 logger.debug("pr_review_watcher: CI check failed PR #%d — %s", pr_number, exc)

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -274,6 +274,62 @@ def test_phase1_skips_empty_diff(tmp_path: Path) -> None:
     gh.merge_pr.assert_not_called()
 
 
+# ── CI-green precondition (not an auto-merge trigger) ──────────────────────────
+
+
+def _settings_with_ci_green_repo() -> MagicMock:
+    repo_cfg = MagicMock(
+        auto_merge_on_ci_green=True,
+        ci_ignored_checks=[],
+        clone_url=f"git@github.com:owner/{REPO_KEY}.git",
+        default_branch="main",
+        await_review=True,
+    )
+    return MagicMock(
+        reviewer=REVIEWER_CFG,
+        repos={REPO_KEY: repo_cfg},
+        plane=MagicMock(base_url="http://plane.local", project_id="proj", workspace_slug="ws"),
+    )
+
+
+def test_phase1_ci_green_requires_lgtm_not_automerge(tmp_path: Path) -> None:
+    # Green CI must NOT auto-merge — it proceeds to the verdict gate; only LGTM merges.
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = []  # CI green
+    settings = _settings_with_ci_green_repo()
+
+    with (
+        patch.object(
+            watcher, "_run_pipeline", return_value={"result": "LGTM", "summary": "ok"}
+        ) as mock_pipeline,
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    mock_pipeline.assert_called_once()  # the verdict gate ran
+    mock_merge.assert_called_once()
+    assert mock_merge.call_args[1]["reason"] == "self_review_lgtm"  # not auto_merge_on_ci_green
+
+
+def test_phase1_ci_red_defers_without_review(tmp_path: Path) -> None:
+    # Red CI defers — no expensive self-review, no merge — until CI goes green.
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["Lint (ruff): failure"]  # CI red
+    settings = _settings_with_ci_green_repo()
+
+    with patch.object(watcher, "_run_pipeline") as mock_pipeline:
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    mock_pipeline.assert_not_called()
+    gh.merge_pr.assert_not_called()
+
+
 # ── merge_and_done ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Why
Follow-up to #224. Every managed repo sets `auto_merge_on_ci_green: true`, which merged autonomy PRs the instant CI went green — **before** the verdict-gated self-review from #224 ever ran. Green CI doesn't prove the issue is complete (missing docs / partial work can still pass CI), so PRs could ship half-finished through this path. This closes that bypass so the gate actually applies to every autonomy PR.

## What changed
**`pr_review_watcher/main.py` (`_phase1` fast path)** — green CI is now a **precondition**, not a trigger:
- CI red → defer (no expensive self-review) until CI goes green.
- CI green → fall through to the verdict-gated self-review. **LGTM remains the only merge path**, so a PR is never merged on green CI alone.

**`config/operations_center.example.yaml`** — updated stale reviewer docs: removed the long-gone human-review phase, documented the LGTM-only / fix-loop / close+requeue flow + the CI-green precondition, and surfaced `reviewer.max_fix_attempts`.

## Test
- `test_phase1_ci_green_requires_lgtm_not_automerge` — green CI merges via `self_review_lgtm`, not `auto_merge_on_ci_green`.
- `test_phase1_ci_red_defers_without_review` — red CI defers without running a review.
- 108 passed (pr_review_watcher + entrypoints), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)