### PR TITLE
fix(reviewer): close gaps from adversarial audit of the verdict-gate loop

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,34 @@
+## 2026-06-02 — Reviewer gate: adversarial-audit gap fixes (operator-directed)
+
+**Status**: ✅ On `fix/reviewer-gate-gaps`. Adversarial audit of the verdict-gate
+work (#224/#226) surfaced gaps; fixed the real ones:
+
+- **Fix-pass no-op signal** (`_run_fix_pass`): returned True on `result.success`
+  even when nothing was pushed; now keys off `branch_pushed` only, so a no-op
+  pass is logged honestly.
+- **Dedicated re-queue budget**: `_requeue_plane_task` used the shared
+  `retry-count` label (also bumped by executor-kill/transient retries), so the
+  re-queue budget was conflated/non-deterministic. Now uses its own
+  `reviewer-requeue-count` label.
+- **Don't lose work on close** (`_close_and_requeue`): re-queue now happens
+  FIRST and returns a bool — the PR is closed only after the issue is safely
+  re-queued (a Plane outage no longer closes a PR into the void). Closing now
+  also deletes the head branch (no orphan-branch accumulation). No Plane task →
+  escalate (leave open) instead of closing.
+- **No-verdict ≠ bad PR**: a persistent no-verdict (usually a transient backend
+  rate-limit) now leaves the PR OPEN + needs-human (via new
+  `_escalate_needs_human`) and keeps polling, instead of closing/re-queuing a
+  possibly-good PR.
+- **DoD wording** made role-neutral (applies to test/goal alike).
+
+Noted but NOT changed (pre-existing / out of scope): H1 fix-pass plans against
+default_branch (oversize check is vs HEAD so it only measures the fix delta —
+benign; branch is squash-rewritten, fine for squash-merge repos); Phase-0
+ci_fix stash robustness; non-atomic state writes; conflicted-LGTM retried
+forever. 34 reviewer tests + 113 total (reviewer+entrypoints) pass; ruff clean.
+
+---
+
 ## 2026-06-02 — Reviewer: CI-green is a precondition, not an auto-merge (operator-directed)
 
 **Status**: ✅ Implemented on `feat/ci-green-requires-lgtm`. Closes the bypass left

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-06-02 — Reviewer gate: bound CI-defer + fix hermetic probe tests (operator-directed)
+
+**Status**: ✅ Added to `fix/reviewer-gate-gaps`. Two follow-on findings while
+verifying CI for the gap-fix PR:
+
+- **CRITICAL — #226 could stall the loop.** The CI-green precondition deferred on
+  ANY failed check; OC's own "Test (pytest)" check is red on every PR (coverage
+  gate, below), and OC has `auto_merge_on_ci_green: true` — so every OC autonomy
+  PR would defer forever. Fixed: bound the deferral (`_MAX_CI_WAIT_CYCLES`=20);
+  persistently-red CI now escalates to needs-human (leave open) instead of
+  silently stalling or merging on red.
+- **Hermetic probe tests.** `tests/unit/backends/test_worker_backend_probe.py`
+  called the real `shutil.which` for `claude`/`codex`, so 3 tests passed on dev
+  boxes (CLI present) but failed in CI (absent). Added an autouse fixture stubbing
+  `_resolve`. All 2694 unit tests now pass.
+
+**Open decision (NOT changed — needs operator call):** the #215 coverage gate
+`--cov-fail-under=85` (ci.yml:82/90, .coveragerc:13) measures all of `src` from
+the `tests/unit` subset → ~61.5%, so "Test (pytest)" has been red on every PR
+since #215. It's the last root cause of OC's red CI and now (with the precondition)
+gates OC autonomy. Needs a decision: lower the threshold to a realistic floor,
+measure coverage over the full suite, or scope `--cov`.
+
+---
+
 ## 2026-06-02 — Reviewer gate: adversarial-audit gap fixes (operator-directed)
 
 **Status**: ✅ On `fix/reviewer-gate-gaps`. Adversarial audit of the verdict-gate

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -363,15 +363,16 @@ def _append_definition_of_done(goal_text: str) -> str:
     return (
         f"{goal_text}\n\n"
         "## Definition of done (complete ALL before finishing)\n"
-        "1. Implement the issue in its ENTIRETY — every acceptance criterion, every\n"
-        "   file the change implies (code, tests, and docs). Do not leave TODOs,\n"
-        "   stubs, or 'follow-up' gaps; a partial change will be rejected in review.\n"
-        "2. Add or update tests that prove the change works.\n"
+        "1. Complete the task in its ENTIRETY — every acceptance criterion and every\n"
+        "   file the task implies (implementation, tests, and docs as applicable). Do\n"
+        "   not leave TODOs, stubs, or 'follow-up' gaps; a partial change is rejected\n"
+        "   in review.\n"
+        "2. Add or update tests/checks that prove the work is correct.\n"
         "3. Run the repository's test suite and linters/formatters and make them\n"
         "   pass locally. If anything fails, fix it before finishing — do not hand\n"
         "   off a red build.\n"
-        "4. Only consider the task done when the full change is implemented AND\n"
-        "   verified green. The PR you open should be mergeable as-is.\n"
+        "4. Only consider the task done when the full change is in place AND verified\n"
+        "   green. The PR you open should be mergeable as-is.\n"
     )
 
 

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -13,12 +13,17 @@ Phase 1 (self_review): executor reviews the diff and emits LGTM or CONCERNS.
     branch (updating the open PR), then re-review next cycle. After
     max_fix_attempts without reaching LGTM, the PR is CLOSED and the issue is
     re-queued for a fresh attempt — a half-finished PR is never shipped.
-  - No verdict (pipeline crash/timeout) → retry; after max_self_review_loops
-    with no parseable verdict, close + re-queue rather than merge blind.
+  - No verdict (pipeline crash/timeout/rate-limit) → retry; after
+    max_self_review_loops with no parseable verdict the PR is left OPEN and
+    flagged needs-human (a reviewer outage must not destroy a good PR), and
+    polling continues so a recovered backend reviews it later.
 
-Re-queuing is bounded by _MAX_REQUEUES; once exhausted the issue is left
-Blocked for a human. There is no human_review phase — autonomy PRs either reach
-LGTM and merge, or are closed and re-queued.
+Green CI is a precondition for merge, not a trigger: a red-CI PR defers; a
+green-CI PR still must pass the verdict gate. Re-queuing is bounded by
+_MAX_REQUEUES (its own label); once exhausted the issue is left Blocked for a
+human. There is no human_review phase — autonomy PRs reach LGTM and merge, are
+closed + re-queued (concerns unresolvable), or are left open for a human
+(unreviewable).
 
 State per PR persisted in state/pr_reviews/<repo_key>-<pr_number>.json.
 The state file is the single source of truth; Plane is updated after state is written.
@@ -374,9 +379,10 @@ def _run_fix_pass(
     state_key: str,
 ) -> bool:
     """Dispatch a worker pass that resolves review concerns on the PR's own
-    branch and pushes (updating the open PR). Returns True if the pass reported
-    pushing changes — best-effort, used only for logging; the next review cycle
-    re-evaluates the actual diff regardless."""
+    branch and pushes (updating the open PR). Returns True only if the pass
+    actually pushed changes to the branch — a no-op pass (worker couldn't
+    resolve anything) returns False so the caller can log it; the next review
+    cycle re-evaluates the actual diff regardless."""
     goal_text = (
         "A self-review of the currently open pull request raised the concerns "
         "below. Resolve ALL of them by editing the code on the current branch, "
@@ -402,13 +408,86 @@ def _run_fix_pass(
     result = outcome.get("result")
     if not isinstance(result, dict):
         result = outcome
-    return bool(result.get("branch_pushed") or result.get("success"))
+    # Only "branch_pushed" proves the diff changed. result.success is True even
+    # for a no-op pass (executor ran cleanly but committed nothing), which would
+    # mask a worker that resolved nothing — don't count that as a push.
+    return bool(result.get("branch_pushed"))
+
+
+# Dedicated label for reviewer re-queues — kept separate from board_worker's
+# `retry-count` (executor-kill/transient retries) so the two budgets don't
+# consume each other.
+_REQUEUE_LABEL_PREFIX = "reviewer-requeue-count"
+
+
+def _label_names(labels: list) -> list[str]:
+    out = []
+    for lab in labels or []:
+        name = (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
+        if name:
+            out.append(name)
+    return out
+
+
+def _requeue_count(labels: list) -> int:
+    raw = _label_value(labels, _REQUEUE_LABEL_PREFIX)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _labels_with_requeue_count(
+    labels: list, count: int, *, extra: list[str] | None = None
+) -> list[str]:
+    """Full replacement label set: existing names minus the old requeue-count
+    (and any in *extra*, to avoid dupes), plus the new count and *extra*."""
+    drop = {_REQUEUE_LABEL_PREFIX.lower()} | {e.lower() for e in (extra or [])}
+    kept = [n for n in _label_names(labels) if n.split(":", 1)[0].strip().lower() not in drop]
+    return kept + [f"{_REQUEUE_LABEL_PREFIX}: {count}", *(extra or [])]
+
+
+def _escalate_needs_human(
+    state: dict,
+    state_path: Path,
+    gh_client,
+    owner: str,
+    repo: str,
+    settings,
+    *,
+    reason: str,
+    detail: str,
+) -> None:
+    """Leave the PR OPEN and flag it for a human. Used when the PR must not be
+    merged (unresolved) but also must not be closed (work would be lost) — e.g.
+    the review pipeline is persistently unavailable, or there is no Plane task
+    to re-queue. Comments exactly once, then keeps polling."""
+    pr_number = state["pr_number"]
+    if not state.get("escalated_needs_human"):
+        marker = settings.reviewer.bot_comment_marker
+        try:
+            gh_client.post_comment(
+                owner,
+                repo,
+                pr_number,
+                f"{marker}\n**Needs human attention** (reason=`{reason}`). Left open — "
+                f"not merged (unresolved) and not closed (work preserved).\n\n{detail}",
+            )
+        except Exception as exc:
+            logger.warning(
+                "pr_review_watcher: failed to post needs-human comment PR #%d — %s", pr_number, exc
+            )
+        state["escalated_needs_human"] = True
+        logger.warning(
+            "pr_review_watcher: PR #%d escalated for human attention (reason=%s)", pr_number, reason
+        )
+    _save_state(state_path, state)
 
 
 def _close_and_requeue(
     state: dict,
     state_path: Path,
-    _pr_data: dict,
+    pr_data: dict,
     gh_client,
     owner: str,
     repo: str,
@@ -419,10 +498,41 @@ def _close_and_requeue(
 ) -> None:
     """Close a PR WITHOUT merging and re-queue its issue for a fresh attempt.
 
-    The verdict gate's escape hatch: when a PR cannot reach LGTM, it is never
-    merged half-finished — it is closed and the originating issue is sent back
-    to the queue (bounded by ``_MAX_REQUEUES``)."""
+    The verdict gate's escape hatch: when a PR cannot reach LGTM it is never
+    merged half-finished. Re-queue happens FIRST — the PR is only closed once
+    the issue is safely back in the queue, so a Plane outage can't lose the
+    work. With no Plane task to re-queue, the PR is left open + escalated rather
+    than closed into the void."""
     pr_number = state["pr_number"]
+    plane_task_id = state.get("plane_task_id")
+
+    if not plane_task_id:
+        logger.warning(
+            "pr_review_watcher: PR #%d has no Plane task — escalating instead of closing "
+            "(closing would lose the work)",
+            pr_number,
+        )
+        _escalate_needs_human(
+            state,
+            state_path,
+            gh_client,
+            owner,
+            repo,
+            settings,
+            reason=f"{reason}:no_task",
+            detail=detail,
+        )
+        return
+
+    # Re-queue first; only close if it succeeded.
+    if not _requeue_plane_task(settings, plane_task_id, pr_number=pr_number, reason=reason):
+        logger.warning(
+            "pr_review_watcher: re-queue failed for PR #%d — leaving PR open, will retry",
+            pr_number,
+        )
+        _save_state(state_path, state)
+        return
+
     marker = settings.reviewer.bot_comment_marker
     try:
         gh_client.post_comment(
@@ -430,8 +540,8 @@ def _close_and_requeue(
             repo,
             pr_number,
             f"{marker}\n**Closing without merge** (reason=`{reason}`). A PR is never "
-            f"merged with unresolved review concerns — re-queuing the issue for a "
-            f"fresh attempt.\n\n{detail}",
+            f"merged with unresolved review concerns — the issue has been re-queued for "
+            f"a fresh attempt.\n\n{detail}",
         )
     except Exception as exc:
         logger.warning(
@@ -441,26 +551,35 @@ def _close_and_requeue(
         gh_client.close_pr(owner, repo, pr_number)
         logger.info("pr_review_watcher: closed PR #%d without merge (reason=%s)", pr_number, reason)
     except Exception as exc:
+        # Issue is already re-queued; the open PR is gated from double-claim by
+        # OPEN_PR_GATE. Keep state so the close is retried next cycle.
         logger.error("pr_review_watcher: failed to close PR #%d — %s", pr_number, exc)
-        return  # leave state file so the close is retried next cycle
+        _save_state(state_path, state)
+        return
 
-    plane_task_id = state.get("plane_task_id")
-    if plane_task_id:
-        _requeue_plane_task(settings, plane_task_id, pr_number=pr_number, reason=reason)
+    # Delete the head branch so closed-PR branches don't accumulate as orphans.
+    head_ref = (pr_data.get("head") or {}).get("ref") or ""
+    if head_ref:
+        try:
+            gh_client.delete_branch(owner, repo, head_ref)
+        except Exception as exc:
+            logger.warning(
+                "pr_review_watcher: failed to delete branch %s for PR #%d — %s",
+                head_ref,
+                pr_number,
+                exc,
+            )
 
     state_path.unlink(missing_ok=True)
 
 
-def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason: str) -> None:
+def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason: str) -> bool:
     """Send the issue back to the queue for a fresh attempt, bounded by
-    ``_MAX_REQUEUES``; once exhausted, leave it Blocked for a human."""
-    from operations_center.entrypoints.board_worker.labels import (
-        STATE_BLOCKED,
-        STATE_READY,
-        add_label,
-        increment_retry_count,
-        retry_count_from_labels,
-    )
+    ``_MAX_REQUEUES`` (its own dedicated label); once exhausted, leave it
+    Blocked for a human. Returns True if the issue was handled (re-queued or
+    blocked), False on failure (e.g. Plane unreachable) so the caller can keep
+    the PR open and retry."""
+    from operations_center.entrypoints.board_worker.labels import STATE_BLOCKED, STATE_READY
 
     try:
         client = _plane_client(settings)
@@ -470,12 +589,15 @@ def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason:
             plane_task_id,
             exc,
         )
-        return
+        return False
     try:
         issue = client.fetch_issue(plane_task_id)
-        attempts = retry_count_from_labels(issue.get("labels", []) or [])
+        labels = issue.get("labels", []) or []
+        attempts = _requeue_count(labels)
         if attempts >= _MAX_REQUEUES:
-            add_label(client, issue, "needs-human")
+            client.update_issue_labels(
+                plane_task_id, _labels_with_requeue_count(labels, attempts, extra=["needs-human"])
+            )
             client.transition_issue(plane_task_id, STATE_BLOCKED)
             client.comment_issue(
                 plane_task_id,
@@ -484,7 +606,9 @@ def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason:
             )
             logger.warning("pr_review_watcher: task=%s hit re-queue limit — Blocked", plane_task_id)
         else:
-            increment_retry_count(client, issue)
+            client.update_issue_labels(
+                plane_task_id, _labels_with_requeue_count(labels, attempts + 1)
+            )
             client.transition_issue(plane_task_id, STATE_READY)
             client.comment_issue(
                 plane_task_id,
@@ -496,8 +620,10 @@ def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason:
                 plane_task_id,
                 attempts + 1,
             )
+        return True
     except Exception as exc:
         logger.warning("pr_review_watcher: re-queue failed task=%s — %s", plane_task_id, exc)
+        return False
     finally:
         try:
             client.close()
@@ -891,28 +1017,38 @@ def _phase1(
     state.setdefault("no_verdict_passes", 0)
 
     if verdict is None:
-        # Pipeline produced no verdict (crash/timeout/rate-limit). Retry a few
-        # times; if it never produces a parseable verdict, the PR is
-        # unreviewable — close it and re-queue rather than merging blind.
+        # Pipeline produced no verdict (crash/timeout/rate-limit). This is a
+        # REVIEWER failure, not a PR-quality failure — the PR may be perfectly
+        # good, we just can't review it right now (often a transient backend
+        # rate-limit). Never merge blind; but also never close/destroy a good
+        # PR over infra flakiness. Retry a few times, then leave the PR open and
+        # escalate for a human, and keep polling (a recovered backend will
+        # review it next cycle).
         state["no_verdict_passes"] += 1
         if state["no_verdict_passes"] >= reviewer.max_self_review_loops:
             logger.warning(
                 "pr_review_watcher: PR #%d produced no verdict after %d passes — "
-                "closing and re-queuing (never auto-merge unreviewed)",
+                "escalating (leaving open; reviewer unavailable, work preserved)",
                 pr_number,
                 state["no_verdict_passes"],
             )
-            _close_and_requeue(
+            _escalate_needs_human(
                 state,
                 state_path,
-                pr_data,
                 gh_client,
                 owner,
                 repo,
                 settings,
-                reason="no_verdict_exhausted",
-                detail="Self-review produced no parseable verdict after repeated passes.",
+                reason="no_verdict_unreviewable",
+                detail=(
+                    "Self-review produced no parseable verdict after repeated passes "
+                    "(likely a transient backend/rate-limit issue, or a diff too large "
+                    "to review). The PR is left open for human attention; automated "
+                    "review will retry."
+                ),
             )
+            state["no_verdict_passes"] = 0  # keep retrying in case it was transient
+            _save_state(state_path, state)
         else:
             logger.warning(
                 "pr_review_watcher: no verdict PR #%d (no_verdict_pass=%d/%d) — will retry",

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -367,6 +367,11 @@ def _merge_and_done(
 # unfixable issue can't loop forever, while still never merging half-finished.
 _MAX_REQUEUES = 3
 
+# How many polls a PR may wait for red CI to go green before it is escalated to
+# a human (rather than deferring forever — a persistently-red required check
+# must not silently stall the loop, nor merge on red).
+_MAX_CI_WAIT_CYCLES = 20
+
 
 def _run_fix_pass(
     oc_root: Path,
@@ -931,14 +936,39 @@ def _phase1(
                     ignored_checks=ignored,
                 )
                 if failed:
+                    # Defer while CI is red so ci_fix / CI can resolve it — but
+                    # BOUND the wait. If CI never goes green (e.g. a persistently
+                    # failing check), don't defer forever (that would silently
+                    # stall the loop) and don't merge red — escalate for a human.
+                    state["ci_wait_cycles"] = state.get("ci_wait_cycles", 0) + 1
+                    if state["ci_wait_cycles"] >= _MAX_CI_WAIT_CYCLES:
+                        _escalate_needs_human(
+                            state,
+                            state_path,
+                            gh_client,
+                            owner,
+                            repo,
+                            settings,
+                            reason="ci_persistently_red",
+                            detail=(
+                                f"CI has not gone green after {state['ci_wait_cycles']} "
+                                f"checks ({len(failed)} failing: "
+                                f"{', '.join(failed[:5])}). Not merged (red CI) and not "
+                                f"closed (work preserved) — needs a human to fix CI."
+                            ),
+                        )
+                        return
                     logger.info(
-                        "pr_review_watcher: PR #%d CI not green (%d failed) — deferring "
-                        "self-review until CI is green",
+                        "pr_review_watcher: PR #%d CI not green (%d failed, wait %d/%d) — "
+                        "deferring self-review until CI is green",
                         pr_number,
                         len(failed),
+                        state["ci_wait_cycles"],
+                        _MAX_CI_WAIT_CYCLES,
                     )
                     _save_state(state_path, state)
                     return
+                state["ci_wait_cycles"] = 0  # CI green — reset the wait counter
                 logger.info(
                     "pr_review_watcher: PR #%d CI green — proceeding to verdict-gated "
                     "self-review (LGTM required to merge)",

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -333,6 +333,30 @@ def test_phase1_ci_red_defers_without_review(tmp_path: Path) -> None:
 
     mock_pipeline.assert_not_called()
     gh.merge_pr.assert_not_called()
+    # the wait counter advances so the deferral is bounded
+    assert watcher._load_state(sp)["ci_wait_cycles"] == 1
+
+
+def test_phase1_ci_persistently_red_escalates(tmp_path: Path) -> None:
+    # Red CI that never goes green must NOT defer forever and must NOT merge —
+    # after the wait cap it escalates to a human (leaves the PR open).
+    state, sp = _make_state(
+        tmp_path, phase="self_review", ci_wait_cycles=watcher._MAX_CI_WAIT_CYCLES - 1
+    )
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["Test (pytest): fail"]  # persistently red
+    settings = _settings_with_ci_green_repo()
+
+    with patch.object(watcher, "_run_pipeline") as mock_pipeline:
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    mock_pipeline.assert_not_called()
+    gh.merge_pr.assert_not_called()
+    gh.close_pr.assert_not_called()  # work preserved, not closed
+    gh.post_comment.assert_called_once()  # needs-human escalation
+    assert watcher._load_state(sp)["escalated_needs_human"] is True
 
 
 # ── merge_and_done ────────────────────────────────────────────────────────────

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -240,8 +240,9 @@ def test_phase1_no_verdict_retries_next_poll(tmp_path: Path) -> None:
     gh.post_comment.assert_not_called()
 
 
-def test_phase1_no_verdict_closes_and_requeues_at_max_loops(tmp_path: Path) -> None:
-    # No parseable verdict at the retry cap → close+requeue, never merge blind.
+def test_phase1_no_verdict_escalates_keeps_pr_open(tmp_path: Path) -> None:
+    # No parseable verdict at the retry cap → escalate (leave PR open), never
+    # merge blind and never close/destroy a possibly-good PR over infra flakiness.
     # max_self_review_loops=2; pre-seed one prior no-verdict pass so this is the 2nd.
     state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1, no_verdict_passes=1)
     gh = _make_gh()
@@ -249,15 +250,19 @@ def test_phase1_no_verdict_closes_and_requeues_at_max_loops(tmp_path: Path) -> N
     with (
         patch.object(watcher, "_run_pipeline", return_value=None),
         patch.object(watcher, "_merge_and_done") as mock_merge,
-        patch.object(watcher, "_close_and_requeue") as mock_requeue,
+        patch.object(watcher, "_close_and_requeue") as mock_close,
     ):
         watcher._phase1(
             state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
         )
 
     mock_merge.assert_not_called()
-    mock_requeue.assert_called_once()
-    assert mock_requeue.call_args[1]["reason"] == "no_verdict_exhausted"
+    mock_close.assert_not_called()  # good PR is NOT closed on reviewer-unavailable
+    gh.close_pr.assert_not_called()
+    gh.post_comment.assert_called_once()  # one needs-human escalation comment
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is True
+    assert loaded["no_verdict_passes"] == 0  # reset to keep retrying
 
 
 def test_phase1_skips_empty_diff(tmp_path: Path) -> None:
@@ -360,7 +365,55 @@ def test_merge_and_done_transitions_plane_task(tmp_path: Path) -> None:
 # ── close + re-queue (verdict gate's escape hatch) ─────────────────────────────
 
 
-def test_close_and_requeue_closes_without_merge(tmp_path: Path) -> None:
+def test_close_and_requeue_requeues_then_closes_and_deletes_branch(tmp_path: Path) -> None:
+    # Re-queue succeeds → close PR (no merge) + delete head branch + drop state.
+    state, sp = _make_state(tmp_path, plane_task_id="task-abc")
+    gh = _make_gh()
+
+    with patch.object(watcher, "_requeue_plane_task", return_value=True) as mock_rq:
+        watcher._close_and_requeue(
+            state,
+            sp,
+            _pr_data(),
+            gh,
+            "owner",
+            "repo",
+            SETTINGS,
+            reason="fix_attempts_exhausted",
+            detail="nope",
+        )
+
+    mock_rq.assert_called_once()
+    gh.close_pr.assert_called_once_with("owner", "repo", PR_NUMBER)
+    gh.delete_branch.assert_called_once_with("owner", "repo", f"goal/{PR_NUMBER}")
+    gh.merge_pr.assert_not_called()
+    assert not sp.exists()
+
+
+def test_close_and_requeue_keeps_pr_open_when_requeue_fails(tmp_path: Path) -> None:
+    # Plane down → re-queue fails → DON'T close (work would be lost); retry later.
+    state, sp = _make_state(tmp_path, plane_task_id="task-abc")
+    gh = _make_gh()
+
+    with patch.object(watcher, "_requeue_plane_task", return_value=False):
+        watcher._close_and_requeue(
+            state,
+            sp,
+            _pr_data(),
+            gh,
+            "owner",
+            "repo",
+            SETTINGS,
+            reason="fix_attempts_exhausted",
+            detail="nope",
+        )
+
+    gh.close_pr.assert_not_called()
+    assert sp.exists()  # state preserved → retried next cycle
+
+
+def test_close_and_requeue_no_task_escalates_not_closes(tmp_path: Path) -> None:
+    # No Plane task → nowhere to re-queue → escalate (leave open), never close.
     state, sp = _make_state(tmp_path, plane_task_id=None)
     gh = _make_gh()
 
@@ -376,32 +429,74 @@ def test_close_and_requeue_closes_without_merge(tmp_path: Path) -> None:
         detail="nope",
     )
 
-    gh.close_pr.assert_called_once_with("owner", "repo", PR_NUMBER)
-    gh.merge_pr.assert_not_called()
-    assert not sp.exists()
+    gh.close_pr.assert_not_called()
+    gh.post_comment.assert_called_once()  # needs-human escalation
+    assert watcher._load_state(sp)["escalated_needs_human"] is True
 
 
 def test_requeue_plane_task_below_cap_goes_ready(tmp_path: Path) -> None:
     mock_client = MagicMock()
-    mock_client.fetch_issue.return_value = {"id": "t1", "labels": [{"name": "retry-count: 0"}]}
+    mock_client.fetch_issue.return_value = {"id": "t1", "labels": []}
 
     with patch.object(watcher, "_plane_client", return_value=mock_client):
-        watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+        ok = watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
 
+    assert ok is True
     mock_client.transition_issue.assert_called_once_with("t1", "Ready for AI")
+    # dedicated label bumped to 1
+    labels = mock_client.update_issue_labels.call_args[0][1]
+    assert "reviewer-requeue-count: 1" in labels
 
 
 def test_requeue_plane_task_at_cap_goes_blocked(tmp_path: Path) -> None:
     mock_client = MagicMock()
     mock_client.fetch_issue.return_value = {
         "id": "t1",
-        "labels": [{"name": f"retry-count: {watcher._MAX_REQUEUES}"}],
+        "labels": [{"name": f"reviewer-requeue-count: {watcher._MAX_REQUEUES}"}],
+    }
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        ok = watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+
+    assert ok is True
+    mock_client.transition_issue.assert_called_once_with("t1", "Blocked")
+    labels = mock_client.update_issue_labels.call_args[0][1]
+    assert "needs-human" in labels
+
+
+def test_requeue_plane_task_ignores_execution_retry_count(tmp_path: Path) -> None:
+    # board_worker's retry-count must NOT consume the reviewer re-queue budget.
+    mock_client = MagicMock()
+    mock_client.fetch_issue.return_value = {
+        "id": "t1",
+        "labels": [{"name": "retry-count: 9"}],  # high execution-retry count
     }
 
     with patch.object(watcher, "_plane_client", return_value=mock_client):
         watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
 
-    mock_client.transition_issue.assert_called_once_with("t1", "Blocked")
+    # Still re-queues (not Blocked) — reviewer-requeue-count is absent → 0.
+    mock_client.transition_issue.assert_called_once_with("t1", "Ready for AI")
+
+
+def test_requeue_plane_task_returns_false_when_plane_unavailable(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.fetch_issue.side_effect = Exception("plane down")
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        ok = watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+
+    assert ok is False
+
+
+def test_run_fix_pass_noop_returns_false(tmp_path: Path) -> None:
+    # Executor ran cleanly but pushed nothing → must NOT report a push.
+    outcome = {"result": {"success": True, "branch_pushed": False}}
+    with patch.object(watcher, "_run_pipeline", return_value=outcome):
+        pushed = watcher._run_fix_pass(
+            tmp_path, tmp_path / "cfg.yaml", REPO_KEY, "goal/1", "fix it", SETTINGS, state_key="k"
+        )
+    assert pushed is False
 
 
 def test_merge_and_done_keeps_state_on_merge_failure(tmp_path: Path) -> None:

--- a/tests/unit/backends/test_worker_backend_probe.py
+++ b/tests/unit/backends/test_worker_backend_probe.py
@@ -6,6 +6,9 @@ import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
+from operations_center.backends import worker_backend_probe
 from operations_center.backends.worker_backend_probe import (
     ProbeResult,
     probe_model,
@@ -14,6 +17,15 @@ from operations_center.backends.worker_backend_probe import (
 from operations_center.execution.usage_store import UsageStore
 
 _NOW = datetime(2026, 5, 31, 8, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _stub_cli_resolution(monkeypatch):
+    """Make the probed CLI always resolvable so probe_model exercises the
+    injected fake runner. Without this the tests depend on the `claude`/`codex`
+    binary being installed on the host (present on dev machines, absent in CI),
+    making them pass locally but fail in CI."""
+    monkeypatch.setattr(worker_backend_probe, "_resolve", lambda command: f"/usr/bin/{command}")
 
 
 class _FakeProc:


### PR DESCRIPTION
## Why
Adversarial audit of the verdict-gate work (#224/#226) found several real gaps. This fixes the substantive ones.

## Fixes
- **No-op fix pass masked as success** — `_run_fix_pass` returned True on `result.success` even when nothing was pushed. Now keys off `branch_pushed` only, so a no-op pass is logged honestly.
- **Conflated re-queue budget** — `_requeue_plane_task` used the shared `retry-count` label (also bumped by executor-kill/transient retries), so `_MAX_REQUEUES` could be silently consumed by unrelated failures. Now uses a dedicated `reviewer-requeue-count` label and returns a bool.
- **Work lost on close** — `_close_and_requeue` now re-queues **first** and only closes the PR once the issue is safely re-queued; a Plane outage no longer closes a PR into the void (state preserved, retried). Closing now also **deletes the head branch** (no orphan accumulation). No Plane task → escalate (leave open) instead of closing.
- **No-verdict ≠ bad PR** — a persistent no-verdict (usually a transient backend rate-limit) now leaves the PR **open + needs-human** and keeps polling, instead of closing/re-queuing a possibly-good PR.
- **DoD wording** made role-neutral (test/goal alike).

## Verified non-issues (not changed)
The fix pass plans against `default_branch`, but the oversize guard diffs `--cached` vs HEAD, so it only measures the fix delta (benign); the branch is squash-rewritten, fine for squash-merge repos. Pre-existing items (Phase-0 stash robustness, non-atomic state writes, conflicted-LGTM retried forever) noted for later, out of scope here.

## Test
Rewrote close/requeue + no-verdict tests for the new behavior; added no-op fix pass, requeue-fails-keeps-open, no-task-escalates, dedicated-label, and execution-retry-count-isolation coverage. **113 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)