### PR TITLE
test: raise unit coverage past the 85% gate (61.5% → 86.9%)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,33 @@
+## 2026-06-02 — Raise unit coverage past the 85% gate (operator-directed)
+
+**Status**: ✅ On `test/coverage-climb-1`. The #215 `--cov-fail-under=85` gate had
+never passed (unit ~61.5%); operator chose to keep 85% and reach it with real
+tests. Drove it with two parallel test-writing workflows (one agent per high-gap
+module): wave 1 (22 modules: tuning/, observer/, decision, policy, run_memory,
+slice_replay, worker_backend_selector, artifact_index, ci_evaluator/coordinator,
+audit_governance, executors) → 61.5%→68.9%; wave 2 (26 modules: usage_store,
+board_worker outcomes/dispatch/spec_author/_text, plane & git & github adapters,
+workspace, coordinator, campaign_store, proposer/*, spec_author/*, scheduled_tasks,
+triage_scan, board_unblock, task_parser, quality_alerts, …) → **86.9%**.
+
+~49 new hermetic test files (~2,300 tests), all `*_cov.py`. Fixes along the way:
+made all `tests/unit/` subdirs proper packages (`__init__.py`) to resolve
+duplicate-basename collisions; patched the policy/engine agent's tests (missing
+required `PolicyViolation.message`); ruff-fixed one unused import. Full gate:
+`pytest tests/unit -m "not slow" --cov=src --cov-fail-under=85` → 4561 passed,
+86.9%. CI "Test (pytest)" now goes green, so OC autonomy PRs can self-merge again
+(no longer escalated by the bounded CI-green precondition).
+
+Third workflow then cleaned the Custodian test-hygiene findings the generated
+tests tripped (the pre-push guard runs `--fail-on-findings`): 43 N2 (module-level
+helpers renamed to `_`-prefix + call sites), 23 T2 (assert-less tests given
+meaningful assertions), 1 T3 (ungated `pytest.skip` removed). Custodian audit now
+0 findings; full gate still green at 86.9%. Also added the SPDX license header
+to the new `tests/unit/**/__init__.py` package markers (CI's License-headers job
+requires it on every `.py`).
+
+---
+
 ## 2026-06-02 — Reviewer gate: bound CI-defer + fix hermetic probe tests (operator-directed)
 
 **Status**: ✅ Added to `fix/reviewer-gate-gaps`. Two follow-on findings while

--- a/tests/unit/adapters/__init__.py
+++ b/tests/unit/adapters/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/adapters/git/__init__.py
+++ b/tests/unit/adapters/git/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/adapters/git/test_client_cov.py
+++ b/tests/unit/adapters/git/test_client_cov.py
@@ -1,0 +1,646 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from operations_center.adapters.git.client import GitClient, branch_allowed
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _run
+# ---------------------------------------------------------------------------
+
+
+def test_run_success_strips_output():
+    client = GitClient()
+    with patch("subprocess.run", return_value=_proc(stdout="  hello \n")) as sr:
+        out = client._run(["git", "status"], cwd=Path("/repo"), timeout=12)
+    assert out == "hello"
+    sr.assert_called_once_with(
+        ["git", "status"],
+        cwd=Path("/repo"),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=12,
+    )
+
+
+def test_run_failure_raises_with_stderr():
+    client = GitClient()
+    with patch("subprocess.run", return_value=_proc(returncode=1, stderr="boom")):
+        with pytest.raises(RuntimeError) as exc:
+            client._run(["git", "status"])
+    assert "git command failed" in str(exc.value)
+    assert "boom" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# _run_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_run_bytes_success():
+    client = GitClient()
+    with patch("subprocess.run", return_value=_proc(stdout=b"raw")):
+        out = client._run_bytes(["git", "x"], cwd=Path("/r"))
+    assert out == b"raw"
+
+
+def test_run_bytes_failure_decodes_stderr():
+    client = GitClient()
+    with patch("subprocess.run", return_value=_proc(returncode=2, stderr=b"\xff bad")):
+        with pytest.raises(RuntimeError) as exc:
+            client._run_bytes(["git", "x"])
+    assert "git command failed" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# clone
+# ---------------------------------------------------------------------------
+
+
+def test_clone_returns_repo_path(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        result = client.clone("https://example/repo.git", tmp_path)
+    assert result == tmp_path / "repo"
+    run.assert_called_once_with(
+        ["git", "clone", "https://example/repo.git", str(tmp_path / "repo")]
+    )
+
+
+# ---------------------------------------------------------------------------
+# add_local_exclude
+# ---------------------------------------------------------------------------
+
+
+def test_add_local_exclude_creates_file(tmp_path):
+    client = GitClient()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    client.add_local_exclude(repo, "artifact.json")
+    exclude = repo / ".git" / "info" / "exclude"
+    assert exclude.read_text(encoding="utf-8") == "artifact.json\n"
+
+
+def test_add_local_exclude_already_present_noop(tmp_path):
+    client = GitClient()
+    repo = tmp_path / "repo"
+    exclude = repo / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True)
+    exclude.write_text("foo\nbar\n", encoding="utf-8")
+    client.add_local_exclude(repo, "  foo  ")
+    assert exclude.read_text(encoding="utf-8") == "foo\nbar\n"
+
+
+def test_add_local_exclude_appends_newline_when_missing(tmp_path):
+    client = GitClient()
+    repo = tmp_path / "repo"
+    exclude = repo / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True)
+    exclude.write_text("existing", encoding="utf-8")  # no trailing newline
+    client.add_local_exclude(repo, "new")
+    assert exclude.read_text(encoding="utf-8") == "existing\nnew\n"
+
+
+def test_add_local_exclude_existing_with_newline(tmp_path):
+    client = GitClient()
+    repo = tmp_path / "repo"
+    exclude = repo / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True)
+    exclude.write_text("existing\n", encoding="utf-8")
+    client.add_local_exclude(repo, "new")
+    assert exclude.read_text(encoding="utf-8") == "existing\nnew\n"
+
+
+# ---------------------------------------------------------------------------
+# verify_remote_branch_exists
+# ---------------------------------------------------------------------------
+
+
+def test_verify_remote_branch_exists_ok(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="abc123\trefs/heads/main") as run:
+        result = client.verify_remote_branch_exists(tmp_path, "main")
+    assert result is None
+    run.assert_called_once()
+
+
+def test_verify_remote_branch_exists_missing(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value=""):
+        with pytest.raises(ValueError, match="Base branch does not exist"):
+            client.verify_remote_branch_exists(tmp_path, "main")
+
+
+# ---------------------------------------------------------------------------
+# remote_default_branch
+# ---------------------------------------------------------------------------
+
+
+def test_remote_default_branch(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="refs/remotes/origin/main"):
+        assert client.remote_default_branch(tmp_path) == "main"
+
+
+# ---------------------------------------------------------------------------
+# create_remote_branch_from
+# ---------------------------------------------------------------------------
+
+
+def test_create_remote_branch_from(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.create_remote_branch_from(tmp_path, "feat", "origin/main")
+    assert run.call_args_list == [
+        call(["git", "push", "origin", "origin/main:refs/heads/feat"], cwd=tmp_path),
+        call(
+            ["git", "fetch", "origin", "feat:refs/remotes/origin/feat"],
+            cwd=tmp_path,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# checkout_base
+# ---------------------------------------------------------------------------
+
+
+def test_checkout_base_pull_succeeds(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.checkout_base(tmp_path, "main")
+    assert run.call_args_list == [
+        call(["git", "checkout", "main"], cwd=tmp_path),
+        call(["git", "pull", "--ff-only"], cwd=tmp_path),
+    ]
+
+
+def test_checkout_base_pull_failure_swallowed(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:2] == ["git", "pull"]:
+            raise RuntimeError("no upstream")
+        return ""
+
+    with patch.object(client, "_run", side_effect=side) as run:
+        result = client.checkout_base(tmp_path, "main")
+    assert result is None
+    run.assert_any_call(["git", "checkout", "main"], cwd=tmp_path)
+    run.assert_any_call(["git", "pull", "--ff-only"], cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# restore_to_head
+# ---------------------------------------------------------------------------
+
+
+def test_restore_to_head_ok(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.restore_to_head(tmp_path, "file.json")
+    run.assert_called_once_with(["git", "checkout", "HEAD", "--", "file.json"], cwd=tmp_path)
+
+
+def test_restore_to_head_error_swallowed(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", side_effect=RuntimeError("absent")) as run:
+        result = client.restore_to_head(tmp_path, "file.json")
+    assert result is None
+    run.assert_called_once_with(["git", "checkout", "HEAD", "--", "file.json"], cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# create_task_branch
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_branch_existing_on_remote(tmp_path):
+    client = GitClient()
+    calls = []
+
+    def side(args, cwd=None):
+        calls.append(args)
+        if args[:3] == ["git", "ls-remote", "--heads"]:
+            return "sha\trefs/heads/task"
+        return ""
+
+    with patch.object(client, "_run", side_effect=side):
+        existed = client.create_task_branch(tmp_path, "task")
+    assert existed is True
+    assert ["git", "fetch", "origin", "task:refs/remotes/origin/task"] in calls
+    assert ["git", "checkout", "-b", "task", "origin/task"] in calls
+
+
+def test_create_task_branch_new(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:3] == ["git", "ls-remote", "--heads"]:
+            return ""
+        return ""
+
+    with patch.object(client, "_run", side_effect=side) as run:
+        existed = client.create_task_branch(tmp_path, "task")
+    assert existed is False
+    run.assert_any_call(["git", "checkout", "-b", "task"], cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# try_merge_base
+# ---------------------------------------------------------------------------
+
+
+def test_try_merge_base_success(tmp_path):
+    client = GitClient()
+    with patch("subprocess.run", return_value=_proc(returncode=0)) as sr:
+        ok, conflicts = client.try_merge_base(tmp_path, "main")
+    assert ok is True
+    assert conflicts == []
+    sr.assert_called_once()
+
+
+def test_try_merge_base_conflict(tmp_path):
+    client = GitClient()
+    results = [
+        _proc(returncode=1),  # merge fails
+        _proc(returncode=0, stdout="a.py\n b.py \n\n"),  # diff
+    ]
+    with patch("subprocess.run", side_effect=results):
+        ok, conflicts = client.try_merge_base(tmp_path, "main")
+    assert ok is False
+    assert conflicts == ["a.py", "b.py"]
+
+
+def test_try_merge_base_conflict_diff_command_fails(tmp_path, caplog):
+    client = GitClient()
+    results = [
+        _proc(returncode=1),  # merge fails
+        _proc(returncode=128, stdout="", stderr="fatal: bad"),  # diff fails
+    ]
+    with patch("subprocess.run", side_effect=results):
+        ok, conflicts = client.try_merge_base(tmp_path, "main")
+    assert ok is False
+    assert conflicts == []
+    assert any("diff --diff-filter=U failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# recent_commits / recent_changed_files
+# ---------------------------------------------------------------------------
+
+
+def test_recent_commits(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="aaa one\n  bbb two  \n\n"):
+        out = client.recent_commits(tmp_path, max_count=2)
+    assert out == ["aaa one", "bbb two"]
+
+
+def test_recent_changed_files_dedups_and_normalizes(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="./a/b.py\na/b.py\nc.py\n"):
+        out = client.recent_changed_files(tmp_path)
+    assert out == ["a/b.py", "c.py"]
+
+
+# ---------------------------------------------------------------------------
+# set_identity
+# ---------------------------------------------------------------------------
+
+
+def test_set_identity(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.set_identity(tmp_path, "Bot", "bot@example.com")
+    assert run.call_args_list == [
+        call(["git", "config", "user.name", "Bot"], cwd=tmp_path),
+        call(["git", "config", "user.email", "bot@example.com"], cwd=tmp_path),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# changed_files
+# ---------------------------------------------------------------------------
+
+
+def test_changed_files(tmp_path):
+    client = GitClient()
+    diff = b"M\x00a.py\x00R100\x00old.py\x00new.py\x00"
+    untracked = b"./c.py\x00d.py\x00"
+    with patch.object(client, "_run_bytes", side_effect=[diff, untracked]):
+        out = client.changed_files(tmp_path)
+    assert out == sorted({"a.py", "new.py", "c.py", "d.py"})
+
+
+# ---------------------------------------------------------------------------
+# diff_stat
+# ---------------------------------------------------------------------------
+
+
+def test_diff_stat(tmp_path):
+    client = GitClient()
+    with (
+        patch.object(client, "_run", return_value=" a.py | 2 ++\n\n  \n 1 file"),
+        patch.object(client, "_run_bytes", return_value=b"./new.py\x00"),
+    ):
+        out = client.diff_stat(tmp_path)
+    assert "a.py | 2 ++" in out
+    assert " untracked | new.py" in out
+    assert " 1 file" in out
+
+
+# ---------------------------------------------------------------------------
+# diff_patch
+# ---------------------------------------------------------------------------
+
+
+def test_diff_patch(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="diff --git") as run:
+        assert client.diff_patch(tmp_path) == "diff --git"
+    run.assert_called_once_with(["git", "diff", "--binary", "HEAD"], cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# commit_all
+# ---------------------------------------------------------------------------
+
+
+def test_commit_all_with_changes(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:2] == ["git", "status"]:
+            return " M a.py"
+        return ""
+
+    with patch.object(client, "_run", side_effect=side) as run:
+        committed = client.commit_all(tmp_path, "msg")
+    assert committed is True
+    run.assert_any_call(["git", "commit", "-m", "msg"], cwd=tmp_path)
+
+
+def test_commit_all_no_changes(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:2] == ["git", "status"]:
+            return ""
+        return ""
+
+    with patch.object(client, "_run", side_effect=side) as run:
+        committed = client.commit_all(tmp_path, "msg")
+    assert committed is False
+    for c in run.call_args_list:
+        assert c.args[0][:2] != ["git", "commit"]
+
+
+# ---------------------------------------------------------------------------
+# push_branch / push_branch_force
+# ---------------------------------------------------------------------------
+
+
+def test_push_branch(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.push_branch(tmp_path, "feat")
+    run.assert_called_once_with(["git", "push", "-u", "origin", "feat"], cwd=tmp_path)
+
+
+def test_push_branch_force(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.push_branch_force(tmp_path, "feat")
+    run.assert_called_once_with(
+        ["git", "push", "--force-with-lease", "origin", "feat"], cwd=tmp_path
+    )
+
+
+# ---------------------------------------------------------------------------
+# squash_commits
+# ---------------------------------------------------------------------------
+
+
+def test_squash_commits_performed(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:3] == ["git", "rev-list", "--count"]:
+            return "3"
+        if args[:2] == ["git", "merge-base"]:
+            return "basesha\n"
+        return ""
+
+    with patch.object(client, "_run", side_effect=side) as run:
+        result = client.squash_commits(tmp_path, "main", "squashed")
+    assert result is True
+    run.assert_any_call(["git", "reset", "--soft", "basesha"], cwd=tmp_path)
+    run.assert_any_call(["git", "commit", "-m", "squashed"], cwd=tmp_path)
+
+
+def test_squash_commits_single_commit_noop(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="1"):
+        assert client.squash_commits(tmp_path, "main", "x") is False
+
+
+def test_squash_commits_count_error(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", side_effect=RuntimeError("no ref")):
+        assert client.squash_commits(tmp_path, "main", "x") is False
+
+
+def test_squash_commits_count_not_int(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="notanumber"):
+        assert client.squash_commits(tmp_path, "main", "x") is False
+
+
+# ---------------------------------------------------------------------------
+# checkout_branch
+# ---------------------------------------------------------------------------
+
+
+def test_checkout_branch(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        client.checkout_branch(tmp_path, "feat")
+    run.assert_called_once_with(["git", "checkout", "feat"], cwd=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# revert_commit
+# ---------------------------------------------------------------------------
+
+
+def test_revert_commit_success(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        ok = client.revert_commit(tmp_path, "deadbeef", new_branch="revert-x")
+    assert ok is True
+    run.assert_any_call(["git", "checkout", "-b", "revert-x"], cwd=tmp_path)
+    run.assert_any_call(["git", "revert", "--no-edit", "deadbeef"], cwd=tmp_path)
+
+
+def test_revert_commit_conflict_aborts(tmp_path):
+    client = GitClient()
+    calls = []
+
+    def side(args, cwd=None):
+        calls.append(args)
+        if args[:2] == ["git", "revert"] and "--abort" not in args:
+            raise RuntimeError("conflict")
+        return ""
+
+    with patch.object(client, "_run", side_effect=side):
+        ok = client.revert_commit(tmp_path, "deadbeef", new_branch="revert-x")
+    assert ok is False
+    assert ["git", "revert", "--abort"] in calls
+
+
+def test_revert_commit_conflict_abort_also_fails(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:2] == ["git", "revert"]:
+            raise RuntimeError("conflict")
+        return ""
+
+    with patch.object(client, "_run", side_effect=side):
+        ok = client.revert_commit(tmp_path, "deadbeef", new_branch="revert-x")
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# rebase_onto_origin
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_onto_origin_success(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", return_value="") as run:
+        assert client.rebase_onto_origin(tmp_path, "main") is True
+    run.assert_any_call(["git", "fetch", "origin", "main"], cwd=tmp_path)
+    run.assert_any_call(["git", "rebase", "origin/main"], cwd=tmp_path)
+
+
+def test_rebase_onto_origin_fetch_fails(tmp_path):
+    client = GitClient()
+    with patch.object(client, "_run", side_effect=RuntimeError("no network")):
+        assert client.rebase_onto_origin(tmp_path, "main") is False
+
+
+def test_rebase_onto_origin_conflict_aborts(tmp_path):
+    client = GitClient()
+    calls = []
+
+    def side(args, cwd=None):
+        calls.append(args)
+        if args[:2] == ["git", "rebase"] and "--abort" not in args:
+            raise RuntimeError("conflict")
+        return ""
+
+    with patch.object(client, "_run", side_effect=side):
+        assert client.rebase_onto_origin(tmp_path, "main") is False
+    assert ["git", "rebase", "--abort"] in calls
+
+
+def test_rebase_onto_origin_conflict_abort_also_fails(tmp_path):
+    client = GitClient()
+
+    def side(args, cwd=None):
+        if args[:2] == ["git", "rebase"]:
+            raise RuntimeError("conflict")
+        return ""
+
+    with patch.object(client, "_run", side_effect=side):
+        assert client.rebase_onto_origin(tmp_path, "main") is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_name_status_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_name_status_empty():
+    client = GitClient()
+    assert client._parse_name_status_output(b"") == []
+
+
+def test_parse_name_status_modified_and_rename():
+    client = GitClient()
+    out = b"M\x00a.py\x00R100\x00old.py\x00new.py\x00A\x00c.py\x00"
+    assert client._parse_name_status_output(out) == ["a.py", "new.py", "c.py"]
+
+
+def test_parse_name_status_rename_truncated():
+    client = GitClient()
+    # rename status with missing new path -> break
+    out = b"R100\x00old.py\x00"
+    assert client._parse_name_status_output(out) == []
+
+
+def test_parse_name_status_simple_truncated():
+    client = GitClient()
+    # status code but no following path -> break
+    out = b"M\x00"
+    assert client._parse_name_status_output(out) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_null_delimited_paths
+# ---------------------------------------------------------------------------
+
+
+def test_parse_null_delimited_empty():
+    client = GitClient()
+    assert client._parse_null_delimited_paths(b"") == []
+
+
+def test_parse_null_delimited():
+    client = GitClient()
+    assert client._parse_null_delimited_paths(b"a\x00b\x00") == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# _normalize_repo_relative_path
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_repo_relative_path():
+    client = GitClient()
+    assert client._normalize_repo_relative_path("./a/b.py") == "a/b.py"
+    assert client._normalize_repo_relative_path("a\\b.py") == "a/b.py"
+
+
+# ---------------------------------------------------------------------------
+# branch_allowed
+# ---------------------------------------------------------------------------
+
+
+def test_branch_allowed_no_patterns():
+    assert branch_allowed("main", []) is True
+
+
+def test_branch_allowed_match():
+    assert branch_allowed("release/1.0", ["release/*"]) is True
+
+
+def test_branch_allowed_no_match():
+    assert branch_allowed("feature/x", ["release/*", "main"]) is False

--- a/tests/unit/adapters/plane/__init__.py
+++ b/tests/unit/adapters/plane/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/adapters/plane/test_client_cov.py
+++ b/tests/unit/adapters/plane/test_client_cov.py
@@ -1,0 +1,750 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from operations_center.adapters.plane.client import PlaneClient
+
+
+class FakeResponse:
+    """Minimal stand-in for httpx.Response."""
+
+    def __init__(
+        self,
+        *,
+        json_data: Any = None,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        raise_error: bool = False,
+    ) -> None:
+        self._json = json_data
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._raise_error = raise_error
+        self.raise_called = False
+
+    def json(self) -> Any:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        self.raise_called = True
+        if self._raise_error:
+            raise httpx.HTTPStatusError("boom", request=MagicMock(), response=MagicMock())
+
+
+@pytest.fixture
+def client() -> PlaneClient:
+    """Construct a PlaneClient with its httpx client replaced by a mock."""
+    c = PlaneClient(
+        base_url="https://plane.example.com/",
+        api_token="tok",
+        workspace_slug="ws",
+        project_id="proj",
+    )
+    # Replace the real httpx client so no network or sleeps occur.
+    c._client = MagicMock()
+    return c
+
+
+def _make_request_returning(client: PlaneClient, response: FakeResponse) -> list[dict[str, Any]]:
+    """Patch ``_request`` to return ``response`` and record calls."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(method: str, url: str, **kwargs: Any) -> FakeResponse:
+        calls.append({"method": method, "url": url, "kwargs": kwargs})
+        return response
+
+    client._request = fake_request  # type: ignore[method-assign]
+    return calls
+
+
+# --------------------------------------------------------------------------
+# __init__ / close
+# --------------------------------------------------------------------------
+
+
+def test_init_strips_trailing_slash_and_sets_fields() -> None:
+    c = PlaneClient(
+        base_url="https://x.test/",
+        api_token="tok",
+        workspace_slug="ws",
+        project_id="proj",
+    )
+    assert c.base_url == "https://x.test"
+    assert c.workspace_slug == "ws"
+    assert c.project_id == "proj"
+    assert c._states_cache is None
+    assert c._labels_cache is None
+
+
+def test_close_delegates_to_client(client: PlaneClient) -> None:
+    result = client.close()
+    assert result is None
+    assert client._client.close.call_count == 1
+    client._client.close.assert_called_once_with()
+
+
+# --------------------------------------------------------------------------
+# fetch_issue / fetch_project
+# --------------------------------------------------------------------------
+
+
+def test_fetch_issue_hydrates_dict(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"id": "1", "labels": [{"name": "a"}]})
+    calls = _make_request_returning(client, resp)
+    out = client.fetch_issue("T1")
+    assert out["id"] == "1"
+    assert calls[0]["method"] == "GET"
+    assert "work-items/T1/" in calls[0]["url"]
+    assert calls[0]["kwargs"]["params"] == {"expand": "state"}
+    assert resp.raise_called
+
+
+def test_fetch_issue_non_dict_payload_returned_as_is(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=["not-a-dict"])
+    _make_request_returning(client, resp)
+    assert client.fetch_issue("T1") == ["not-a-dict"]
+
+
+def test_fetch_project(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"name": "p"})
+    calls = _make_request_returning(client, resp)
+    assert client.fetch_project() == {"name": "p"}
+    assert calls[0]["url"].endswith("projects/proj/")
+
+
+# --------------------------------------------------------------------------
+# list_issues
+# --------------------------------------------------------------------------
+
+
+def test_list_issues_list_payload(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=[{"id": "1"}, "skip", {"id": "2"}])
+    _make_request_returning(client, resp)
+    out = client.list_issues()
+    assert [i["id"] for i in out] == ["1", "2"]
+
+
+def test_list_issues_paginated_dict_payload(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": [{"id": "9"}, 5]})
+    _make_request_returning(client, resp)
+    out = client.list_issues()
+    assert [i["id"] for i in out] == ["9"]
+
+
+def test_list_issues_unexpected_payload_returns_empty(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"no_results": True})
+    _make_request_returning(client, resp)
+    assert client.list_issues() == []
+
+
+def test_list_issues_results_not_a_list(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": "nope"})
+    _make_request_returning(client, resp)
+    assert client.list_issues() == []
+
+
+# --------------------------------------------------------------------------
+# list_states (with caching)
+# --------------------------------------------------------------------------
+
+
+def test_list_states_list_payload_and_cache(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=[{"id": "s1", "name": "Todo"}, 7])
+    calls = _make_request_returning(client, resp)
+    out = client.list_states()
+    assert out == [{"id": "s1", "name": "Todo"}]
+    # Second call uses cache, no new request.
+    out2 = client.list_states()
+    assert out2 == out
+    assert out2 is not out  # returns a copy
+    assert len(calls) == 1
+
+
+def test_list_states_paginated(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": [{"id": "s2"}, "x"]})
+    _make_request_returning(client, resp)
+    assert client.list_states() == [{"id": "s2"}]
+
+
+def test_list_states_unexpected_returns_empty_and_no_cache(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data="weird")
+    _make_request_returning(client, resp)
+    assert client.list_states() == []
+    assert client._states_cache is None
+
+
+def test_list_states_dict_without_list_results(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": 123})
+    _make_request_returning(client, resp)
+    assert client.list_states() == []
+
+
+# --------------------------------------------------------------------------
+# list_labels (caching + force_refresh)
+# --------------------------------------------------------------------------
+
+
+def test_list_labels_list_and_cache_and_force_refresh(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=[{"id": "l1", "name": "bug"}])
+    calls = _make_request_returning(client, resp)
+    assert client.list_labels() == [{"id": "l1", "name": "bug"}]
+    # Cached.
+    client.list_labels()
+    assert len(calls) == 1
+    # force_refresh bypasses cache.
+    client.list_labels(force_refresh=True)
+    assert len(calls) == 2
+
+
+def test_list_labels_paginated(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": [{"id": "l2"}, None]})
+    _make_request_returning(client, resp)
+    assert client.list_labels() == [{"id": "l2"}]
+
+
+def test_list_labels_unexpected_returns_empty(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=42)
+    _make_request_returning(client, resp)
+    assert client.list_labels() == []
+
+
+def test_list_labels_dict_results_not_list(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": {}})
+    _make_request_returning(client, resp)
+    assert client.list_labels() == []
+
+
+# --------------------------------------------------------------------------
+# list_comments
+# --------------------------------------------------------------------------
+
+
+def test_list_comments_list(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data=[{"c": 1}, "x"])
+    _make_request_returning(client, resp)
+    assert client.list_comments("T1") == [{"c": 1}]
+
+
+def test_list_comments_paginated(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": [{"c": 2}, 0]})
+    _make_request_returning(client, resp)
+    assert client.list_comments("T1") == [{"c": 2}]
+
+
+def test_list_comments_unexpected(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data="nope")
+    _make_request_returning(client, resp)
+    assert client.list_comments("T1") == []
+
+
+def test_list_comments_dict_results_not_list(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"results": 1})
+    _make_request_returning(client, resp)
+    assert client.list_comments("T1") == []
+
+
+# --------------------------------------------------------------------------
+# to_board_task
+# --------------------------------------------------------------------------
+
+
+def _exec_description(extra: str = "") -> str:
+    return (
+        "## Goal\nDo the thing.\n\n## Execution\nrepo: myrepo\nbase_branch: main\n" + extra + "\n"
+    )
+
+
+def test_to_board_task_full(client: PlaneClient) -> None:
+    issue = {
+        "id": "ID1",
+        "project_id": "P9",
+        "name": "My Task",
+        "description": _exec_description("mode: goal\nopen_pr: true\n"),
+        "labels": [{"name": "x"}, {"name": "y"}, "bad"],
+        "state": {"name": "Running"},
+    }
+    bt = client.to_board_task(issue)
+    assert bt.task_id == "ID1"
+    assert bt.project_id == "P9"
+    assert bt.title == "My Task"
+    assert bt.status == "Running"
+    assert bt.labels == ["x", "y"]
+    assert bt.repo_key == "myrepo"
+    assert bt.base_branch == "main"
+    assert bt.open_pr is True
+    assert bt.goal_text == "Do the thing."
+
+
+def test_to_board_task_defaults_and_state_string(client: PlaneClient) -> None:
+    issue = {
+        "id": 5,
+        "description": _exec_description(),
+        "state": "CustomState",
+    }
+    bt = client.to_board_task(issue)
+    assert bt.task_id == "5"
+    assert bt.project_id == "proj"  # falls back to client.project_id
+    assert bt.title == "Untitled"
+    assert bt.status == "CustomState"
+    assert bt.allowed_paths == []
+    assert bt.validation_profile is None
+    assert bt.open_pr is False
+
+
+def test_to_board_task_state_none_unknown(client: PlaneClient) -> None:
+    issue = {"id": "z", "description": _exec_description(), "state": None}
+    bt = client.to_board_task(issue)
+    assert bt.status == "Unknown"
+
+
+def test_to_board_task_with_validation_profile_and_paths(client: PlaneClient) -> None:
+    desc = _exec_description("validation_profile: strict\nallowed_paths:\n  - a/b\n  - c/d\n")
+    issue = {"id": "1", "description": desc, "state": {"name": "Todo"}}
+    bt = client.to_board_task(issue)
+    assert bt.validation_profile == "strict"
+    assert bt.allowed_paths == ["a/b", "c/d"]
+
+
+# --------------------------------------------------------------------------
+# transition_issue
+# --------------------------------------------------------------------------
+
+
+def test_transition_issue_running_sets_start_date(client: PlaneClient) -> None:
+    client._states_cache = [{"id": "SID", "name": "Running"}]
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.transition_issue("T1", "Running")
+    body = calls[0]["kwargs"]["json"]
+    assert body["state"] == "SID"
+    assert "start_date" in body
+    assert "target_date" not in body
+    assert calls[0]["method"] == "PATCH"
+
+
+@pytest.mark.parametrize("state", ["Done", "Review", "In Review", "Blocked"])
+def test_transition_issue_terminal_sets_target_date(client: PlaneClient, state: str) -> None:
+    client._states_cache = []  # no resolution -> keeps raw name
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.transition_issue("T1", state)
+    body = calls[0]["kwargs"]["json"]
+    assert body["state"] == state
+    assert "target_date" in body
+    assert "start_date" not in body
+
+
+def test_transition_issue_other_state_no_dates(client: PlaneClient) -> None:
+    client._states_cache = []
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.transition_issue("T1", "Todo")
+    body = calls[0]["kwargs"]["json"]
+    assert body == {"state": "Todo"}
+
+
+# --------------------------------------------------------------------------
+# create_issue
+# --------------------------------------------------------------------------
+
+
+def test_create_issue_minimal(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"id": "new"})
+    calls = _make_request_returning(client, resp)
+    out = client.create_issue(name="N", description="hello world")
+    assert out == {"id": "new"}
+    body = calls[0]["kwargs"]["json"]
+    assert body["name"] == "N"
+    assert body["description_stripped"] == "hello world"
+    assert body["description_html"] == "<p>hello world</p>"
+    assert "state" not in body
+    assert "labels" not in body
+
+
+def test_create_issue_with_state_and_labels(client: PlaneClient) -> None:
+    client._states_cache = [{"id": "SID", "name": "Todo"}]
+    client._labels_cache = [{"id": "LID", "name": "bug"}]
+    resp = FakeResponse(json_data={"id": "new"})
+    calls = _make_request_returning(client, resp)
+    client.create_issue(name="N", description="d", state="Todo", label_names=["bug"])
+    body = calls[0]["kwargs"]["json"]
+    assert body["state"] == "SID"
+    assert body["labels"] == ["LID"]
+
+
+# --------------------------------------------------------------------------
+# update_issue_description / update_issue_labels
+# --------------------------------------------------------------------------
+
+
+def test_update_issue_description(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.update_issue_description("T1", "para one\n\npara two")
+    body = calls[0]["kwargs"]["json"]
+    assert body["description_stripped"] == "para one\n\npara two"
+    assert body["description_html"] == "<p>para one</p><p>para two</p>"
+    assert calls[0]["method"] == "PATCH"
+
+
+def test_update_issue_labels(client: PlaneClient) -> None:
+    client._labels_cache = [{"id": "LID", "name": "bug"}]
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.update_issue_labels("T1", ["bug"])
+    assert calls[0]["kwargs"]["json"] == {"labels": ["LID"]}
+
+
+# --------------------------------------------------------------------------
+# comment_issue
+# --------------------------------------------------------------------------
+
+
+def test_comment_issue(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={})
+    calls = _make_request_returning(client, resp)
+    client.comment_issue("T1", "Summary line\n- item")
+    body = calls[0]["kwargs"]["json"]
+    assert body["comment_html"] == "<p>Summary line</p><ul><li>item</li></ul>"
+    assert calls[0]["method"] == "POST"
+
+
+# --------------------------------------------------------------------------
+# _resolve_state_value
+# --------------------------------------------------------------------------
+
+
+def test_resolve_state_value_match_case_insensitive(client: PlaneClient) -> None:
+    client._states_cache = [{"id": "SID", "name": "In Progress"}]
+    assert client._resolve_state_value("  in progress ") == "SID"
+
+
+def test_resolve_state_value_no_match_returns_original(client: PlaneClient) -> None:
+    client._states_cache = [{"id": "SID", "name": "Todo"}]
+    assert client._resolve_state_value("Nonexistent") == "Nonexistent"
+
+
+# --------------------------------------------------------------------------
+# _ensure_label_ids / _create_label
+# --------------------------------------------------------------------------
+
+
+def test_ensure_label_ids_existing_only(client: PlaneClient) -> None:
+    client._labels_cache = [
+        {"id": "L1", "name": "Bug"},
+        {"id": "L2", "name": "feature"},
+        {"id": None, "name": "ignored"},  # filtered out (no id)
+        {"id": "L3", "name": ""},  # filtered out (no name)
+    ]
+    ids = client._ensure_label_ids(["bug", "FEATURE", "  ", ""])
+    assert ids == ["L1", "L2"]
+
+
+def test_ensure_label_ids_creates_missing(client: PlaneClient) -> None:
+    client._labels_cache = []
+    resp = FakeResponse(json_data={"id": "NEW", "name": "shiny"})
+    calls = _make_request_returning(client, resp)
+    ids = client._ensure_label_ids(["shiny", "shiny"])
+    # Created once, reused on the second occurrence.
+    assert ids == ["NEW", "NEW"]
+    create_calls = [c for c in calls if c["method"] == "POST"]
+    assert len(create_calls) == 1
+    assert create_calls[0]["kwargs"]["json"] == {"name": "shiny"}
+    # Cache was appended to.
+    assert {"id": "NEW", "name": "shiny"} in client._labels_cache
+
+
+def test_create_label_no_cache_append_when_cache_none(client: PlaneClient) -> None:
+    client._labels_cache = None
+    resp = FakeResponse(json_data={"id": "NEW", "name": "x"})
+    _make_request_returning(client, resp)
+    out = client._create_label("x")
+    assert out == {"id": "NEW", "name": "x"}
+    assert client._labels_cache is None
+
+
+def test_create_label_non_dict_response_not_appended(client: PlaneClient) -> None:
+    client._labels_cache = []
+    resp = FakeResponse(json_data="not-a-dict")
+    _make_request_returning(client, resp)
+    out = client._create_label("x")
+    assert out == "not-a-dict"
+    assert client._labels_cache == []
+
+
+# --------------------------------------------------------------------------
+# _hydrate_issue_labels
+# --------------------------------------------------------------------------
+
+
+def test_hydrate_labels_empty_or_missing(client: PlaneClient) -> None:
+    assert client._hydrate_issue_labels({"labels": []}) == {"labels": []}
+    assert client._hydrate_issue_labels({"labels": "x"}) == {"labels": "x"}
+    assert client._hydrate_issue_labels({}) == {}
+
+
+def test_hydrate_labels_already_dicts(client: PlaneClient) -> None:
+    issue = {"labels": [{"id": "1"}, {"id": "2"}]}
+    assert client._hydrate_issue_labels(issue) is issue
+
+
+def test_hydrate_labels_resolves_ids_from_cache(client: PlaneClient) -> None:
+    client._labels_cache = [{"id": "L1", "name": "bug"}, {"id": "L2", "name": "feat"}]
+    issue = {"labels": ["L1", "L2"]}
+    out = client._hydrate_issue_labels(issue)
+    assert out["labels"] == [
+        {"id": "L1", "name": "bug"},
+        {"id": "L2", "name": "feat"},
+    ]
+
+
+def test_hydrate_labels_force_refresh_for_unresolved(client: PlaneClient) -> None:
+    # First label_map call (cache) misses L9 -> triggers force_refresh fetch.
+    client._labels_cache = [{"id": "L1", "name": "bug"}]
+    resp = FakeResponse(json_data=[{"id": "L1", "name": "bug"}, {"id": "L9", "name": "new"}])
+    _make_request_returning(client, resp)
+    issue = {"labels": ["L1", "L9", "missing"]}
+    out = client._hydrate_issue_labels(issue)
+    assert out["labels"][0] == {"id": "L1", "name": "bug"}
+    assert out["labels"][1] == {"id": "L9", "name": "new"}
+    # Still unresolved -> raw kept.
+    assert out["labels"][2] == "missing"
+
+
+def test_hydrate_labels_mixed_dict_and_id(client: PlaneClient) -> None:
+    client._labels_cache = [{"id": "L1", "name": "bug"}]
+    issue = {"labels": [{"id": "X", "name": "inline"}, "L1"]}
+    out = client._hydrate_issue_labels(issue)
+    assert out["labels"][0] == {"id": "X", "name": "inline"}
+    assert out["labels"][1] == {"id": "L1", "name": "bug"}
+
+
+# --------------------------------------------------------------------------
+# _request — retry logic
+# --------------------------------------------------------------------------
+
+
+def _real_request_client() -> PlaneClient:
+    c = PlaneClient(
+        base_url="https://plane.example.com",
+        api_token="tok",
+        workspace_slug="ws",
+        project_id="proj",
+    )
+    c._client = MagicMock()
+    return c
+
+
+def test_request_success_first_try(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _real_request_client()
+    ok = MagicMock(status_code=200)
+    c._client.request.return_value = ok
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.client.time.sleep", lambda s: slept.append(s)
+    )
+    assert c._request("GET", "/x") is ok
+    assert slept == []
+    c._client.request.assert_called_once()
+
+
+def test_request_retries_on_connect_error_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _real_request_client()
+    ok = MagicMock(status_code=200)
+    c._client.request.side_effect = [httpx.ConnectError("nope"), ok]
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.client.time.sleep", lambda s: slept.append(s)
+    )
+    assert c._request("GET", "/x") is ok
+    assert slept == [2]  # attempt 1 backoff
+
+
+def test_request_connect_error_exhausts_and_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _real_request_client()
+    c._client.request.side_effect = httpx.TimeoutException("timeout")
+    monkeypatch.setattr("operations_center.adapters.plane.client.time.sleep", lambda s: None)
+    with pytest.raises(httpx.TimeoutException):
+        c._request("GET", "/x")
+    assert c._client.request.call_count == 4
+
+
+def test_request_429_with_retry_after_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _real_request_client()
+    r429 = MagicMock(status_code=429, headers={"Retry-After": "7"})
+    ok = MagicMock(status_code=200)
+    c._client.request.side_effect = [r429, ok]
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.client.time.sleep", lambda s: slept.append(s)
+    )
+    assert c._request("GET", "/x") is ok
+    assert slept == [7]
+
+
+def test_request_429_non_numeric_retry_after_uses_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _real_request_client()
+    r429 = MagicMock(status_code=429, headers={"Retry-After": "soon"})
+    ok = MagicMock(status_code=200)
+    c._client.request.side_effect = [r429, ok]
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.client.time.sleep", lambda s: slept.append(s)
+    )
+    assert c._request("GET", "/x") is ok
+    assert slept == [2]  # attempt 1 * 2
+
+
+def test_request_429_exhausts_returns_last_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _real_request_client()
+    r429 = MagicMock(status_code=429, headers={})
+    c._client.request.return_value = r429
+    monkeypatch.setattr("operations_center.adapters.plane.client.time.sleep", lambda s: None)
+    assert c._request("GET", "/x") is r429
+    assert c._client.request.call_count == 4
+
+
+def test_request_5xx_retried_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _real_request_client()
+    r503 = MagicMock(status_code=503, headers={})
+    ok = MagicMock(status_code=200)
+    c._client.request.side_effect = [r503, ok]
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.client.time.sleep", lambda s: slept.append(s)
+    )
+    assert c._request("GET", "/x") is ok
+    assert slept == [2]
+
+
+def test_request_5xx_exhausts_returns_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _real_request_client()
+    r502 = MagicMock(status_code=502, headers={})
+    c._client.request.return_value = r502
+    monkeypatch.setattr("operations_center.adapters.plane.client.time.sleep", lambda s: None)
+    # On the final attempt, the 5xx branch is skipped and the response returns.
+    assert c._request("GET", "/x") is r502
+    assert c._client.request.call_count == 4
+
+
+def test_request_non_retryable_4xx_returned_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _real_request_client()
+    r404 = MagicMock(status_code=404, headers={})
+    c._client.request.return_value = r404
+    monkeypatch.setattr("operations_center.adapters.plane.client.time.sleep", lambda s: None)
+    assert c._request("GET", "/x") is r404
+    c._client.request.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# _render_comment_html
+# --------------------------------------------------------------------------
+
+
+def test_render_comment_html_empty() -> None:
+    assert PlaneClient._render_comment_html("   \n  ") == "<p>(no summary)</p>"
+
+
+def test_render_comment_html_header_only() -> None:
+    assert PlaneClient._render_comment_html("Just a header") == "<p>Just a header</p>"
+
+
+def test_render_comment_html_with_items_and_escaping() -> None:
+    out = PlaneClient._render_comment_html("Head <x>\n- a & b\n  ignored\n- c")
+    assert out == "<p>Head &lt;x&gt;</p><ul><li>a &amp; b</li><li>c</li></ul>"
+
+
+# --------------------------------------------------------------------------
+# _render_text_html
+# --------------------------------------------------------------------------
+
+
+def test_render_text_html_empty() -> None:
+    assert PlaneClient._render_text_html("   ") == "<p></p>"
+
+
+def test_render_text_html_multiline_blocks() -> None:
+    out = PlaneClient._render_text_html("line1\nline<2>\n\nblock2")
+    assert out == "<p>line1<br/>line&lt;2&gt;</p><p>block2</p>"
+
+
+# --------------------------------------------------------------------------
+# _issue_description_text
+# --------------------------------------------------------------------------
+
+
+def test_issue_description_text_prefers_description() -> None:
+    assert PlaneClient._issue_description_text({"description": "raw"}) == "raw"
+
+
+def test_issue_description_text_uses_stripped() -> None:
+    assert PlaneClient._issue_description_text({"description_stripped": "stripped"}) == "stripped"
+
+
+def test_issue_description_text_falls_back_to_html() -> None:
+    out = PlaneClient._issue_description_text(
+        {"description": "  ", "description_html": "<p>hi</p>"}
+    )
+    assert out == "hi"
+
+
+def test_issue_description_text_empty() -> None:
+    assert PlaneClient._issue_description_text({}) == ""
+    assert PlaneClient._issue_description_text({"description_html": "   "}) == ""
+
+
+# --------------------------------------------------------------------------
+# _html_to_task_text
+# --------------------------------------------------------------------------
+
+
+def test_html_to_task_text_headings_lists_breaks() -> None:
+    html_body = (
+        "<h2>Title</h2><ul><li>one</li><li>two</li></ul><p>first<br/>second</p><div>boxed</div>"
+    )
+    out = PlaneClient._html_to_task_text(html_body)
+    assert "## Title" in out
+    assert "- one" in out
+    assert "- two" in out
+    assert "first" in out
+    assert "second" in out
+    assert "boxed" in out
+    assert "<" not in out  # all tags stripped
+
+
+def test_html_to_task_text_unescapes_entities() -> None:
+    out = PlaneClient._html_to_task_text("<p>a &amp; b</p>")
+    assert out == "a & b"
+
+
+def test_html_to_task_text_collapses_blank_lines() -> None:
+    out = PlaneClient._html_to_task_text("<p>a</p><p></p><p></p><p>b</p>")
+    assert "\n\n\n" not in out
+
+
+# --------------------------------------------------------------------------
+# raise_for_status propagation
+# --------------------------------------------------------------------------
+
+
+def test_fetch_issue_raises_on_http_error(client: PlaneClient) -> None:
+    resp = FakeResponse(json_data={"id": "1"}, raise_error=True)
+    _make_request_returning(client, resp)
+    with pytest.raises(httpx.HTTPStatusError):
+        client.fetch_issue("T1")

--- a/tests/unit/adapters/test_github_pr_cov.py
+++ b/tests/unit/adapters/test_github_pr_cov.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from unittest import mock
+
+import httpx
+import pytest
+
+from operations_center.adapters import github_pr
+from operations_center.adapters.github_pr import GitHubPRClient
+
+
+def _make_response(
+    *,
+    status_code: int = 200,
+    json_data=None,
+    text: str | None = None,
+    headers: dict | None = None,
+):
+    """Build a mock httpx.Response-like object."""
+    resp = mock.Mock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.json.return_value = json_data
+    if text is not None:
+        resp.text = text
+
+    def _raise():
+        if status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=mock.Mock(), response=resp)
+
+    resp.raise_for_status.side_effect = _raise
+    return resp
+
+
+@pytest.fixture
+def client():
+    return GitHubPRClient("tok123")
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+def test_init_sets_headers():
+    c = GitHubPRClient("abc")
+    assert c._headers["Authorization"] == "Bearer abc"
+    assert c._headers["Accept"] == "application/vnd.github+json"
+    assert c._headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+# ---------------------------------------------------------------------------
+# _request
+# ---------------------------------------------------------------------------
+def test_request_happy_path_sets_defaults(client):
+    resp = _make_response(status_code=200, json_data={})
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp) as req:
+        out = client._request("GET", "http://x")
+    assert out is resp
+    _, kwargs = req.call_args
+    assert kwargs["timeout"] == 30
+    assert kwargs["follow_redirects"] is True
+    assert kwargs["headers"] == client._headers
+
+
+def test_request_respects_caller_overrides(client):
+    resp = _make_response(status_code=200)
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp) as req:
+        client._request("GET", "http://x", timeout=5, follow_redirects=False)
+    _, kwargs = req.call_args
+    assert kwargs["timeout"] == 5
+    assert kwargs["follow_redirects"] is False
+
+
+def test_request_low_quota_warns(client, caplog):
+    resp = _make_response(
+        status_code=200,
+        headers={"X-RateLimit-Remaining": "3", "X-RateLimit-Reset": "12345"},
+    )
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp):
+        with caplog.at_level("WARNING"):
+            client._request("GET", "http://x")
+    assert "github_rate_limit_low" in caplog.text
+
+
+def test_request_high_quota_no_warn(client, caplog):
+    resp = _make_response(status_code=200, headers={"X-RateLimit-Remaining": "500"})
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp):
+        with caplog.at_level("WARNING"):
+            client._request("GET", "http://x")
+    assert "github_rate_limit_low" not in caplog.text
+
+
+def test_request_invalid_remaining_header_ignored(client):
+    resp = _make_response(status_code=200, headers={"X-RateLimit-Remaining": "not-a-number"})
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp):
+        out = client._request("GET", "http://x")
+    assert out is resp
+
+
+def test_request_no_remaining_header(client):
+    resp = _make_response(status_code=200, headers={})
+    with mock.patch.object(github_pr.httpx, "request", return_value=resp):
+        out = client._request("GET", "http://x")
+    assert out is resp
+
+
+def test_request_429_retries_then_succeeds(client, caplog):
+    r429 = _make_response(status_code=429, headers={"Retry-After": "1"})
+    r200 = _make_response(status_code=200, json_data={})
+    seq = [r429, r200]
+    with (
+        mock.patch.object(github_pr.httpx, "request", side_effect=seq),
+        mock.patch.object(github_pr.time, "sleep") as sleeper,
+    ):
+        with caplog.at_level("WARNING"):
+            out = client._request("GET", "http://x")
+    assert out is r200
+    sleeper.assert_called_once_with(1)
+    assert "github_rate_limited" in caplog.text
+
+
+def test_request_429_invalid_retry_after_uses_default(client):
+    r429 = _make_response(status_code=429, headers={"Retry-After": "soon"})
+    r200 = _make_response(status_code=200)
+    with (
+        mock.patch.object(github_pr.httpx, "request", side_effect=[r429, r200]),
+        mock.patch.object(github_pr.time, "sleep") as sleeper,
+    ):
+        client._request("GET", "http://x")
+    sleeper.assert_called_once_with(github_pr._GH_RATE_LIMIT_DEFAULT_BACKOFF_SECONDS)
+
+
+def test_request_429_missing_retry_after_uses_default(client):
+    r429 = _make_response(status_code=429, headers={})
+    r200 = _make_response(status_code=200)
+    with (
+        mock.patch.object(github_pr.httpx, "request", side_effect=[r429, r200]),
+        mock.patch.object(github_pr.time, "sleep") as sleeper,
+    ):
+        client._request("GET", "http://x")
+    sleeper.assert_called_once_with(github_pr._GH_RATE_LIMIT_DEFAULT_BACKOFF_SECONDS)
+
+
+def test_request_429_exhausts_retries_returns_last(client):
+    r429 = _make_response(status_code=429, headers={"Retry-After": "1"})
+    # max retries = 3, so 4 attempts total; all 429
+    with (
+        mock.patch.object(github_pr.httpx, "request", return_value=r429) as req,
+        mock.patch.object(github_pr.time, "sleep") as sleeper,
+    ):
+        out = client._request("GET", "http://x")
+    assert out is r429
+    assert req.call_count == github_pr._GH_RATE_LIMIT_MAX_RETRIES + 1
+    assert sleeper.call_count == github_pr._GH_RATE_LIMIT_MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# owner_repo_from_clone_url
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/owner/repo.git", ("owner", "repo")),
+        ("https://github.com/owner/repo", ("owner", "repo")),
+        ("git@github.com:owner/repo.git", ("owner", "repo")),
+        ("git@github.com:owner/repo", ("owner", "repo")),
+    ],
+)
+def test_owner_repo_from_clone_url_ok(url, expected):
+    assert GitHubPRClient.owner_repo_from_clone_url(url) == expected
+
+
+def test_owner_repo_from_clone_url_invalid():
+    with pytest.raises(ValueError, match="Cannot parse owner/repo"):
+        GitHubPRClient.owner_repo_from_clone_url("nonsense")
+
+
+# ---------------------------------------------------------------------------
+# create_pr / get_pr / merge_pr / delete_branch
+# ---------------------------------------------------------------------------
+def test_create_pr(client):
+    resp = _make_response(status_code=200, json_data={"number": 7})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        out = client.create_pr("o", "r", head="h", base="b", title="t", body="bod")
+    assert out == {"number": 7}
+    method, url = req.call_args[0]
+    assert method == "POST"
+    assert url.endswith("/repos/o/r/pulls")
+    assert req.call_args[1]["json"] == {
+        "title": "t",
+        "head": "h",
+        "base": "b",
+        "body": "bod",
+    }
+
+
+def test_get_pr(client):
+    resp = _make_response(status_code=200, json_data={"id": 1})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        out = client.get_pr("o", "r", 5)
+    assert out == {"id": 1}
+    assert req.call_args[0][0] == "GET"
+    assert req.call_args[0][1].endswith("/repos/o/r/pulls/5")
+
+
+def test_get_pr_raises_on_error(client):
+    resp = _make_response(status_code=404)
+    with mock.patch.object(client, "_request", return_value=resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get_pr("o", "r", 5)
+
+
+def test_merge_pr_default_method(client):
+    resp = _make_response(status_code=200, json_data={"merged": True})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        out = client.merge_pr("o", "r", 9)
+    assert out == {"merged": True}
+    assert req.call_args[1]["json"] == {"merge_method": "squash"}
+    assert req.call_args[0][1].endswith("/repos/o/r/pulls/9/merge")
+
+
+def test_merge_pr_custom_method(client):
+    resp = _make_response(status_code=200, json_data={})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        client.merge_pr("o", "r", 9, merge_method="rebase")
+    assert req.call_args[1]["json"] == {"merge_method": "rebase"}
+
+
+def test_delete_branch(client):
+    resp = _make_response(status_code=204)
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.delete_branch("o", "r", "feat") is None
+    method, url = req.call_args[0]
+    assert method == "DELETE"
+    assert url.endswith("/git/refs/heads/feat")
+
+
+# ---------------------------------------------------------------------------
+# simple GET list/dict endpoints
+# ---------------------------------------------------------------------------
+def test_get_pr_reactions(client):
+    resp = _make_response(status_code=200, json_data=[{"content": "+1"}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.get_pr_reactions("o", "r", 1) == [{"content": "+1"}]
+    assert req.call_args[0][1].endswith("/issues/1/reactions")
+
+
+def test_list_pr_comments(client):
+    resp = _make_response(status_code=200, json_data=[{"body": "hi"}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.list_pr_comments("o", "r", 1) == [{"body": "hi"}]
+    assert req.call_args[0][1].endswith("/issues/1/comments")
+
+
+def test_list_pr_review_comments(client):
+    resp = _make_response(status_code=200, json_data=[{"body": "x"}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.list_pr_review_comments("o", "r", 1) == [{"body": "x"}]
+    assert req.call_args[0][1].endswith("/pulls/1/comments")
+
+
+def test_get_comment_reactions(client):
+    resp = _make_response(status_code=200, json_data=[{"content": "heart"}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.get_comment_reactions("o", "r", 42) == [{"content": "heart"}]
+    assert req.call_args[0][1].endswith("/issues/comments/42/reactions")
+
+
+def test_update_pr_description(client):
+    resp = _make_response(status_code=200, json_data={"body": "new"})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        out = client.update_pr_description("o", "r", 3, "new")
+    assert out == {"body": "new"}
+    method, url = req.call_args[0]
+    assert method == "PATCH"
+    assert url.endswith("/pulls/3")
+    assert req.call_args[1]["json"] == {"body": "new"}
+
+
+def test_post_comment(client):
+    resp = _make_response(status_code=200, json_data={"id": 11})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        out = client.post_comment("o", "r", 3, "hello")
+    assert out == {"id": 11}
+    method, url = req.call_args[0]
+    assert method == "POST"
+    assert url.endswith("/issues/3/comments")
+    assert req.call_args[1]["json"] == {"body": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# get_check_runs
+# ---------------------------------------------------------------------------
+def test_get_check_runs_returns_list(client):
+    resp = _make_response(status_code=200, json_data={"check_runs": [{"name": "ci"}]})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.get_check_runs("o", "r", "sha") == [{"name": "ci"}]
+    assert req.call_args[1]["params"] == {"per_page": 100}
+    assert req.call_args[0][1].endswith("/commits/sha/check-runs")
+
+
+def test_get_check_runs_missing_key(client):
+    resp = _make_response(status_code=200, json_data={})
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.get_check_runs("o", "r", "sha") == []
+
+
+# ---------------------------------------------------------------------------
+# get_failed_checks
+# ---------------------------------------------------------------------------
+def test_get_failed_checks_fetches_pr_when_none(client):
+    pr = {"head": {"sha": "abc"}}
+    with (
+        mock.patch.object(client, "get_pr", return_value=pr) as getpr,
+        mock.patch.object(
+            client,
+            "get_check_runs",
+            return_value=[
+                {"id": 1, "name": "lint", "conclusion": "failure"},
+            ],
+        ),
+    ):
+        out = client.get_failed_checks("o", "r", 1)
+    getpr.assert_called_once_with("o", "r", 1)
+    assert out == ["lint: failure"]
+
+
+def test_get_failed_checks_no_head_sha(client):
+    out = client.get_failed_checks("o", "r", 1, pr_data={"head": {}})
+    assert out == []
+
+
+def test_get_failed_checks_head_none(client):
+    out = client.get_failed_checks("o", "r", 1, pr_data={"head": None})
+    assert out == []
+
+
+def test_get_failed_checks_check_runs_exception(client):
+    with mock.patch.object(client, "get_check_runs", side_effect=RuntimeError("boom")):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == []
+
+
+def test_get_failed_checks_uses_output_title(client):
+    runs = [
+        {
+            "id": 1,
+            "name": "build",
+            "conclusion": "failure",
+            "output": {"title": "compile error"},
+        }
+    ]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == ["build: compile error"]
+
+
+def test_get_failed_checks_output_none_falls_back_to_conclusion(client):
+    runs = [{"id": 1, "name": "test", "conclusion": "timed_out", "output": None}]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == ["test: timed_out"]
+
+
+def test_get_failed_checks_dedup_keeps_latest(client):
+    runs = [
+        {"id": 1, "name": "ci", "conclusion": "failure"},
+        {"id": 5, "name": "ci", "conclusion": "success"},
+    ]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    # latest (id=5) is success -> no failures
+    assert out == []
+
+
+def test_get_failed_checks_ignored(client):
+    runs = [
+        {"id": 1, "name": "flaky-base-check", "conclusion": "failure"},
+        {"id": 2, "name": "real", "conclusion": "cancelled"},
+    ]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks(
+            "o",
+            "r",
+            1,
+            pr_data={"head": {"sha": "x"}},
+            ignored_checks=["flaky"],
+        )
+    assert out == ["real: cancelled"]
+
+
+def test_get_failed_checks_success_not_failed(client):
+    runs = [{"id": 1, "name": "ci", "conclusion": "success"}]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == []
+
+
+def test_get_failed_checks_unnamed_run(client):
+    runs = [{"id": 1, "conclusion": "failure"}]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_failed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == ["unknown: failure"]
+
+
+# ---------------------------------------------------------------------------
+# list_open_prs
+# ---------------------------------------------------------------------------
+def test_list_open_prs(client):
+    resp = _make_response(status_code=200, json_data=[{"number": 1}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.list_open_prs("o", "r") == [{"number": 1}]
+    assert req.call_args[1]["params"] == {"state": "open", "per_page": 100}
+
+
+# ---------------------------------------------------------------------------
+# list_pr_files
+# ---------------------------------------------------------------------------
+def test_list_pr_files_ok(client):
+    resp = _make_response(
+        status_code=200,
+        json_data=[
+            {"filename": "a.py"},
+            {"filename": "b.py"},
+            {"no_filename": True},
+            "not-a-dict",
+        ],
+    )
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.list_pr_files("o", "r", 1) == ["a.py", "b.py"]
+
+
+def test_list_pr_files_error_returns_empty(client):
+    with mock.patch.object(client, "_request", side_effect=RuntimeError):
+        assert client.list_pr_files("o", "r", 1) == []
+
+
+def test_list_pr_files_raise_for_status_error(client):
+    resp = _make_response(status_code=500)
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.list_pr_files("o", "r", 1) == []
+
+
+# ---------------------------------------------------------------------------
+# get_pr_diff / _pr_diff_too_large_summary
+# ---------------------------------------------------------------------------
+def test_get_pr_diff_ok(client):
+    resp = _make_response(status_code=200, text="diff --git")
+    with mock.patch.object(github_pr.httpx, "get", return_value=resp) as g:
+        assert client.get_pr_diff("o", "r", 1) == "diff --git"
+    _, kwargs = g.call_args
+    assert kwargs["headers"]["Accept"] == "application/vnd.github.v3.diff"
+
+
+def test_get_pr_diff_406_falls_back(client):
+    resp = _make_response(status_code=406)
+    with (
+        mock.patch.object(github_pr.httpx, "get", return_value=resp),
+        mock.patch.object(client, "_pr_diff_too_large_summary", return_value="SUMMARY") as summ,
+    ):
+        assert client.get_pr_diff("o", "r", 1) == "SUMMARY"
+    summ.assert_called_once_with("o", "r", 1)
+
+
+def test_get_pr_diff_http_error_returns_empty(client):
+    resp = _make_response(status_code=500)
+    with mock.patch.object(github_pr.httpx, "get", return_value=resp):
+        assert client.get_pr_diff("o", "r", 1) == ""
+
+
+def test_get_pr_diff_exception_returns_empty(client):
+    with mock.patch.object(github_pr.httpx, "get", side_effect=httpx.ConnectError("x")):
+        assert client.get_pr_diff("o", "r", 1) == ""
+
+
+def test_pr_diff_too_large_summary_ok(client):
+    files = [
+        {
+            "status": "added",
+            "filename": "a.py",
+            "additions": 5,
+            "deletions": 0,
+        },
+        {"filename": "b.py"},  # defaults
+        "not-a-dict",
+    ]
+    resp = _make_response(status_code=200, json_data=files)
+    with mock.patch.object(client, "_request", return_value=resp):
+        out = client._pr_diff_too_large_summary("o", "r", 1)
+    assert "DIFF_TOO_LARGE" in out
+    assert "showing 3 changed files" in out
+    assert "added    a.py (+5/-0)" in out
+    assert "modified b.py (+0/-0)" in out
+
+
+def test_pr_diff_too_large_summary_error_returns_empty(client):
+    with mock.patch.object(client, "_request", side_effect=RuntimeError):
+        assert client._pr_diff_too_large_summary("o", "r", 1) == ""
+
+
+def test_pr_diff_too_large_summary_raise_for_status_error(client):
+    resp = _make_response(status_code=500)
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client._pr_diff_too_large_summary("o", "r", 1) == ""
+
+
+# ---------------------------------------------------------------------------
+# get_mergeable
+# ---------------------------------------------------------------------------
+def test_get_mergeable_true(client):
+    with mock.patch.object(client, "get_pr", return_value={"mergeable": True}):
+        assert client.get_mergeable("o", "r", 1) is True
+
+
+def test_get_mergeable_false(client):
+    with mock.patch.object(client, "get_pr", return_value={"mergeable": False}):
+        assert client.get_mergeable("o", "r", 1) is False
+
+
+def test_get_mergeable_none_while_computing(client):
+    with mock.patch.object(client, "get_pr", return_value={"mergeable": None}):
+        assert client.get_mergeable("o", "r", 1) is None
+
+
+def test_get_mergeable_exception(client):
+    with mock.patch.object(client, "get_pr", side_effect=RuntimeError):
+        assert client.get_mergeable("o", "r", 1) is None
+
+
+# ---------------------------------------------------------------------------
+# close_pr
+# ---------------------------------------------------------------------------
+def test_close_pr(client):
+    resp = _make_response(status_code=200, json_data={"state": "closed"})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.close_pr("o", "r", 1) == {"state": "closed"}
+    method, url = req.call_args[0]
+    assert method == "PATCH"
+    assert req.call_args[1]["json"] == {"state": "closed"}
+
+
+# ---------------------------------------------------------------------------
+# list_pr_reviews / pr_has_changes_requested
+# ---------------------------------------------------------------------------
+def test_list_pr_reviews(client):
+    resp = _make_response(status_code=200, json_data=[{"state": "APPROVED"}])
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.list_pr_reviews("o", "r", 1) == [{"state": "APPROVED"}]
+    assert req.call_args[1]["params"] == {"per_page": 100}
+
+
+def test_pr_has_changes_requested_true(client):
+    reviews = [{"state": "APPROVED"}, {"state": "CHANGES_REQUESTED"}]
+    with mock.patch.object(client, "list_pr_reviews", return_value=reviews):
+        assert client.pr_has_changes_requested("o", "r", 1) is True
+
+
+def test_pr_has_changes_requested_false(client):
+    reviews = [{"state": "APPROVED"}]
+    with mock.patch.object(client, "list_pr_reviews", return_value=reviews):
+        assert client.pr_has_changes_requested("o", "r", 1) is False
+
+
+def test_pr_has_changes_requested_exception(client):
+    with mock.patch.object(client, "list_pr_reviews", side_effect=RuntimeError):
+        assert client.pr_has_changes_requested("o", "r", 1) is False
+
+
+# ---------------------------------------------------------------------------
+# get_branch_head
+# ---------------------------------------------------------------------------
+def test_get_branch_head_ok(client):
+    resp = _make_response(status_code=200, json_data={"commit": {"sha": "deadbeef"}})
+    with mock.patch.object(client, "_request", return_value=resp) as req:
+        assert client.get_branch_head("o", "r", "main") == "deadbeef"
+    assert req.call_args[0][1].endswith("/branches/main")
+
+
+def test_get_branch_head_empty_sha_returns_none(client):
+    resp = _make_response(status_code=200, json_data={"commit": {"sha": ""}})
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.get_branch_head("o", "r", "main") is None
+
+
+def test_get_branch_head_no_commit_returns_none(client):
+    resp = _make_response(status_code=200, json_data={"commit": None})
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.get_branch_head("o", "r", "main") is None
+
+
+def test_get_branch_head_exception(client):
+    with mock.patch.object(client, "_request", side_effect=RuntimeError):
+        assert client.get_branch_head("o", "r", "main") is None
+
+
+def test_get_branch_head_raise_for_status_error(client):
+    resp = _make_response(status_code=404)
+    with mock.patch.object(client, "_request", return_value=resp):
+        assert client.get_branch_head("o", "r", "main") is None
+
+
+# ---------------------------------------------------------------------------
+# has_thumbs_up
+# ---------------------------------------------------------------------------
+def test_has_thumbs_up_true():
+    assert GitHubPRClient.has_thumbs_up([{"content": "-1"}, {"content": "+1"}])
+
+
+def test_has_thumbs_up_false():
+    assert not GitHubPRClient.has_thumbs_up([{"content": "heart"}])
+
+
+def test_has_thumbs_up_empty():
+    assert not GitHubPRClient.has_thumbs_up([])
+
+
+# ---------------------------------------------------------------------------
+# create_and_merge
+# ---------------------------------------------------------------------------
+def test_create_and_merge(client):
+    pr = {"number": 12, "html_url": "https://gh/pr/12"}
+    with (
+        mock.patch.object(client, "create_pr", return_value=pr) as create,
+        mock.patch.object(client, "merge_pr") as merge,
+        mock.patch.object(client, "delete_branch") as delete,
+    ):
+        url = client.create_and_merge("o", "r", head="h", base="b", title="t", body="bod")
+    assert url == "https://gh/pr/12"
+    create.assert_called_once_with("o", "r", head="h", base="b", title="t", body="bod")
+    merge.assert_called_once_with("o", "r", 12, merge_method="squash")
+    delete.assert_called_once_with("o", "r", "h")
+
+
+def test_create_and_merge_custom_method(client):
+    pr = {"number": 1, "html_url": "u"}
+    with (
+        mock.patch.object(client, "create_pr", return_value=pr),
+        mock.patch.object(client, "merge_pr") as merge,
+        mock.patch.object(client, "delete_branch"),
+    ):
+        client.create_and_merge("o", "r", head="h", base="b", title="t", merge_method="merge")
+    merge.assert_called_once_with("o", "r", 1, merge_method="merge")

--- a/tests/unit/application/__init__.py
+++ b/tests/unit/application/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/application/test_task_parser_cov.py
+++ b/tests/unit/application/test_task_parser_cov.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import pytest
+
+from operations_center.application.task_parser import TaskParser
+from operations_center.domain import ParsedTaskBody
+
+
+@pytest.fixture
+def parser() -> TaskParser:
+    return TaskParser()
+
+
+# --------------------------------------------------------------------------- #
+# Happy path                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_full_description_with_all_sections(parser: TaskParser) -> None:
+    description = (
+        "## Goal\n"
+        "Do the thing properly.\n\n"
+        "## Execution\n"
+        "repo: myrepo\n"
+        "mode: goal\n"
+        "base_branch: develop\n\n"
+        "## Constraints\n"
+        "Be careful.\n"
+    )
+    result = parser.parse(description)
+    assert isinstance(result, ParsedTaskBody)
+    assert result.goal_text == "Do the thing properly."
+    assert result.constraints_text == "Be careful."
+    assert result.execution_metadata["repo"] == "myrepo"
+    assert result.execution_metadata["mode"] == "goal"
+    assert result.execution_metadata["base_branch"] == "develop"
+    assert result.execution_metadata["open_pr"] is False
+    assert result.execution_metadata["allowed_paths"] == []
+
+
+def test_default_mode_and_base_branch_applied(parser: TaskParser) -> None:
+    description = "## Goal\nText\n\n## Execution\nrepo: r1\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["mode"] == "goal"
+    assert result.execution_metadata["base_branch"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# Label-derived repo                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_repo_from_labels_when_no_execution_section(parser: TaskParser) -> None:
+    description = "## Goal\nJust a goal."
+    result = parser.parse(description, labels=["repo: labelrepo"])
+    assert result.execution_metadata["repo"] == "labelrepo"
+    assert result.execution_metadata["mode"] == "goal"
+
+
+def test_label_repo_fills_missing_repo_in_execution(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nmode: goal\n"
+    result = parser.parse(description, labels=["repo:fromlabel"])
+    assert result.execution_metadata["repo"] == "fromlabel"
+
+
+def test_execution_repo_takes_precedence_over_label(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: execrepo\n"
+    result = parser.parse(description, labels=["repo: labelrepo"])
+    assert result.execution_metadata["repo"] == "execrepo"
+
+
+def test_repo_from_labels_case_insensitive_prefix(parser: TaskParser) -> None:
+    description = "## Goal\nG"
+    result = parser.parse(description, labels=["REPO: caps"])
+    assert result.execution_metadata["repo"] == "caps"
+
+
+def test_repo_from_labels_skips_empty_value(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\n"
+    # Empty repo label is ignored; execution repo wins.
+    result = parser.parse(description, labels=["repo:   ", "other:x"])
+    assert result.execution_metadata["repo"] == "r"
+
+
+def test_repo_from_labels_returns_none_for_unrelated_labels(parser: TaskParser) -> None:
+    description = "## Goal\nG"
+    with pytest.raises(ValueError, match="Missing '## Execution' section"):
+        parser.parse(description, labels=["priority:high"])
+
+
+# --------------------------------------------------------------------------- #
+# Error paths                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_execution_and_no_label_raises(parser: TaskParser) -> None:
+    with pytest.raises(ValueError, match="Missing '## Execution' section"):
+        parser.parse("## Goal\nG")
+
+
+def test_empty_description_raises(parser: TaskParser) -> None:
+    with pytest.raises(ValueError, match="Missing '## Execution' section"):
+        parser.parse("")
+
+
+def test_none_description_raises(parser: TaskParser) -> None:
+    with pytest.raises(ValueError, match="Missing '## Execution' section"):
+        parser.parse(None)  # type: ignore[arg-type]
+
+
+def test_non_dict_yaml_in_execution_raises(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\n- just\n- a\n- list\n"
+    with pytest.raises(ValueError, match="must be valid key/value YAML"):
+        parser.parse(description)
+
+
+def test_execution_yaml_resolving_to_none_uses_label_repo(parser: TaskParser) -> None:
+    # A comment-only execution body -> yaml.safe_load returns None -> {} .
+    description = "## Goal\nG\n\n## Execution\n# only a comment\n"
+    result = parser.parse(description, labels=["repo:lbl"])
+    assert result.execution_metadata["repo"] == "lbl"
+
+
+def test_execution_yaml_none_and_no_label_missing_repo(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\n# only a comment\n"
+    with pytest.raises(ValueError, match="Missing execution metadata fields: repo"):
+        parser.parse(description)
+
+
+def test_missing_required_repo_field_raises(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nmode: goal\n"
+    with pytest.raises(ValueError, match="Missing execution metadata fields: repo"):
+        parser.parse(description)
+
+
+def test_missing_goal_raises(parser: TaskParser) -> None:
+    description = "## Execution\nrepo: r\n"
+    with pytest.raises(ValueError, match="Missing goal text"):
+        parser.parse(description)
+
+
+def test_unsupported_mode_raises(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nmode: bogus\n"
+    with pytest.raises(ValueError, match="Unsupported execution mode 'bogus'"):
+        parser.parse(description)
+
+
+# --------------------------------------------------------------------------- #
+# Goal fallback logic                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_goal_fallback_strips_execution_block_with_trailing_content(
+    parser: TaskParser,
+) -> None:
+    # No ## Goal section; ## Execution present with a following ## section.
+    description = "Intro paragraph.\n\n## Execution\nrepo: r\n\n## Notes\ntrailing note\n"
+    result = parser.parse(description)
+    assert "Intro paragraph." in result.goal_text
+    assert "## Notes" in result.goal_text
+    assert "trailing note" in result.goal_text
+    assert "repo: r" not in result.goal_text
+
+
+def test_goal_fallback_strips_execution_block_to_end(parser: TaskParser) -> None:
+    # No ## Goal, ## Execution is the last section.
+    description = "Lead text here.\n\n## Execution\nrepo: r\n"
+    result = parser.parse(description)
+    assert result.goal_text == "Lead text here."
+
+
+def test_goal_fallback_when_no_goal_and_no_exec_body_but_label_repo(
+    parser: TaskParser,
+) -> None:
+    # execution_raw empty (label-based repo) and no ## Goal -> fallback is whole desc.
+    description = "Plain description with no sections."
+    result = parser.parse(description, labels=["repo:lbl"])
+    assert result.goal_text == "Plain description with no sections."
+
+
+def test_goal_fallback_empty_after_strip_raises(parser: TaskParser) -> None:
+    # Only an execution section, no goal text -> fallback becomes empty.
+    description = "## Execution\nrepo: r\n"
+    with pytest.raises(ValueError, match="Missing goal text"):
+        parser.parse(description)
+
+
+def test_goal_section_present_overrides_fallback(parser: TaskParser) -> None:
+    description = "## Goal\nReal goal.\n\n## Execution\nrepo: r\n## Notes\nx\n"
+    result = parser.parse(description)
+    assert result.goal_text == "Real goal."
+
+
+# --------------------------------------------------------------------------- #
+# Section extraction                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_sections_no_headers_returns_empty(parser: TaskParser) -> None:
+    assert parser._extract_sections("plain text no headers") == {}
+
+
+def test_extract_sections_titles_lowercased(parser: TaskParser) -> None:
+    sections = parser._extract_sections("## GOAL\nbody\n## Execution\nrepo: r")
+    assert "goal" in sections
+    assert "execution" in sections
+    assert sections["goal"] == "body"
+
+
+# --------------------------------------------------------------------------- #
+# Metadata normalization                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_mode_alias_test(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nmode: test\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["mode"] == "test_campaign"
+
+
+def test_mode_alias_improve(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nmode: improve\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["mode"] == "improve_campaign"
+
+
+def test_mode_canonical_campaign_modes(parser: TaskParser) -> None:
+    for mode in ("test_campaign", "improve_campaign", "fix_pr"):
+        description = f"## Goal\nG\n\n## Execution\nrepo: r\nmode: {mode}\n"
+        result = parser.parse(description)
+        assert result.execution_metadata["mode"] == mode
+
+
+def test_mode_whitespace_and_uppercase_normalized(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nmode: '  GOAL  '\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["mode"] == "goal"
+
+
+def test_allowed_paths_string_coerced_to_list(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nallowed_paths: src/foo\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["allowed_paths"] == ["src/foo"]
+
+
+def test_allowed_paths_list_trimmed_and_emptied(parser: TaskParser) -> None:
+    description = (
+        "## Goal\nG\n\n## Execution\nrepo: r\nallowed_paths:\n  - '  a  '\n  - ''\n  - b\n"
+    )
+    result = parser.parse(description)
+    assert result.execution_metadata["allowed_paths"] == ["a", "b"]
+
+
+def test_open_pr_truthy_values(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\nopen_pr: true\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["open_pr"] is True
+
+
+def test_open_pr_default_false_when_absent(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\n"
+    result = parser.parse(description)
+    assert result.execution_metadata["open_pr"] is False
+
+
+def test_campaign_passthrough_fields_stringified(parser: TaskParser) -> None:
+    description = (
+        "## Goal\nG\n\n## Execution\n"
+        "repo: r\nmode: test_campaign\n"
+        "spec_campaign_id: 12345\n"
+        "spec_file: specs/x.md\n"
+        "task_phase: '  phase1  '\n"
+        "spec_coverage_hint: 80\n"
+    )
+    result = parser.parse(description)
+    md = result.execution_metadata
+    assert md["spec_campaign_id"] == "12345"
+    assert md["spec_file"] == "specs/x.md"
+    assert md["task_phase"] == "phase1"
+    assert md["spec_coverage_hint"] == "80"
+
+
+def test_passthrough_fields_absent_not_added(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\n"
+    result = parser.parse(description)
+    for field in ("spec_campaign_id", "spec_file", "task_phase", "spec_coverage_hint"):
+        assert field not in result.execution_metadata
+
+
+def test_constraints_blank_becomes_none(parser: TaskParser) -> None:
+    description = "## Goal\nG\n\n## Execution\nrepo: r\n\n## Constraints\n   \n"
+    result = parser.parse(description)
+    assert result.constraints_text is None

--- a/tests/unit/artifact_index/test_cli_cov.py
+++ b/tests/unit/artifact_index/test_cli_cov.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Coverage-complement tests for the artifact_index CLI.
+
+These tests target serialization helpers and command branches that the
+existing ``test_cli.py`` does not exercise, using fully mocked collaborators
+so they are hermetic (no real index build, filesystem walk, or retrieval).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from operations_center.artifact_index import cli as cli_mod
+from operations_center.artifact_index.cli import (
+    _path_default,
+    _run_summary,
+    app,
+)
+from operations_center.artifact_index.errors import (
+    ArtifactNotFoundError,
+    ArtifactPathUnresolvableError,
+)
+
+_runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Lightweight fakes
+# ---------------------------------------------------------------------------
+
+
+def _enum(value: str) -> SimpleNamespace:
+    """Mimic an enum member exposing ``.value``."""
+    return SimpleNamespace(value=value)
+
+
+def _make_run(
+    *,
+    run_id: str = "run_a",
+    repo_id: str = "repo1",
+    audit_type: str = "audit_type_1",
+    producer: str = "producer1",
+    manifest_path: Path | None = None,
+    run_status: str | None = "completed",
+    manifest_status: str | None = "completed",
+    finalized_at: datetime | None = None,
+    artifact_count: int = 2,
+    is_partial: bool = False,
+    load_error: str | None = None,
+    index: object | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        run_id=run_id,
+        repo_id=repo_id,
+        audit_type=audit_type,
+        producer=producer,
+        manifest_path=manifest_path or Path("/tmp/x/artifact_manifest.json"),
+        run_status=_enum(run_status) if run_status else None,
+        manifest_status=_enum(manifest_status) if manifest_status else None,
+        finalized_at=finalized_at,
+        artifact_count=artifact_count,
+        is_partial=is_partial,
+        load_error=load_error,
+        index=index,
+    )
+
+
+def _make_artifact(
+    *,
+    artifact_id: str = "art1",
+    artifact_kind: str = "stage_report",
+    location: str = "run_root",
+    path_role: str = "primary",
+    source_stage: str | None = "StageA",
+    status: str = "present",
+    path: str = "a/b.json",
+    resolved_path: Path | None = None,
+    exists_on_disk: bool | None = True,
+    is_repo_singleton: bool = False,
+    size_bytes: int | None = 10,
+    content_type: str = "application/json",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        artifact_id=artifact_id,
+        artifact_kind=artifact_kind,
+        location=_enum(location),
+        path_role=_enum(path_role),
+        source_stage=source_stage,
+        status=_enum(status),
+        path=path,
+        resolved_path=resolved_path,
+        exists_on_disk=exists_on_disk,
+        is_repo_singleton=is_repo_singleton,
+        size_bytes=size_bytes,
+        content_type=content_type,
+    )
+
+
+def _patch_index(monkeypatch: pytest.MonkeyPatch, idx: object) -> MagicMock:
+    """Make build_multi_run_index return ``idx`` regardless of args."""
+    m = MagicMock(return_value=idx)
+    monkeypatch.setattr(cli_mod, "build_multi_run_index", m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _path_default
+# ---------------------------------------------------------------------------
+
+
+class TestPathDefault:
+    def test_path_serialized_to_str(self) -> None:
+        assert _path_default(Path("/a/b")) == str(Path("/a/b"))
+
+    def test_non_path_raises_typeerror(self) -> None:
+        with pytest.raises(TypeError, match="unserializable"):
+            _path_default(object())
+
+
+# ---------------------------------------------------------------------------
+# _run_summary
+# ---------------------------------------------------------------------------
+
+
+class TestRunSummary:
+    def test_all_present(self) -> None:
+        fin = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        run = _make_run(finalized_at=fin)
+        s = _run_summary(run)
+        assert s["run_id"] == "run_a"
+        assert s["run_status"] == "completed"
+        assert s["manifest_status"] == "completed"
+        assert s["finalized_at"] == fin.isoformat()
+        assert s["manifest_path"] == str(run.manifest_path)
+        assert s["artifact_count"] == 2
+
+    def test_none_fields(self) -> None:
+        run = _make_run(run_status=None, manifest_status=None, finalized_at=None)
+        s = _run_summary(run)
+        assert s["run_status"] is None
+        assert s["manifest_status"] is None
+        assert s["finalized_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# index command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdIndexBranches:
+    def test_json_empty_runs_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace(search_root=Path("/root"), runs=[], skipped_paths=[])
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index", "/root", "--json"])
+        assert out.exit_code == 2
+        # JSON still printed before the exit.
+        data = json.loads(out.output)
+        assert data["runs"] == []
+
+    def test_json_with_runs_and_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace(
+            search_root=Path("/root"),
+            runs=[_make_run()],
+            skipped_paths=[(Path("/root/bad"), "too deep")],
+        )
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index", "/root", "--json"])
+        assert out.exit_code == 0
+        data = json.loads(out.output)
+        assert data["runs"][0]["run_id"] == "run_a"
+        assert data["skipped"][0] == ["/root/bad", "too deep"]
+
+    def test_table_with_partial_and_load_error_notes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fin = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        runs = [
+            _make_run(run_id="r1", is_partial=True, load_error="boom", finalized_at=fin),
+            _make_run(
+                run_id="",
+                repo_id="",
+                audit_type="",
+                run_status=None,
+                manifest_status=None,
+                finalized_at=None,
+            ),
+        ]
+        idx = SimpleNamespace(search_root=Path("/root"), runs=runs, skipped_paths=[])
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index", "/root"])
+        assert out.exit_code == 0
+        assert "Audit Runs" in out.output
+
+    def test_table_empty_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace(search_root=Path("/root"), runs=[], skipped_paths=[])
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index", "/root"])
+        assert out.exit_code == 2
+        assert "No audit runs" in out.output
+
+
+# ---------------------------------------------------------------------------
+# index-show command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdIndexShowBranches:
+    def _idx_with_run(self, run: SimpleNamespace) -> SimpleNamespace:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(return_value=run)
+        return idx
+
+    def test_ambiguous_prefix_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(side_effect=ValueError("ambiguous"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index-show", "/root", "abc"])
+        assert out.exit_code == 2
+        assert "Ambiguous" in out.output
+
+    def test_not_found_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(side_effect=ArtifactNotFoundError("nope"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["index-show", "/root", "abc"])
+        assert out.exit_code == 1
+        assert "Not found" in out.output
+
+    def test_load_error_exits_3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run = _make_run(load_error="bad json", index=None)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a"])
+        assert out.exit_code == 3
+        assert "failed to load" in out.output
+
+    def test_index_none_without_load_error_exits_3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run = _make_run(load_error=None, index=None)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a"])
+        assert out.exit_code == 3
+
+    def test_filters_applied_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        arts = [
+            _make_artifact(artifact_id="keep", artifact_kind="k1", source_stage="s1"),
+            _make_artifact(artifact_id="dropkind", artifact_kind="other", source_stage="s1"),
+            _make_artifact(artifact_id="dropstage", artifact_kind="k1", source_stage="other"),
+            _make_artifact(
+                artifact_id="dropexists",
+                artifact_kind="k1",
+                source_stage="s1",
+                exists_on_disk=False,
+            ),
+            _make_artifact(
+                artifact_id="dropnone",
+                artifact_kind="k1",
+                source_stage=None,
+                exists_on_disk=None,
+            ),
+        ]
+        index = SimpleNamespace(artifacts=arts)
+        run = _make_run(index=index)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(
+            app,
+            [
+                "index-show",
+                "/root",
+                "run_a",
+                "--kind",
+                "k1",
+                "--stage",
+                "s1",
+                "--location",
+                "run_root",
+            ],
+        )
+        assert out.exit_code == 0
+        assert "keep" in out.output
+
+    def test_missing_only_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        arts = [
+            _make_artifact(artifact_id="present_one", status="present"),
+            _make_artifact(artifact_id="missing_one", status="missing"),
+        ]
+        index = SimpleNamespace(artifacts=arts)
+        run = _make_run(index=index)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a", "--missing-only", "--json"])
+        assert out.exit_code == 0
+        data = json.loads(out.output)
+        ids = [a["artifact_id"] for a in data["artifacts"]]
+        assert ids == ["missing_one"]
+
+    def test_json_output_with_resolved_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        arts = [_make_artifact(resolved_path=Path("/abs/a/b.json"))]
+        index = SimpleNamespace(artifacts=arts)
+        run = _make_run(index=index)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a", "--json"])
+        assert out.exit_code == 0
+        data = json.loads(out.output)
+        a = data["artifacts"][0]
+        assert a["resolved_path"] == str(Path("/abs/a/b.json"))
+        assert a["exists_on_disk"] is True
+
+    def test_json_output_resolved_path_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        arts = [_make_artifact(resolved_path=None)]
+        index = SimpleNamespace(artifacts=arts)
+        run = _make_run(index=index)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a", "--json"])
+        data = json.loads(out.output)
+        assert data["artifacts"][0]["resolved_path"] is None
+
+    def test_table_on_disk_glyphs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        arts = [
+            _make_artifact(artifact_id="a_yes", exists_on_disk=True, source_stage="s"),
+            _make_artifact(artifact_id="a_no", exists_on_disk=False, source_stage=None),
+            _make_artifact(artifact_id="a_unknown", exists_on_disk=None),
+        ]
+        index = SimpleNamespace(artifacts=arts)
+        run = _make_run(index=index)
+        _patch_index(monkeypatch, self._idx_with_run(run))
+        out = _runner.invoke(app, ["index-show", "/root", "run_a"])
+        assert out.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# get-artifact command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdGetArtifactBranches:
+    def _idx(self, run: SimpleNamespace) -> SimpleNamespace:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(return_value=run)
+        return idx
+
+    def test_not_found_run_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(side_effect=ArtifactNotFoundError("nope"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 1
+        assert "Not found" in out.output
+
+    def test_ambiguous_prefix_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        idx = SimpleNamespace()
+        idx.find_run_by_prefix = MagicMock(side_effect=ValueError("amb"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 2
+        assert "Ambiguous" in out.output
+
+    def test_load_error_exits_3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run = _make_run(load_error="boom", index=None)
+        _patch_index(monkeypatch, self._idx(run))
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 3
+
+    def test_resolve_artifact_not_found_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        index = SimpleNamespace(artifacts=[], get_by_id=MagicMock(return_value=None))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(side_effect=ArtifactNotFoundError("missing artifact"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 1
+        assert "Artifact not found" in out.output
+
+    def test_resolve_missing_on_disk_exits_5(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        index = SimpleNamespace(artifacts=[])
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(
+            side_effect=ArtifactPathUnresolvableError("file no longer exists on disk")
+        )
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 5
+        assert "missing" in out.output.lower()
+
+    def test_resolve_unresolvable_exits_4(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        index = SimpleNamespace(artifacts=[])
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(
+            side_effect=ArtifactPathUnresolvableError("cannot resolve relative path")
+        )
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 4
+        assert "Unresolvable" in out.output
+
+    def test_resolve_prints_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run = _make_run(index=SimpleNamespace(artifacts=[]))
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.json"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1"])
+        assert out.exit_code == 0
+        assert "/abs/file.json" in out.output
+
+    def test_no_recheck_flag_passed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run = _make_run(index=SimpleNamespace(artifacts=[]))
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.json"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--no-recheck"])
+        assert out.exit_code == 0
+        # recheck_exists should be False when --no-recheck given.
+        _, kwargs = idx.resolve.call_args
+        assert kwargs["recheck_exists"] is False
+
+    def test_print_content_disappeared_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=None))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.json"))
+        _patch_index(monkeypatch, idx)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--print-content"])
+        assert out.exit_code == 1
+        assert "disappeared" in out.output
+
+    def test_print_content_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        indexed = _make_artifact(content_type="application/json")
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=indexed))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.json"))
+        _patch_index(monkeypatch, idx)
+        monkeypatch.setattr(cli_mod, "read_json_artifact", lambda *a, **k: {"hello": "world"})
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--print-content"])
+        assert out.exit_code == 0
+        assert "hello" in out.output
+
+    def test_print_content_json_read_error_exits_4(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        indexed = _make_artifact(content_type="application/json")
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=indexed))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.json"))
+        _patch_index(monkeypatch, idx)
+
+        def _boom(*a, **k):
+            raise RuntimeError("json broke")
+
+        monkeypatch.setattr(cli_mod, "read_json_artifact", _boom)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--print-content"])
+        assert out.exit_code == 4
+        assert "read_json_artifact failed" in out.output
+
+    def test_print_content_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        indexed = _make_artifact(content_type="text/plain")
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=indexed))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.txt"))
+        _patch_index(monkeypatch, idx)
+        monkeypatch.setattr(cli_mod, "read_text_artifact", lambda *a, **k: "plain body")
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--print-content"])
+        assert out.exit_code == 0
+        assert "plain body" in out.output
+
+    def test_print_content_text_read_error_exits_4(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        indexed = _make_artifact(content_type="text/plain")
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=indexed))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.txt"))
+        _patch_index(monkeypatch, idx)
+
+        def _boom(*a, **k):
+            raise RuntimeError("text broke")
+
+        monkeypatch.setattr(cli_mod, "read_text_artifact", _boom)
+        out = _runner.invoke(app, ["get-artifact", "/root", "run_a", "art1", "--print-content"])
+        assert out.exit_code == 4
+        assert "read_text_artifact failed" in out.output
+
+    def test_print_content_truncated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        indexed = _make_artifact(content_type="text/plain")
+        index = SimpleNamespace(get_by_id=MagicMock(return_value=indexed))
+        run = _make_run(index=index)
+        idx = self._idx(run)
+        idx.resolve = MagicMock(return_value=Path("/abs/file.txt"))
+        _patch_index(monkeypatch, idx)
+        long_text = "X" * 100
+        monkeypatch.setattr(cli_mod, "read_text_artifact", lambda *a, **k: long_text)
+        out = _runner.invoke(
+            app,
+            [
+                "get-artifact",
+                "/root",
+                "run_a",
+                "art1",
+                "--print-content",
+                "--max-bytes",
+                "10",
+            ],
+        )
+        assert out.exit_code == 0
+        assert "truncated" in out.output

--- a/tests/unit/artifact_index/test_multi_run_cov.py
+++ b/tests/unit/artifact_index/test_multi_run_cov.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Coverage-complement tests for the multi-run artifact index.
+
+These complement ``test_multi_run.py`` by exercising the internal helpers
+(``_parse_iso``, ``_coerce_status``, ``_peek_manifest_metadata``,
+``_build_one``) and branches not already covered: symlink following,
+raced-away manifests, the ManifestInvalid metadata-peek fallback,
+finalized_at sorting, and the secondary lookup/iter accessors.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from operations_center.artifact_index import multi_run as mr
+from operations_center.artifact_index.errors import (
+    ArtifactNotFoundError,
+    ArtifactPathUnresolvableError,
+)
+from operations_center.artifact_index.models import IndexedArtifact
+from operations_center.artifact_index.multi_run import (
+    IndexedRun,
+    MultiRunArtifactIndex,
+    _build_one,
+    _coerce_status,
+    _parse_iso,
+    _peek_manifest_metadata,
+    build_multi_run_index,
+    discover_manifest_files,
+)
+from operations_center.audit_contracts.vocabulary import ManifestStatus, RunStatus
+
+from tests.unit.artifact_index.conftest import _BASE_ENTRY, _make_manifest_payload  # type: ignore
+
+
+def _write_bucket(root: Path, *, run_id: str, payload_factory=_make_manifest_payload) -> Path:
+    bucket = root / "tools" / "audit" / "report" / "audit_type_1" / f"Bucket_{run_id}"
+    bucket.mkdir(parents=True, exist_ok=True)
+    payload = payload_factory(run_id=run_id, run_root=str(bucket.relative_to(root)))
+    (bucket / "artifact_manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+    return bucket
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso
+# ---------------------------------------------------------------------------
+
+
+class TestParseIso:
+    def test_parses_z_suffix(self) -> None:
+        got = _parse_iso("2026-04-26T12:00:00Z")
+        assert got == datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_parses_offset(self) -> None:
+        got = _parse_iso("2026-04-26T12:00:00+02:00")
+        assert got is not None
+        assert got.utcoffset() == _dt.timedelta(hours=2)
+
+    def test_non_string_returns_none(self) -> None:
+        assert _parse_iso(None) is None
+        assert _parse_iso(12345) is None
+        assert _parse_iso(["2026-04-26"]) is None
+
+    def test_invalid_string_returns_none(self) -> None:
+        assert _parse_iso("not-a-date") is None
+        assert _parse_iso("") is None
+
+
+# ---------------------------------------------------------------------------
+# _coerce_status
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceStatus:
+    def test_valid_run_status(self) -> None:
+        assert _coerce_status("running", RunStatus) is RunStatus.RUNNING
+
+    def test_valid_manifest_status(self) -> None:
+        assert _coerce_status("partial", ManifestStatus) is ManifestStatus.PARTIAL
+
+    def test_none_returns_none(self) -> None:
+        assert _coerce_status(None, RunStatus) is None
+
+    def test_invalid_value_returns_none(self) -> None:
+        assert _coerce_status("nonsense", RunStatus) is None
+
+    def test_wrong_type_returns_none(self) -> None:
+        # Unhashable / wrong type triggers TypeError inside enum lookup.
+        assert _coerce_status(["x"], RunStatus) is None
+
+
+# ---------------------------------------------------------------------------
+# _peek_manifest_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestPeekManifestMetadata:
+    def test_reads_valid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "m.json"
+        p.write_text(json.dumps({"run_id": "x"}), encoding="utf-8")
+        assert _peek_manifest_metadata(p) == {"run_id": "x"}
+
+    def test_corrupt_json_returns_none(self, tmp_path: Path) -> None:
+        p = tmp_path / "m.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert _peek_manifest_metadata(p) is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert _peek_manifest_metadata(tmp_path / "missing.json") is None
+
+
+# ---------------------------------------------------------------------------
+# IndexedRun.loaded property
+# ---------------------------------------------------------------------------
+
+
+class TestIndexedRunLoaded:
+    def _run(self, *, index, load_error) -> IndexedRun:
+        return IndexedRun(
+            manifest_path=Path("/tmp/x.json"),
+            run_id="r",
+            repo_id="repo",
+            audit_type="audit_type_1",
+            producer="p",
+            run_status=None,
+            manifest_status=None,
+            finalized_at=None,
+            artifact_count=0,
+            is_partial=False,
+            load_error=load_error,
+            index=index,
+        )
+
+    def test_loaded_true(self) -> None:
+        sentinel = object()
+        assert self._run(index=sentinel, load_error=None).loaded is True
+
+    def test_loaded_false_when_no_index(self) -> None:
+        assert self._run(index=None, load_error=None).loaded is False
+
+    def test_loaded_false_when_error_present(self) -> None:
+        sentinel = object()
+        assert self._run(index=sentinel, load_error="boom").loaded is False
+
+
+# ---------------------------------------------------------------------------
+# _build_one branches
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOneFailureBranches:
+    def test_manifest_not_found_raced_away(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_load(_path):
+            raise mr.ManifestNotFoundError("gone")
+
+        monkeypatch.setattr(mr, "load_artifact_manifest", fake_load)
+        run = _build_one(Path("/tmp/does-not-matter.json"), repo_root=None)
+        assert run.index is None
+        assert run.load_error == "gone"
+        assert run.run_id == ""
+        assert run.repo_id == ""
+        assert run.artifact_count == 0
+        assert run.is_partial is False
+        assert run.loaded is False
+
+    def test_manifest_invalid_peeks_metadata(self, tmp_path: Path, monkeypatch) -> None:
+        # Write a file whose JSON is parseable (peek succeeds) but treat it as
+        # invalid for full validation by stubbing the loader.
+        p = tmp_path / "artifact_manifest.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "run_id": "peeked_run",
+                    "repo_id": "peeked_repo",
+                    "audit_type": "peeked_audit",
+                    "producer": "peeked_producer",
+                    "run_status": "running",
+                    "manifest_status": "partial",
+                    "finalized_at": "2026-04-26T12:01:00Z",
+                    "artifacts": [{}, {}, {}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        def fake_load(_path):
+            raise mr.ManifestInvalidError("validation failed")
+
+        monkeypatch.setattr(mr, "load_artifact_manifest", fake_load)
+        run = _build_one(p, repo_root=None)
+        assert run.index is None
+        assert run.load_error == "validation failed"
+        assert run.run_id == "peeked_run"
+        assert run.repo_id == "peeked_repo"
+        assert run.audit_type == "peeked_audit"
+        assert run.producer == "peeked_producer"
+        assert run.run_status is RunStatus.RUNNING
+        assert run.manifest_status is ManifestStatus.PARTIAL
+        assert run.finalized_at == datetime(2026, 4, 26, 12, 1, 0, tzinfo=timezone.utc)
+        assert run.artifact_count == 3
+        assert run.is_partial is True
+
+    def test_manifest_invalid_with_unpeekable_metadata(self, tmp_path: Path, monkeypatch) -> None:
+        # Corrupt JSON so the peek fallback returns None -> empty defaults.
+        p = tmp_path / "artifact_manifest.json"
+        p.write_text("{not json", encoding="utf-8")
+
+        def fake_load(_path):
+            raise mr.ManifestInvalidError("validation failed")
+
+        monkeypatch.setattr(mr, "load_artifact_manifest", fake_load)
+        run = _build_one(p, repo_root=None)
+        assert run.run_id == ""
+        assert run.repo_id == ""
+        assert run.audit_type == ""
+        assert run.producer == ""
+        assert run.run_status is None
+        assert run.manifest_status is None
+        assert run.finalized_at is None
+        assert run.artifact_count == 0
+        assert run.is_partial is False
+        assert run.load_error == "validation failed"
+
+
+# ---------------------------------------------------------------------------
+# discover_manifest_files extra branches
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverExtras:
+    def test_root_is_file_returns_empty(self, tmp_path: Path) -> None:
+        f = tmp_path / "afile.json"
+        f.write_text("{}")
+        assert discover_manifest_files(f) == []
+
+    def test_skips_node_modules(self, tmp_path: Path) -> None:
+        nm = tmp_path / "node_modules"
+        nm.mkdir()
+        (nm / "artifact_manifest.json").write_text("{}")
+        assert discover_manifest_files(tmp_path) == []
+
+    def test_accepts_str_path(self, tmp_path: Path) -> None:
+        bucket = tmp_path / "b"
+        bucket.mkdir()
+        m = bucket / "artifact_manifest.json"
+        m.write_text("{}")
+        assert discover_manifest_files(str(tmp_path)) == [m]
+
+    def test_follow_symlinks_true_traverses_linked_dir(self, tmp_path: Path) -> None:
+        real = tmp_path / "real"
+        real.mkdir()
+        (real / "artifact_manifest.json").write_text("{}")
+        link_parent = tmp_path / "linkroot"
+        link_parent.mkdir()
+        link = link_parent / "linked"
+        link.symlink_to(real, target_is_directory=True)
+        found = discover_manifest_files(link_parent, follow_symlinks=True)
+        assert (link / "artifact_manifest.json") in found
+
+
+# ---------------------------------------------------------------------------
+# build_multi_run_index extras: skipped, sorting
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExtras:
+    def test_skipped_when_manifest_disappears(self, tmp_path: Path, monkeypatch) -> None:
+        bucket = _write_bucket(tmp_path, run_id="r1")
+        mp = bucket / "artifact_manifest.json"
+        monkeypatch.setattr(mr, "discover_manifest_files", lambda *a, **k: [mp])
+        # Delete the file after discovery so is_file() is False.
+        mp.unlink()
+        idx = build_multi_run_index(tmp_path)
+        assert idx.runs == []
+        assert len(idx.skipped_paths) == 1
+        skipped_path, reason = idx.skipped_paths[0]
+        assert skipped_path == mp
+        assert "disappeared" in reason
+
+    def test_sorted_most_recent_first(self, tmp_path: Path) -> None:
+        def fac_old(*, run_id, run_root):
+            return _make_manifest_payload(
+                run_id=run_id, run_root=run_root, finalized_at="2026-01-01T00:00:00Z"
+            )
+
+        def fac_new(*, run_id, run_root):
+            return _make_manifest_payload(
+                run_id=run_id, run_root=run_root, finalized_at="2026-12-31T00:00:00Z"
+            )
+
+        _write_bucket(tmp_path, run_id="old_run", payload_factory=fac_old)
+        _write_bucket(tmp_path, run_id="new_run", payload_factory=fac_new)
+        idx = build_multi_run_index(tmp_path)
+        assert [r.run_id for r in idx.runs] == ["new_run", "old_run"]
+
+    def test_str_search_root_resolved(self, tmp_path: Path) -> None:
+        _write_bucket(tmp_path, run_id="r1")
+        idx = build_multi_run_index(str(tmp_path))
+        assert idx.search_root == tmp_path.resolve()
+
+    def test_filter_keeps_when_metadata_missing(self, tmp_path: Path) -> None:
+        # A failed (raced-away) run with empty repo_id/audit_type must survive
+        # filters because the filter only drops runs with truthy mismatching
+        # metadata.
+        bad = tmp_path / "broken"
+        bad.mkdir()
+        (bad / "artifact_manifest.json").write_text("{not json", encoding="utf-8")
+        idx = build_multi_run_index(tmp_path, repo_filter="something", audit_type_filter="other")
+        assert len(idx.runs) == 1
+        assert idx.runs[0].repo_id == ""
+
+
+# ---------------------------------------------------------------------------
+# MultiRunArtifactIndex secondary accessors
+# ---------------------------------------------------------------------------
+
+
+class TestAccessors:
+    def test_by_repo_and_by_audit_type(self, tmp_path: Path) -> None:
+        _write_bucket(tmp_path, run_id="r1")
+        idx = build_multi_run_index(tmp_path)
+        assert [r.run_id for r in idx.by_repo("example_managed_repo")] == ["r1"]
+        assert idx.by_repo("nope") == []
+        assert [r.run_id for r in idx.by_audit_type("audit_type_1")] == ["r1"]
+        assert idx.by_audit_type("nope") == []
+
+    def test_get_run_missing_returns_none(self, tmp_path: Path) -> None:
+        idx = build_multi_run_index(tmp_path)
+        assert idx.get_run("nothing") is None
+
+    def test_iter_artifacts_federates(self, tmp_path: Path) -> None:
+        _write_bucket(tmp_path, run_id="r1")
+        _write_bucket(tmp_path, run_id="r2")
+        idx = build_multi_run_index(tmp_path)
+        artifacts = list(idx.iter_artifacts())
+        assert len(artifacts) == 2
+        assert all(isinstance(a, IndexedArtifact) for a in artifacts)
+
+    def test_iter_artifacts_skips_failed_runs(self, tmp_path: Path) -> None:
+        _write_bucket(tmp_path, run_id="r1")
+        bad = tmp_path / "tools" / "audit" / "report" / "audit_type_1" / "broken"
+        bad.mkdir(parents=True)
+        (bad / "artifact_manifest.json").write_text("{not json", encoding="utf-8")
+        idx = build_multi_run_index(tmp_path)
+        # One good, one failed -> only good run's artifacts yielded.
+        assert len(list(idx.iter_artifacts())) == 1
+        assert len(idx.failed_runs) == 1
+
+    def test_query_returns_empty_when_no_loaded_runs(self, tmp_path: Path) -> None:
+        idx = build_multi_run_index(tmp_path)
+        assert idx.query() == []
+
+
+# ---------------------------------------------------------------------------
+# resolve: get_run None vs index None
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBranches:
+    def test_resolve_unknown_run_message(self, tmp_path: Path) -> None:
+        idx = MultiRunArtifactIndex(search_root=tmp_path, runs=[])
+        with pytest.raises(ArtifactNotFoundError, match="search_root="):
+            idx.resolve("missing", "art")
+
+    def test_resolve_failed_index_none(self, tmp_path: Path) -> None:
+        run = IndexedRun(
+            manifest_path=tmp_path / "x.json",
+            run_id="r1",
+            repo_id="repo",
+            audit_type="audit_type_1",
+            producer="p",
+            run_status=None,
+            manifest_status=None,
+            finalized_at=None,
+            artifact_count=0,
+            is_partial=False,
+            load_error="bad manifest",
+            index=None,
+        )
+        idx = MultiRunArtifactIndex(search_root=tmp_path, runs=[run])
+        with pytest.raises(ArtifactPathUnresolvableError, match="failed to load: bad manifest"):
+            idx.resolve("r1", "art")
+
+    def test_resolve_recheck_false_no_stat(self, tmp_path: Path) -> None:
+        _write_bucket(tmp_path, run_id="r1")
+        idx = build_multi_run_index(tmp_path, repo_root=tmp_path)
+        # Artifact file not materialized; recheck disabled returns the path.
+        path = idx.resolve("r1", _BASE_ENTRY["artifact_id"], recheck_exists=False)
+        assert isinstance(path, Path)
+        assert not path.exists()

--- a/tests/unit/audit_dispatch/test_lock_store_cov.py
+++ b/tests/unit/audit_dispatch/test_lock_store_cov.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Supplementary coverage tests for the persistent lock store.
+
+Complements ``test_lock_store.py`` by exercising the helper functions,
+serialization edge cases, sentinel filtering, and the atomic-write
+error-cleanup path without duplicating the existing happy-path coverage.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import re
+import socket
+from pathlib import Path
+
+import pytest
+
+from operations_center.audit_dispatch import lock_store as ls
+from operations_center.audit_dispatch.errors import LockStoreCorruptError
+from operations_center.audit_dispatch.lock_store import (
+    LOCK_SCHEMA_VERSION,
+    PersistentLockPayload,
+    PersistentLockStore,
+    _is_pid_alive,
+    _now_iso,
+)
+
+
+def _payload(**overrides) -> PersistentLockPayload:
+    base = dict(
+        repo_id="repo_x",
+        run_id="run_1",
+        audit_type="audit_type_1",
+        oc_pid=os.getpid(),
+        started_at="2026-05-04T12:00:00Z",
+        command="python -m tools.audit.run",
+        expected_run_status_path="/tmp/run_status.json",
+    )
+    base.update(overrides)
+    return PersistentLockPayload(**base)
+
+
+# ---------------------------------------------------------------------------
+# _now_iso
+# ---------------------------------------------------------------------------
+
+
+class TestNowIso:
+    def test_returns_z_suffixed_iso_string(self) -> None:
+        value = _now_iso()
+        assert value.endswith("Z")
+        assert "+00:00" not in value
+        # YYYY-MM-DDTHH:MM:SSZ — second precision, no microseconds.
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", value)
+
+
+# ---------------------------------------------------------------------------
+# _is_pid_alive — every branch
+# ---------------------------------------------------------------------------
+
+
+class TestIsPidAlive:
+    def test_none_is_not_alive(self) -> None:
+        assert _is_pid_alive(None) is False
+
+    def test_zero_is_not_alive(self) -> None:
+        assert _is_pid_alive(0) is False
+
+    def test_negative_is_not_alive(self) -> None:
+        assert _is_pid_alive(-5) is False
+
+    def test_current_pid_is_alive(self) -> None:
+        assert _is_pid_alive(os.getpid()) is True
+
+    def test_process_lookup_error_is_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_kill(pid: int, sig: int) -> None:
+            raise ProcessLookupError
+
+        monkeypatch.setattr(ls.os, "kill", fake_kill)
+        assert _is_pid_alive(1234) is False
+
+    def test_permission_error_is_alive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_kill(pid: int, sig: int) -> None:
+            raise PermissionError
+
+        monkeypatch.setattr(ls.os, "kill", fake_kill)
+        assert _is_pid_alive(1234) is True
+
+    def test_oserror_esrch_is_dead(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_kill(pid: int, sig: int) -> None:
+            raise OSError(errno.ESRCH, "no such process")
+
+        monkeypatch.setattr(ls.os, "kill", fake_kill)
+        assert _is_pid_alive(1234) is False
+
+    def test_oserror_other_errno_is_alive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_kill(pid: int, sig: int) -> None:
+            raise OSError(errno.EINVAL, "invalid")
+
+        monkeypatch.setattr(ls.os, "kill", fake_kill)
+        assert _is_pid_alive(1234) is True
+
+
+# ---------------------------------------------------------------------------
+# PersistentLockPayload serialization
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadSerialization:
+    def test_to_json_contains_all_fields(self) -> None:
+        p = _payload(audit_pid=11, audit_pgid=22, owner_hostname="hostA")
+        data = p.to_json()
+        assert data == {
+            "lock_schema_version": LOCK_SCHEMA_VERSION,
+            "repo_id": "repo_x",
+            "run_id": "run_1",
+            "audit_type": "audit_type_1",
+            "oc_pid": os.getpid(),
+            "audit_pid": 11,
+            "audit_pgid": 22,
+            "started_at": "2026-05-04T12:00:00Z",
+            "command": "python -m tools.audit.run",
+            "expected_run_status_path": "/tmp/run_status.json",
+            "owner_hostname": "hostA",
+        }
+
+    def test_round_trip_json(self) -> None:
+        p = _payload(audit_pid=11, audit_pgid=22, owner_hostname="hostA")
+        restored = PersistentLockPayload.from_json(p.to_json())
+        assert restored == p
+
+    def test_owner_hostname_defaults_to_gethostname(self) -> None:
+        p = _payload()
+        assert p.owner_hostname == socket.gethostname()
+
+    def test_from_json_null_audit_pid_and_pgid(self) -> None:
+        data = _payload().to_json()
+        data["audit_pid"] = None
+        data["audit_pgid"] = None
+        restored = PersistentLockPayload.from_json(data)
+        assert restored.audit_pid is None
+        assert restored.audit_pgid is None
+
+    def test_from_json_coerces_string_numbers(self) -> None:
+        data = _payload().to_json()
+        data["oc_pid"] = "777"
+        data["audit_pid"] = "888"
+        data["audit_pgid"] = "999"
+        restored = PersistentLockPayload.from_json(data)
+        assert restored.oc_pid == 777
+        assert restored.audit_pid == 888
+        assert restored.audit_pgid == 999
+
+    def test_from_json_defaults_owner_hostname_when_absent(self) -> None:
+        data = _payload().to_json()
+        del data["owner_hostname"]
+        restored = PersistentLockPayload.from_json(data)
+        assert restored.owner_hostname == socket.gethostname()
+
+    def test_from_json_defaults_schema_version_when_absent(self) -> None:
+        data = _payload().to_json()
+        del data["lock_schema_version"]
+        restored = PersistentLockPayload.from_json(data)
+        assert restored.lock_schema_version == LOCK_SCHEMA_VERSION
+
+    def test_from_json_missing_required_field_raises(self) -> None:
+        data = _payload().to_json()
+        del data["run_id"]
+        with pytest.raises(LockStoreCorruptError, match="malformed lock payload"):
+            PersistentLockPayload.from_json(data)
+
+    def test_from_json_non_numeric_pid_raises_value_error_path(self) -> None:
+        data = _payload().to_json()
+        data["oc_pid"] = "not-a-number"
+        with pytest.raises(LockStoreCorruptError):
+            PersistentLockPayload.from_json(data)
+
+    def test_from_json_type_error_path(self) -> None:
+        # int(None) raises TypeError, exercised via a non-coercible oc_pid.
+        data = _payload().to_json()
+        data["oc_pid"] = ["list-is-not-int"]
+        with pytest.raises(LockStoreCorruptError):
+            PersistentLockPayload.from_json(data)
+
+
+# ---------------------------------------------------------------------------
+# PersistentLockStore construction / properties
+# ---------------------------------------------------------------------------
+
+
+class TestStoreConstruction:
+    def test_init_creates_state_dir(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "locks"
+        store = PersistentLockStore(target)
+        assert target.is_dir()
+        assert store.state_dir == target
+
+    def test_init_accepts_existing_dir(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        assert store.state_dir == tmp_path
+
+    def test_state_dir_coerced_to_path(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(str(tmp_path))
+        assert isinstance(store.state_dir, Path)
+
+
+# ---------------------------------------------------------------------------
+# _iter_lock_files — sentinel filtering / missing dir
+# ---------------------------------------------------------------------------
+
+
+class TestIterLockFiles:
+    def test_skips_sentinel_files_with_dotted_stem(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        (tmp_path / "repo_a.lock").write_text("{}")
+        # Sentinel created by locked_state_file would look like this.
+        (tmp_path / "repo_a.lock.lock").write_text("")
+        paths = store._iter_lock_files()
+        names = {p.name for p in paths}
+        assert names == {"repo_a.lock"}
+
+    def test_returns_sorted_first_tier_files(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        (tmp_path / "b.lock").write_text("{}")
+        (tmp_path / "a.lock").write_text("{}")
+        paths = store._iter_lock_files()
+        assert [p.name for p in paths] == ["a.lock", "b.lock"]
+
+    def test_empty_when_state_dir_missing(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        # Remove the directory after construction.
+        store._state_dir = tmp_path / "gone"
+        assert store._iter_lock_files() == []
+
+    def test_empty_when_no_lock_files(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        assert store._iter_lock_files() == []
+
+
+# ---------------------------------------------------------------------------
+# reclaim_if_stale — the None branch (no lock present)
+# ---------------------------------------------------------------------------
+
+
+class TestReclaimNone:
+    def test_reclaim_returns_false_when_no_lock(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        assert store.reclaim_if_stale("never_held") is False
+
+    def test_sweep_stale_empty_when_nothing_held(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        assert store.sweep_stale() == []
+
+
+# ---------------------------------------------------------------------------
+# _write_atomic — error cleanup path
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAtomicCleanup:
+    def test_tempfile_removed_when_replace_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = PersistentLockStore(tmp_path)
+        path = tmp_path / "repo_x.lock"
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(ls.os, "replace", boom)
+
+        with pytest.raises(OSError, match="replace failed"):
+            store._write_atomic(path, _payload())
+
+        # No leftover *.tmp tempfiles and the target was never created.
+        leftovers = list(tmp_path.glob("*.tmp"))
+        assert leftovers == []
+        assert not path.exists()
+
+    def test_cleanup_tolerates_missing_tempfile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = PersistentLockStore(tmp_path)
+        path = tmp_path / "repo_x.lock"
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("replace failed")
+
+        def vanish(target: str) -> None:
+            raise OSError("already gone")
+
+        monkeypatch.setattr(ls.os, "replace", boom)
+        monkeypatch.setattr(ls.os, "unlink", vanish)
+
+        # The unlink-failure is swallowed; the original error still propagates.
+        with pytest.raises(OSError, match="replace failed"):
+            store._write_atomic(path, _payload())
+
+    def test_write_atomic_creates_parent_dirs(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        nested = tmp_path / "deep" / "repo_x.lock"
+        store._write_atomic(nested, _payload())
+        assert nested.exists()
+        on_disk = json.loads(nested.read_text())
+        assert on_disk["repo_id"] == "repo_x"
+
+    def test_write_atomic_output_ends_with_newline(self, tmp_path: Path) -> None:
+        store = PersistentLockStore(tmp_path)
+        path = tmp_path / "repo_x.lock"
+        store._write_atomic(path, _payload())
+        assert path.read_text().endswith("\n")

--- a/tests/unit/backends/test_worker_backend_selector_cov.py
+++ b/tests/unit/backends/test_worker_backend_selector_cov.py
@@ -1,0 +1,584 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from operations_center.backends import worker_backend_selector as wbs
+from operations_center.backends.worker_backend_selector import (
+    WorkerBackendExecution,
+    WorkerBackendSelection,
+    alternate_worker_backend,
+    execute_with_worker_backend_round_robin,
+    maybe_record_worker_backend_cooldown,
+    parse_worker_backend_reset,
+    select_worker_backend,
+    worker_backend_candidates,
+    worker_backend_observed_runtime,
+)
+
+NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------
+# worker_backend_candidates
+# --------------------------------------------------------------------------
+def test_candidates_unsupported_backend_returns_self_only() -> None:
+    assert worker_backend_candidates("mystery") == ("mystery",)
+
+
+def test_candidates_remote_backend_includes_remote_alternates() -> None:
+    assert worker_backend_candidates("claude_code") == ("claude_code", "codex_cli")
+    assert worker_backend_candidates("codex_cli") == ("codex_cli", "claude_code")
+
+
+def test_candidates_local_backend_pools_among_local_only() -> None:
+    # aider_local has no other local alternate currently (set of one besides self).
+    assert worker_backend_candidates("aider_local") == ("aider_local", "direct_local")
+    assert worker_backend_candidates("direct_local") == ("direct_local", "aider_local")
+
+
+# --------------------------------------------------------------------------
+# alternate_worker_backend
+# --------------------------------------------------------------------------
+def test_alternate_remote() -> None:
+    assert alternate_worker_backend("claude_code") == "codex_cli"
+
+
+def test_alternate_local() -> None:
+    assert alternate_worker_backend("aider_local") == "direct_local"
+
+
+def test_alternate_unknown_falls_to_local_pool() -> None:
+    # Unknown backend is not in remote pool, so local pool is searched; first
+    # local candidate that differs is returned.
+    assert alternate_worker_backend("unknown") == "aider_local"
+
+
+# --------------------------------------------------------------------------
+# _read_worker_backend_cooldown
+# --------------------------------------------------------------------------
+def test_read_cooldown_prefers_blocked_until() -> None:
+    reset = NOW + timedelta(hours=1)
+    store = SimpleNamespace(
+        worker_backend_blocked_until=lambda backend, now: reset,
+        worker_backend_cooldown_until=lambda backend, now: None,
+    )
+    assert wbs._read_worker_backend_cooldown(store, "claude_code", now=NOW) == reset
+
+
+def test_read_cooldown_falls_back_to_cooldown_until() -> None:
+    reset = NOW + timedelta(hours=2)
+    store = SimpleNamespace(worker_backend_cooldown_until=lambda backend, now: reset)
+    assert wbs._read_worker_backend_cooldown(store, "claude_code", now=NOW) == reset
+
+
+def test_read_cooldown_no_methods_returns_none() -> None:
+    store = SimpleNamespace()
+    assert wbs._read_worker_backend_cooldown(store, "claude_code", now=NOW) is None
+
+
+def test_read_cooldown_non_callable_attr_ignored() -> None:
+    store = SimpleNamespace(worker_backend_blocked_until="not-callable")
+    assert wbs._read_worker_backend_cooldown(store, "claude_code", now=NOW) is None
+
+
+def test_read_cooldown_legacy_no_now_kwarg() -> None:
+    reset = NOW + timedelta(minutes=30)
+
+    def legacy(backend):  # no now kwarg -> TypeError on first call
+        return reset
+
+    store = SimpleNamespace(worker_backend_blocked_until=legacy)
+    assert wbs._read_worker_backend_cooldown(store, "claude_code", now=NOW) == reset
+
+
+# --------------------------------------------------------------------------
+# select_worker_backend
+# --------------------------------------------------------------------------
+def _store_with_cooldowns(mapping: dict[str, datetime | None]):
+    return SimpleNamespace(worker_backend_blocked_until=lambda backend, now: mapping.get(backend))
+
+
+def test_select_dynamic_disabled_returns_preferred() -> None:
+    store = _store_with_cooldowns({"claude_code": NOW + timedelta(hours=5)})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=False,
+        now=NOW,
+    )
+    assert sel.selected_backend == "claude_code"
+    assert sel.reason is None
+    assert sel.preferred_backend == "claude_code"
+
+
+def test_select_picks_preferred_when_no_cooldown() -> None:
+    store = _store_with_cooldowns({})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        now=NOW,
+    )
+    assert sel.selected_backend == "claude_code"
+
+
+def test_select_picks_preferred_when_cooldown_expired() -> None:
+    store = _store_with_cooldowns({"claude_code": NOW - timedelta(minutes=1)})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        now=NOW,
+    )
+    assert sel.selected_backend == "claude_code"
+
+
+def test_select_falls_back_to_alternate() -> None:
+    store = _store_with_cooldowns({"claude_code": NOW + timedelta(hours=2)})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        now=NOW,
+    )
+    assert sel.selected_backend == "codex_cli"
+
+
+def test_select_all_cooling_down_returns_none_with_reason() -> None:
+    reset = NOW + timedelta(hours=3)
+    store = _store_with_cooldowns({"claude_code": reset, "codex_cli": reset})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        now=NOW,
+    )
+    assert sel.selected_backend is None
+    assert sel.reason is not None
+    assert "all worker backends cooling down" in sel.reason
+    assert "claude_code until" in sel.reason
+    assert "codex_cli until" in sel.reason
+
+
+def test_select_default_now_uses_clock(monkeypatch) -> None:
+    store = _store_with_cooldowns({})
+    sel = select_worker_backend(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+    )
+    assert sel.selected_backend == "claude_code"
+
+
+# --------------------------------------------------------------------------
+# parse_worker_backend_reset
+# --------------------------------------------------------------------------
+def test_parse_timezone_reset_later_today() -> None:
+    out = "You're out of usage, resets 2:30pm (America/New_York)"
+    # NOW is 12:00 UTC == 08:00 EDT; 2:30pm EDT is later today.
+    result = parse_worker_backend_reset(out, "claude_code", now=NOW)
+    assert result is not None
+    assert result.tzinfo == UTC
+    local = result.astimezone(__import__("zoneinfo").ZoneInfo("America/New_York"))
+    assert (local.hour, local.minute) == (14, 30)
+
+
+def test_parse_timezone_reset_rolls_to_next_day() -> None:
+    # 8:00am EDT when it is already ~08:00 EDT -> should roll forward a day.
+    out = "resets 8:00am (America/New_York)"
+    result = parse_worker_backend_reset(out, "claude_code", now=NOW)
+    assert result is not None
+    assert result > NOW
+    # Roughly a day out (since reset_local <= now_local triggers +1 day).
+    assert result - NOW >= timedelta(hours=23)
+
+
+def test_parse_timezone_unknown_zone_returns_none() -> None:
+    out = "resets 4:20am (Not/AZone)"
+    assert parse_worker_backend_reset(out, "claude_code", now=NOW) is None
+
+
+def test_parse_iso_reset() -> None:
+    out = "rate limited; resets at 2026-06-03T09:15:00Z"
+    result = parse_worker_backend_reset(out, "claude_code", now=NOW)
+    assert result == datetime(2026, 6, 3, 9, 15, 0, tzinfo=UTC)
+
+
+def test_parse_iso_reset_no_seconds() -> None:
+    out = "resets 2026-06-03T09:15Z"
+    result = parse_worker_backend_reset(out, "claude_code", now=NOW)
+    assert result == datetime(2026, 6, 3, 9, 15, 0, tzinfo=UTC)
+
+
+def test_parse_relative_reset_hms() -> None:
+    out = "too many requests, try again in 1h 30m 15s"
+    result = parse_worker_backend_reset(out, "claude_code", now=NOW)
+    assert result == NOW + timedelta(hours=1, minutes=30, seconds=15)
+
+
+def test_parse_relative_reset_zero_delta_falls_through() -> None:
+    # "in 0h" style: matches relative regex but delta is zero -> not returned;
+    # also no capacity/limit signal -> None.
+    out = "available again in 0s and nothing else"
+    assert parse_worker_backend_reset(out, "claude_code", now=NOW) is None
+
+
+def test_parse_no_match_returns_none() -> None:
+    assert parse_worker_backend_reset("everything is fine", "claude_code", now=NOW) is None
+
+
+def test_parse_limit_signal_without_time_returns_none() -> None:
+    # Has a limit signal (429) but no parseable reset time -> still None.
+    out = "request failed with 429 too many requests"
+    assert parse_worker_backend_reset(out, "claude_code", now=NOW) is None
+
+
+def test_parse_default_now(monkeypatch) -> None:
+    out = "no limit here"
+    assert parse_worker_backend_reset(out, "claude_code") is None
+
+
+# --------------------------------------------------------------------------
+# maybe_record_worker_backend_cooldown
+# --------------------------------------------------------------------------
+def test_maybe_record_empty_output_returns_none() -> None:
+    store = SimpleNamespace()
+    assert (
+        maybe_record_worker_backend_cooldown(
+            usage_store=store, worker_backend="claude_code", combined_output=None
+        )
+        is None
+    )
+
+
+def test_maybe_record_no_reset_returns_none() -> None:
+    store = SimpleNamespace()
+    assert (
+        maybe_record_worker_backend_cooldown(
+            usage_store=store,
+            worker_backend="claude_code",
+            combined_output="all good",
+            now=NOW,
+        )
+        is None
+    )
+
+
+def test_maybe_record_calls_recorder_and_logger() -> None:
+    calls = {}
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        calls["kwargs"] = dict(
+            worker_backend=worker_backend,
+            reset_at=reset_at,
+            now=now,
+            limit_kind=limit_kind,
+            model=model,
+        )
+
+    logs: list[str] = []
+    store = SimpleNamespace(record_worker_backend_cooldown=recorder)
+    out = "Sonnet weekly limit reached, try again in 2h"
+    reset = maybe_record_worker_backend_cooldown(
+        usage_store=store,
+        worker_backend="claude_code",
+        combined_output=out,
+        now=NOW,
+        logger=logs.append,
+    )
+    assert reset == NOW + timedelta(hours=2)
+    assert calls["kwargs"]["worker_backend"] == "claude_code"
+    assert calls["kwargs"]["limit_kind"] == "model_weekly"
+    assert calls["kwargs"]["model"] == "sonnet"
+    assert logs and "cooling down until" in logs[0]
+    assert "(model_weekly/sonnet)" in logs[0]
+
+
+def test_maybe_record_generic_limit_kind_when_unclassified() -> None:
+    captured = {}
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        captured["limit_kind"] = limit_kind
+        captured["model"] = model
+
+    logs: list[str] = []
+    store = SimpleNamespace(record_worker_backend_cooldown=recorder)
+    # Relative reset present, but no recognizable limit-kind words/model.
+    out = "retry in 5m"
+    reset = maybe_record_worker_backend_cooldown(
+        usage_store=store,
+        worker_backend="claude_code",
+        combined_output=out,
+        now=NOW,
+        logger=logs.append,
+    )
+    assert reset == NOW + timedelta(minutes=5)
+    assert captured["limit_kind"] == "generic"
+    assert captured["model"] is None
+    # logger suffix without model component
+    assert "(generic)" in logs[0]
+
+
+def test_maybe_record_legacy_recorder_typeerror_fallback() -> None:
+    seen = {}
+
+    def legacy_recorder(*, worker_backend, reset_at, now):
+        seen["worker_backend"] = worker_backend
+        seen["reset_at"] = reset_at
+
+    store = SimpleNamespace(record_worker_backend_cooldown=legacy_recorder)
+    out = "usage limit reached, retry in 1h"
+    reset = maybe_record_worker_backend_cooldown(
+        usage_store=store,
+        worker_backend="codex_cli",
+        combined_output=out,
+        now=NOW,
+    )
+    assert reset == NOW + timedelta(hours=1)
+    assert seen["worker_backend"] == "codex_cli"
+
+
+def test_maybe_record_non_callable_recorder_skipped_no_logger() -> None:
+    store = SimpleNamespace(record_worker_backend_cooldown="nope")
+    out = "rate limit, retry in 30m"
+    reset = maybe_record_worker_backend_cooldown(
+        usage_store=store,
+        worker_backend="claude_code",
+        combined_output=out,
+        now=NOW,
+    )
+    assert reset == NOW + timedelta(minutes=30)
+
+
+# --------------------------------------------------------------------------
+# worker_backend_observed_runtime
+# --------------------------------------------------------------------------
+def test_observed_runtime_serializes_cooldowns() -> None:
+    reset = NOW + timedelta(hours=1)
+    selection = WorkerBackendSelection(
+        preferred_backend="claude_code",
+        selected_backend="codex_cli",
+        cooldowns={"claude_code": reset, "codex_cli": None},
+    )
+    execution = WorkerBackendExecution(
+        selected_backend="codex_cli",
+        payload="ok",
+        fallback_used=True,
+        selection=selection,
+    )
+    out = worker_backend_observed_runtime(execution)
+    assert out["worker_backend_strategy"] == "round_robin"
+    assert out["preferred_worker_backend"] == "claude_code"
+    assert out["selected_worker_backend"] == "codex_cli"
+    assert out["fallback_used"] is True
+    assert out["worker_backend_cooldowns"] == {
+        "claude_code": reset.isoformat(),
+        "codex_cli": None,
+    }
+
+
+# --------------------------------------------------------------------------
+# execute_with_worker_backend_round_robin
+# --------------------------------------------------------------------------
+def _ok_store():
+    return _store_with_cooldowns({})
+
+
+def test_round_robin_no_backend_available() -> None:
+    reset = NOW + timedelta(hours=3)
+    # Force select to return None by cooling everything; select uses datetime.now
+    # internally, so make resets far in the future.
+    far = datetime.now(UTC) + timedelta(hours=10)
+    store = _store_with_cooldowns({"claude_code": far, "codex_cli": far})
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=lambda b: pytest.fail("should not execute"),
+        failed=lambda p: True,
+        failure_text=lambda p: None,
+    )
+    assert result.selected_backend is None
+    assert result.payload is None
+    assert result.fallback_used is False
+    assert reset  # silence unused
+
+
+def test_round_robin_primary_succeeds() -> None:
+    store = _ok_store()
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=lambda b: f"payload-{b}",
+        failed=lambda p: False,
+        failure_text=lambda p: None,
+    )
+    assert result.selected_backend == "claude_code"
+    assert result.payload == "payload-claude_code"
+    assert result.fallback_used is False
+
+
+def test_round_robin_primary_fails_no_cooldown_recorded() -> None:
+    store = _ok_store()
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=lambda b: f"payload-{b}",
+        failed=lambda p: True,
+        failure_text=lambda p: "generic crash, no limit signal",
+    )
+    # reset_at is None -> returns primary, no fallback.
+    assert result.selected_backend == "claude_code"
+    assert result.fallback_used is False
+
+
+def test_round_robin_dynamic_disabled_no_fallback() -> None:
+    store = _ok_store()
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=False,
+        execute_once=lambda b: f"payload-{b}",
+        failed=lambda p: True,
+        failure_text=lambda p: "usage limit reached, retry in 1h",
+    )
+    # reset_at parsed but dynamic_enabled False -> no fallback path.
+    assert result.selected_backend == "claude_code"
+    assert result.fallback_used is False
+
+
+def test_round_robin_falls_back_to_alternate_success() -> None:
+    # Primary fails with a limit; after recording cooldown the fallback select
+    # must pick the alternate. We track recorded backends in a mutable store.
+    cooled: dict[str, datetime] = {}
+
+    def blocked_until(backend, now):
+        return cooled.get(backend)
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        cooled[worker_backend] = reset_at
+
+    store = SimpleNamespace(
+        worker_backend_blocked_until=blocked_until,
+        record_worker_backend_cooldown=recorder,
+    )
+    logs: list[str] = []
+
+    def execute_once(backend):
+        return {"backend": backend, "fail": backend == "claude_code"}
+
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=execute_once,
+        failed=lambda p: p["fail"],
+        failure_text=lambda p: "usage limit reached, retry in 2h" if p["fail"] else None,
+        logger=logs.append,
+    )
+    assert result.fallback_used is True
+    assert result.selected_backend == "codex_cli"
+    assert result.payload["backend"] == "codex_cli"
+    assert any("retrying with codex_cli" in m for m in logs)
+
+
+def test_round_robin_fallback_also_fails_records_cooldown() -> None:
+    cooled: dict[str, datetime] = {}
+
+    def blocked_until(backend, now):
+        return cooled.get(backend)
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        cooled[worker_backend] = reset_at
+
+    store = SimpleNamespace(
+        worker_backend_blocked_until=blocked_until,
+        record_worker_backend_cooldown=recorder,
+    )
+
+    def execute_once(backend):
+        return {"backend": backend, "fail": True}
+
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="claude_code",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=execute_once,
+        failed=lambda p: p["fail"],
+        failure_text=lambda p: "usage limit reached, retry in 2h",
+    )
+    assert result.fallback_used is True
+    assert result.selected_backend == "codex_cli"
+    # Both backends recorded as cooled down.
+    assert set(cooled) == {"claude_code", "codex_cli"}
+
+
+def test_round_robin_fallback_same_as_primary_no_retry() -> None:
+    # Local backend whose only alternate is also local: after the primary is
+    # cooled, the fallback select returns None (only one local runnable), so we
+    # keep the primary payload with fallback_used False.
+    cooled: dict[str, datetime] = {}
+
+    def blocked_until(backend, now):
+        return cooled.get(backend)
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        cooled[worker_backend] = reset_at
+
+    store = SimpleNamespace(
+        worker_backend_blocked_until=blocked_until,
+        record_worker_backend_cooldown=recorder,
+    )
+
+    def execute_once(backend):
+        return {"backend": backend, "fail": True}
+
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="aider_local",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=execute_once,
+        failed=lambda p: p["fail"],
+        failure_text=lambda p: "usage limit reached, retry in 2h",
+    )
+    # After cooling aider_local, the only alternate (direct_local) is runnable,
+    # so it actually falls back. Adjust expectation: fallback to direct_local.
+    assert result.selected_backend == "direct_local"
+    assert result.fallback_used is True
+
+
+def test_round_robin_fallback_none_keeps_primary() -> None:
+    # An unsupported backend has no alternates (candidates == self only). When it
+    # fails with a limit and is cooled, the fallback select returns None, so the
+    # primary payload is kept with fallback_used False (lines 304-313).
+    cooled: dict[str, datetime] = {}
+
+    def blocked_until(backend, now):
+        return cooled.get(backend)
+
+    def recorder(*, worker_backend, reset_at, now, limit_kind, model):
+        cooled[worker_backend] = reset_at
+
+    store = SimpleNamespace(
+        worker_backend_blocked_until=blocked_until,
+        record_worker_backend_cooldown=recorder,
+    )
+
+    result = execute_with_worker_backend_round_robin(
+        preferred_backend="mystery_backend",
+        usage_store=store,
+        dynamic_enabled=True,
+        execute_once=lambda b: {"backend": b, "fail": True},
+        failed=lambda p: p["fail"],
+        failure_text=lambda p: "usage limit reached, retry in 2h",
+    )
+    assert result.selected_backend == "mystery_backend"
+    assert result.fallback_used is False
+    assert result.selection.selected_backend is None

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/__init__.py
+++ b/tests/unit/entrypoints/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/board_worker/__init__.py
+++ b/tests/unit/entrypoints/board_worker/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/board_worker/test__text_cov.py
+++ b/tests/unit/entrypoints/board_worker/test__text_cov.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from operations_center.entrypoints.board_worker import _text
+
+
+# --------------------------------------------------------------------------
+# desc_text
+# --------------------------------------------------------------------------
+def test_desc_text_prefers_description():
+    assert _text.desc_text({"description": "plain", "description_html": "<b>x</b>"}) == "plain"
+
+
+def test_desc_text_falls_back_to_stripped():
+    assert _text.desc_text({"description_stripped": "stripped"}) == "stripped"
+
+
+def test_desc_text_strips_html_and_unescapes():
+    issue = {"description_html": "<p>Hello<br>World &amp; more</p>"}
+    assert _text.desc_text(issue) == "Hello\nWorld & more"
+
+
+def test_desc_text_self_closing_br():
+    assert _text.desc_text({"description_html": "a<br/>b"}) == "a\nb"
+
+
+def test_desc_text_empty_when_nothing_present():
+    assert _text.desc_text({}) == ""
+
+
+def test_desc_text_html_key_present_but_empty():
+    # description/stripped empty, html key exists but is falsy -> stays ""
+    assert _text.desc_text({"description": "", "description_html": ""}) == ""
+
+
+# --------------------------------------------------------------------------
+# extract_goal
+# --------------------------------------------------------------------------
+def test_extract_goal_from_section():
+    desc = "intro\n## Goal\nDo the thing\nand more\n## Other\nx"
+    assert _text.extract_goal(desc, "TITLE") == "Do the thing\nand more"
+
+
+def test_extract_goal_runs_to_end_of_string():
+    desc = "## Goal\nFinal goal text"
+    assert _text.extract_goal(desc, "TITLE") == "Final goal text"
+
+
+def test_extract_goal_case_insensitive():
+    desc = "## goal\nlower"
+    assert _text.extract_goal(desc, "TITLE") == "lower"
+
+
+def test_extract_goal_empty_section_falls_back_to_title():
+    desc = "## Goal\n   \n## Next\nx"
+    assert _text.extract_goal(desc, "MyTitle") == "MyTitle"
+
+
+def test_extract_goal_no_section_falls_back_to_title():
+    assert _text.extract_goal("no goal here", "MyTitle") == "MyTitle"
+
+
+# --------------------------------------------------------------------------
+# task_type_from_kind
+# --------------------------------------------------------------------------
+def test_task_type_from_kind_known():
+    assert _text.task_type_from_kind("goal") == "feature"
+    assert _text.task_type_from_kind("test") == "test"
+    assert _text.task_type_from_kind("test_campaign") == "test"
+    assert _text.task_type_from_kind("improve") == "refactor"
+    assert _text.task_type_from_kind("improve_campaign") == "refactor"
+    assert _text.task_type_from_kind("spec-author") == "chore"
+
+
+def test_task_type_from_kind_unknown():
+    assert _text.task_type_from_kind("anything-else") == "chore"
+
+
+# --------------------------------------------------------------------------
+# parse_spec_author_payload
+# --------------------------------------------------------------------------
+def test_parse_spec_author_payload_plain_yaml():
+    desc = "intro\n```yaml\nspec_slug: foo\ntask_phase: test\n```\ntail"
+    data = _text.parse_spec_author_payload(desc)
+    assert data == {"spec_slug": "foo", "task_phase": "test"}
+
+
+def test_parse_spec_author_payload_strips_html():
+    desc = "<p>x</p>```yaml<br>spec_slug: bar &amp; baz<br>```"
+    data = _text.parse_spec_author_payload(desc)
+    assert data == {"spec_slug": "bar & baz"}
+
+
+def test_parse_spec_author_payload_no_fence_returns_none():
+    assert _text.parse_spec_author_payload("no yaml here") is None
+
+
+def test_parse_spec_author_payload_invalid_yaml_returns_none():
+    # tab+colon style that breaks yaml parsing
+    desc = "```yaml\nkey: : : [unbalanced\n```"
+    assert _text.parse_spec_author_payload(desc) is None
+
+
+def test_parse_spec_author_payload_non_dict_returns_none():
+    desc = "```yaml\n- just\n- a\n- list\n```"
+    assert _text.parse_spec_author_payload(desc) is None
+
+
+# --------------------------------------------------------------------------
+# summarize_prompt_diff_block
+# --------------------------------------------------------------------------
+def _open():
+    return _text._PROMPT_DIFF_OPEN
+
+
+def _close():
+    return _text._PROMPT_DIFF_CLOSE
+
+
+def test_summarize_read_failure(tmp_path):
+    count, note = _text.summarize_prompt_diff_block(
+        workspace=tmp_path, target_path="does_not_exist.md"
+    )
+    assert count is None
+    assert note.startswith("read failed:")
+
+
+def test_summarize_absent_fence(tmp_path):
+    (tmp_path / "spec.md").write_text("no fence here", encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note == "absent"
+
+
+def test_summarize_only_open_marker_is_absent(tmp_path):
+    (tmp_path / "spec.md").write_text(_open() + "\nedits:\n", encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note == "absent"
+
+
+def test_summarize_parsed(tmp_path):
+    body = (
+        "edits:\n"
+        "  - op: replace\n"
+        '    anchor: "a"\n'
+        '    new_text: "b"\n'
+        '    reason: "r"\n'
+        "  - op: append\n"
+        '    new_text: "x"\n'
+        '    reason: "r2"\n'
+    )
+    content = f"spec body\n{_open()}\n{body}{_close()}\ntrailer"
+    (tmp_path / "spec.md").write_text(content, encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count == 2
+    assert note == "parsed"
+
+
+def test_summarize_edits_key_missing(tmp_path):
+    body = "other: value\n"
+    content = f"{_open()}\n{body}{_close()}"
+    (tmp_path / "spec.md").write_text(content, encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note == "edits key missing or not a list"
+
+
+def test_summarize_empty_body_yaml_none(tmp_path):
+    # empty body -> yaml.safe_load returns None -> doc becomes {} -> edits missing
+    content = f"{_open()}\n{_close()}"
+    (tmp_path / "spec.md").write_text(content, encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note == "edits key missing or not a list"
+
+
+def test_summarize_parse_failure_invalid_edit(tmp_path):
+    # edits is a list but entries fail Edit.model_validate (missing required reason)
+    body = "edits:\n  - op: replace\n    anchor: a\n    new_text: b\n"
+    content = f"{_open()}\n{body}{_close()}"
+    (tmp_path / "spec.md").write_text(content, encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note.startswith("parse failed:")
+
+
+def test_summarize_malformed_yaml_in_body(tmp_path):
+    body = "edits: : : [\n"
+    content = f"{_open()}\n{body}{_close()}"
+    (tmp_path / "spec.md").write_text(content, encoding="utf-8")
+    count, note = _text.summarize_prompt_diff_block(workspace=tmp_path, target_path="spec.md")
+    assert count is None
+    assert note.startswith("parse failed:")
+
+
+# --------------------------------------------------------------------------
+# build_phase_advance_goal_text
+# --------------------------------------------------------------------------
+def test_build_phase_advance_basic():
+    out = _text.build_phase_advance_goal_text(
+        spec_slug="myslug",
+        target_path="specs/foo.md",
+        task_phase="test",
+        seed_text="",
+        ctx={},
+        run_id_placeholder="RUN123",
+    )
+    assert "Spec phase advance — myslug -> test" in out
+    assert "specs/foo.md" in out
+    assert "RUN123" in out
+    assert _open() in out
+    assert _close() in out
+    # no seed -> no phase state section
+    assert "Phase state (from spec_hygiene)" not in out
+    # no git repos
+    assert "Recent Git Activity" not in out
+
+
+def test_build_phase_advance_with_seed_and_repos():
+    ctx = {"recent_git_log_repos": {"repoA": "log lines", "repoB": ""}}
+    out = _text.build_phase_advance_goal_text(
+        spec_slug="s",
+        target_path="t.md",
+        task_phase="improve",
+        seed_text="SEED",
+        ctx=ctx,
+        run_id_placeholder="R",
+    )
+    assert "Phase state (from spec_hygiene)" in out
+    assert "SEED" in out
+    assert "Recent Git Activity (repoA)" in out
+    # empty log skipped
+    assert "Recent Git Activity (repoB)" not in out
+
+
+def test_build_phase_advance_repos_not_dict():
+    out = _text.build_phase_advance_goal_text(
+        spec_slug="s",
+        target_path="t.md",
+        task_phase="p",
+        seed_text="",
+        ctx={"recent_git_log_repos": "not a dict"},
+        run_id_placeholder="R",
+    )
+    assert "Recent Git Activity" not in out
+
+
+# --------------------------------------------------------------------------
+# build_spec_author_goal_text
+# --------------------------------------------------------------------------
+def test_build_spec_author_delegates_when_phase_present(monkeypatch):
+    called = {}
+
+    def fake(**kwargs):
+        called.update(kwargs)
+        return "DELEGATED"
+
+    monkeypatch.setattr(_text, "build_phase_advance_goal_text", fake)
+    payload = {
+        "spec_slug": "sl",
+        "target_path": "tp.md",
+        "task_phase": "test",
+        "seed_text": "sd",
+        "context_bundle": {"k": "v"},
+    }
+    out = _text.build_spec_author_goal_text(payload, "RUNID")
+    assert out == "DELEGATED"
+    assert called["spec_slug"] == "sl"
+    assert called["task_phase"] == "test"
+    assert called["ctx"] == {"k": "v"}
+    assert called["run_id_placeholder"] == "RUNID"
+
+
+def test_build_spec_author_delegates_ctx_not_dict(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        _text,
+        "build_phase_advance_goal_text",
+        lambda **kw: captured.update(kw) or "X",
+    )
+    payload = {"task_phase": "p", "context_bundle": ["notdict"]}
+    _text.build_spec_author_goal_text(payload, "R")
+    assert captured["ctx"] == {}
+
+
+def test_build_spec_author_full_authoring():
+    payload = {
+        "spec_slug": "newslug",
+        "target_path": "specs/new.md",
+        "trigger_source": "operator",
+        "seed_text": "do better",
+        "context_bundle": {
+            "recent_git_log_repos": {"repoX": "commit1", "repoY": ""},
+            "existing_specs": ["specs/old.md"],
+            "board_snapshot": {"ready": 3, "running": 1, "drained": 0},
+        },
+    }
+    out = _text.build_spec_author_goal_text(payload, "RUN9")
+    assert "Spec authoring task" in out
+    assert "specs/new.md" in out
+    assert "RUN9" in out
+    assert "slug: newslug" in out
+    assert "## Available Repos" in out
+    assert "- repoX" in out
+    assert "## Operator Direction\ndo better" in out
+    assert "Recent Git Activity (repoX)" in out
+    assert "Recent Git Activity (repoY)" not in out
+    assert "Existing Specs (do not duplicate)" in out
+    assert "- specs/old.md" in out
+    assert "## Board Summary" in out
+    assert "ready: 3" in out
+    assert "trigger_source: operator" in out
+
+
+def test_build_spec_author_minimal_no_optionals():
+    payload = {"spec_slug": "s", "target_path": "t.md"}
+    out = _text.build_spec_author_goal_text(payload, "R")
+    assert "Spec authoring task" in out
+    assert "## Available Repos" not in out
+    assert "## Operator Direction" not in out
+    assert "Existing Specs" not in out
+    assert "## Board Summary" not in out
+    assert "## Boundaries" in out
+
+
+def test_build_spec_author_repos_present_but_empty_dict():
+    payload = {
+        "spec_slug": "s",
+        "target_path": "t.md",
+        "context_bundle": {"recent_git_log_repos": {}},
+    }
+    out = _text.build_spec_author_goal_text(payload, "R")
+    assert "## Available Repos" not in out
+
+
+def test_build_spec_author_board_snapshot_not_dict():
+    payload = {
+        "spec_slug": "s",
+        "target_path": "t.md",
+        "context_bundle": {"board_snapshot": "nope"},
+    }
+    out = _text.build_spec_author_goal_text(payload, "R")
+    assert "## Board Summary" not in out
+
+
+def test_build_spec_author_board_snapshot_missing_keys():
+    payload = {
+        "spec_slug": "s",
+        "target_path": "t.md",
+        "context_bundle": {"board_snapshot": {"ready": 5}},
+    }
+    out = _text.build_spec_author_goal_text(payload, "R")
+    assert "ready: 5" in out
+    assert "running: ?" in out
+    assert "drained: ?" in out
+
+
+def test_build_spec_author_context_bundle_missing_uses_empty():
+    payload = {"spec_slug": "s", "target_path": "t.md", "context_bundle": None}
+    out = _text.build_spec_author_goal_text(payload, "R")
+    assert "Spec authoring task" in out

--- a/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
@@ -1,0 +1,549 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from operations_center.entrypoints.board_worker import dispatch
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_settings(repos=None):
+    return SimpleNamespace(
+        repos=repos or {},
+        plane=SimpleNamespace(project_id="proj-1"),
+        team_executor=SimpleNamespace(timeout_seconds=900),
+    )
+
+
+def _make_repo_cfg(**kw):
+    defaults = dict(
+        clone_url="https://example.com/repo.git",
+        sandbox_base_branch=None,
+        default_branch="main",
+        local_path=None,
+        require_explicit_approval=False,
+    )
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def _make_issue(
+    task_id="abcdef0123456789",
+    labels=None,
+    name="My Task",
+    description="do the thing",
+):
+    return {
+        "id": task_id,
+        "labels": labels if labels is not None else [{"name": "repo: myrepo"}],
+        "name": name,
+        "description_stripped": description,
+    }
+
+
+class FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _install_common_patches(monkeypatch):
+    """Patch out subprocess-adjacent helpers so dispatch is hermetic."""
+    monkeypatch.setattr(dispatch, "venv_python", lambda root: "/fake/python")
+    monkeypatch.setattr(dispatch, "build_env", lambda root: {"PATH": "/fake"})
+    monkeypatch.setattr(dispatch, "task_type_from_kind", lambda kind: "feature")
+    monkeypatch.setattr(dispatch, "desc_text", lambda issue: issue.get("description_stripped", ""))
+    monkeypatch.setattr(dispatch, "extract_goal", lambda desc, title: desc or title)
+
+
+# ── _repo_local_path ───────────────────────────────────────────────────────────
+
+
+def test_repo_local_path_uses_configured_local_path():
+    settings = _make_settings({"r": _make_repo_cfg(local_path="/srv/r")})
+    assert dispatch._repo_local_path(settings, "r") == "/srv/r"
+
+
+def test_repo_local_path_falls_back_to_github_dir():
+    settings = _make_settings({})
+    out = dispatch._repo_local_path(settings, "ghost")
+    assert out.endswith("/ghost")
+    assert str(dispatch.GITHUB_DIR) in out
+
+
+def test_repo_local_path_repo_without_local_path():
+    settings = _make_settings({"r": _make_repo_cfg(local_path=None)})
+    out = dispatch._repo_local_path(settings, "r")
+    assert out.endswith("/r")
+
+
+# ── prompt builders ──────────────────────────────────────────────────────────
+
+
+def test_append_definition_of_done():
+    out = dispatch._append_definition_of_done("GOAL")
+    assert out.startswith("GOAL")
+    assert "Definition of done" in out
+
+
+def test_append_improve_output_prompt():
+    out = dispatch._append_improve_output_prompt("GOAL")
+    assert out.startswith("GOAL")
+    assert "improve-output.json" in out
+
+
+# ── _build_forwarded_labels ──────────────────────────────────────────────────
+
+
+def test_build_forwarded_labels_no_explicit_required():
+    labels = [
+        {"name": "review_required"},
+        {"name": "source: autonomy"},
+        {"name": "source: human"},
+        {"name": "repo: x"},
+        "plain-string",
+    ]
+    out = dispatch._build_forwarded_labels(labels, _make_repo_cfg(require_explicit_approval=False))
+    assert "review_required" in out
+    assert "source: autonomy" in out
+    assert "source: human" in out
+    # Non-source / non-review labels are dropped.
+    assert "repo: x" not in out
+    assert "plain-string" not in out
+
+
+def test_build_forwarded_labels_explicit_required_filters_and_appends():
+    labels = [
+        {"name": "source: autonomy"},
+        {"name": "source: human"},
+    ]
+    out = dispatch._build_forwarded_labels(labels, _make_repo_cfg(require_explicit_approval=True))
+    assert "source: autonomy" not in out  # filtered out
+    assert "source: human" in out  # kept
+    assert "review_required" in out  # appended
+
+
+def test_build_forwarded_labels_none_repo_cfg():
+    out = dispatch._build_forwarded_labels([{"name": "source: x"}], None)
+    assert out == ["source: x"]
+
+
+# ── dispatch_issue: spec-author short-circuit ────────────────────────────────
+
+
+def test_dispatch_issue_spec_author_short_circuits(monkeypatch):
+    _install_common_patches(monkeypatch)
+    sentinel = MagicMock(return_value=True)
+    monkeypatch.setattr(dispatch, "_dispatch_spec_author", sentinel)
+    issue = _make_issue(labels=[{"name": "task-kind: spec-author"}, {"name": "repo: r"}])
+    out = dispatch.dispatch_issue(issue, "goal", "/cfg.yaml", _make_settings(), MagicMock())
+    assert out is True
+    assert sentinel.called
+
+
+# ── dispatch_issue: planning failures ────────────────────────────────────────
+
+
+def _planning_setup(monkeypatch, plan_proc, settings=None):
+    _install_common_patches(monkeypatch)
+    settings = settings or _make_settings({"myrepo": _make_repo_cfg()})
+    fail_task = MagicMock()
+    monkeypatch.setattr(dispatch, "fail_task", fail_task)
+    monkeypatch.setattr(dispatch.subprocess, "run", MagicMock(return_value=plan_proc))
+    return settings, fail_task
+
+
+def test_dispatch_issue_planning_no_json(monkeypatch):
+    settings, fail_task = _planning_setup(
+        monkeypatch, FakeProc(stdout="not json", stderr="err", returncode=0)
+    )
+    client = MagicMock()
+    out = dispatch.dispatch_issue(_make_issue(), "goal", "/cfg.yaml", settings, client)
+    assert out is False
+    assert "no JSON" in fail_task.call_args[0][3]
+
+
+def test_dispatch_issue_planning_nonzero_returncode(monkeypatch):
+    bundle = {"message": "kaboom"}
+    settings, fail_task = _planning_setup(
+        monkeypatch, FakeProc(stdout=json.dumps(bundle), returncode=2)
+    )
+    client = MagicMock()
+    out = dispatch.dispatch_issue(_make_issue(), "improve", "/cfg.yaml", settings, client)
+    assert out is False
+    assert "planning failed: kaboom" in fail_task.call_args[0][3]
+
+
+def test_dispatch_issue_rejection_patterns_appended(monkeypatch):
+    _install_common_patches(monkeypatch)
+    settings = _make_settings({"myrepo": _make_repo_cfg()})
+    monkeypatch.setattr(dispatch, "fail_task", MagicMock())
+
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return FakeProc(stdout="notjson", returncode=0)
+
+    monkeypatch.setattr(dispatch.subprocess, "run", fake_run)
+
+    # Inject a fake quality_alerts module so the import inside dispatch succeeds.
+    import sys
+
+    fake_mod = SimpleNamespace(
+        _load_rejection_patterns_for_proposal=lambda repo_key: ["bad1", "bad2"]
+    )
+    monkeypatch.setitem(sys.modules, "operations_center.quality_alerts", fake_mod)
+
+    dispatch.dispatch_issue(_make_issue(), "goal", "/cfg.yaml", settings, MagicMock())
+    goal_idx = captured["cmd"].index("--goal") + 1
+    assert "Rejection patterns to avoid" in captured["cmd"][goal_idx]
+    assert "bad1" in captured["cmd"][goal_idx]
+
+
+# ── dispatch_issue: full execution path ──────────────────────────────────────
+
+
+def _run_dispatch_execution(
+    monkeypatch,
+    tmp_path,
+    *,
+    role="goal",
+    plan_bundle=None,
+    exec_outcome=None,
+    write_result=True,
+    result_text=None,
+    retry_outcome=None,
+    settings=None,
+    labels=None,
+    workspace_files=None,
+):
+    """Drive dispatch_issue through the execute branch.
+
+    Returns (out, handle_success_mock, handle_failure_mock, fail_task_mock, client).
+    """
+    _install_common_patches(monkeypatch)
+    settings = settings or _make_settings({"myrepo": _make_repo_cfg()})
+    plan_bundle = plan_bundle if plan_bundle is not None else {"proposal": {}}
+
+    hs = MagicMock()
+    hf = MagicMock()
+    ft = MagicMock()
+    monkeypatch.setattr(dispatch, "handle_success", hs)
+    monkeypatch.setattr(dispatch, "handle_failure", hf)
+    monkeypatch.setattr(dispatch, "fail_task", ft)
+    monkeypatch.setattr(dispatch, "add_label", MagicMock())
+    monkeypatch.setattr(dispatch, "read_improve_output", lambda ws: [{"title": "s"}])
+    monkeypatch.setattr(
+        dispatch, "is_transient_failure", lambda r: r.get("failure_reason") == "network"
+    )
+
+    # Force tempfile to use a deterministic dir under tmp_path so we can inspect.
+    tmpdir = tmp_path / "work"
+    tmpdir.mkdir()
+
+    class FakeTmp:
+        def __init__(self, prefix=""):
+            self.name = str(tmpdir)
+
+        def __enter__(self):
+            return self.name
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(dispatch.tempfile, "TemporaryDirectory", FakeTmp)
+    monkeypatch.setattr(dispatch.shutil, "copy", lambda a, b: None)
+
+    config_path = tmp_path / "cfg.yaml"
+    config_path.write_text("x: 1")
+
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        calls["n"] += 1
+        # Planning call is first.
+        if "operations_center.entrypoints.worker.main" in cmd:
+            return FakeProc(stdout=json.dumps(plan_bundle), returncode=0)
+        # Execute call(s): write result file at --output path.
+        out_path = cmd[cmd.index("--output") + 1]
+        is_retry = "_retry" in cmd[cmd.index("--source") + 1]
+        ws_path = tmpdir / "workspace"
+        if workspace_files:
+            for fname, content in workspace_files.items():
+                (ws_path / fname).write_text(content)
+        if is_retry:
+            if retry_outcome is not None:
+                from pathlib import Path as _P
+
+                _P(out_path).write_text(json.dumps(retry_outcome))
+            return FakeProc(returncode=0)
+        if write_result:
+            from pathlib import Path as _P
+
+            txt = result_text if result_text is not None else json.dumps(exec_outcome or {})
+            _P(out_path).write_text(txt)
+        return FakeProc(returncode=0)
+
+    monkeypatch.setattr(dispatch.subprocess, "run", fake_run)
+
+    client = MagicMock()
+    issue = _make_issue(labels=labels)
+    out = dispatch.dispatch_issue(issue, role, config_path, settings, client)
+    return out, hs, hf, ft, client
+
+
+def test_dispatch_issue_execute_no_result_file(monkeypatch, tmp_path):
+    out, hs, hf, ft, _ = _run_dispatch_execution(monkeypatch, tmp_path, write_result=False)
+    assert out is False
+    assert "no result file" in ft.call_args[0][3]
+
+
+def test_dispatch_issue_execute_empty_result(monkeypatch, tmp_path):
+    monkeypatch.setattr(dispatch, "add_label", MagicMock())
+    inc = MagicMock()
+    import operations_center.entrypoints.board_worker.labels as labels_mod
+
+    monkeypatch.setattr(labels_mod, "increment_retry_count", inc)
+    out, hs, hf, ft, client = _run_dispatch_execution(monkeypatch, tmp_path, result_text="   ")
+    assert out is False
+    assert inc.called
+    assert "empty result.json" in ft.call_args[0][3]
+
+
+def test_dispatch_issue_execute_success(monkeypatch, tmp_path):
+    outcome = {
+        "result": {
+            "success": True,
+            "status": "done",
+            "needs_verification": False,
+            "pull_request_url": "https://pr/1",
+        }
+    }
+    out, hs, hf, ft, _ = _run_dispatch_execution(monkeypatch, tmp_path, exec_outcome=outcome)
+    assert out is True
+    assert hs.called
+    assert hf.called is False
+
+
+def test_dispatch_issue_execute_success_improve_role(monkeypatch, tmp_path):
+    outcome = {"result": {"success": True, "status": "done"}}
+    out, hs, hf, ft, _ = _run_dispatch_execution(
+        monkeypatch, tmp_path, role="improve", exec_outcome=outcome
+    )
+    assert out is True
+    # improve_suggestions forwarded.
+    assert hs.call_args.kwargs["improve_suggestions"] == [{"title": "s"}]
+
+
+def test_dispatch_issue_execute_failure(monkeypatch, tmp_path):
+    outcome = {"result": {"success": False, "status": "errored"}}
+    out, hs, hf, ft, _ = _run_dispatch_execution(monkeypatch, tmp_path, exec_outcome=outcome)
+    assert out is False
+    assert hf.called
+    assert hs.called is False
+
+
+def test_dispatch_issue_scope_too_wide(monkeypatch, tmp_path):
+    outcome = {
+        "result": {
+            "success": True,
+            "status": "done",
+            "branch_pushed": False,
+            "failure_category": "scope_too_wide",
+        }
+    }
+    out, hs, hf, ft, _ = _run_dispatch_execution(
+        monkeypatch,
+        tmp_path,
+        exec_outcome=outcome,
+        workspace_files={"scope-too-wide.json": json.dumps({"files": ["a.py", "b.py"]})},
+    )
+    assert out is False
+    assert hf.called
+    assert hf.call_args.kwargs["scope_files"] == ["a.py", "b.py"]
+
+
+def test_dispatch_issue_scope_file_bad_json(monkeypatch, tmp_path):
+    outcome = {
+        "result": {
+            "success": True,
+            "status": "done",
+            "branch_pushed": False,
+            "failure_category": "scope_too_wide",
+        }
+    }
+    out, hs, hf, ft, _ = _run_dispatch_execution(
+        monkeypatch,
+        tmp_path,
+        exec_outcome=outcome,
+        workspace_files={"scope-too-wide.json": "{not json"},
+    )
+    assert out is False
+    assert hf.call_args.kwargs["scope_files"] == []
+
+
+def test_dispatch_issue_transient_retry_succeeds(monkeypatch, tmp_path):
+    first = {"result": {"success": False, "status": "err", "failure_reason": "network"}}
+    retry = {"result": {"success": True, "status": "done"}}
+    out, hs, hf, ft, _ = _run_dispatch_execution(
+        monkeypatch, tmp_path, exec_outcome=first, retry_outcome=retry
+    )
+    assert out is True
+    assert hs.called
+
+
+def test_dispatch_issue_transient_retry_no_file(monkeypatch, tmp_path):
+    first = {"result": {"success": False, "status": "err", "failure_reason": "network"}}
+    # retry_outcome None => retry subprocess writes nothing => keep original failure.
+    out, hs, hf, ft, _ = _run_dispatch_execution(
+        monkeypatch, tmp_path, exec_outcome=first, retry_outcome=None
+    )
+    assert out is False
+    assert hf.called
+
+
+# ── CI loop branch ───────────────────────────────────────────────────────────
+
+
+def test_dispatch_issue_ci_loop_branch(monkeypatch, tmp_path):
+    _install_common_patches(monkeypatch)
+    settings = _make_settings({"myrepo": _make_repo_cfg()})
+    monkeypatch.setattr(dispatch.shutil, "copy", lambda a, b: None)
+
+    run_ci = MagicMock(return_value=True)
+    monkeypatch.setattr(dispatch, "run_ci_loop", run_ci)
+
+    tmpdir = tmp_path / "work"
+    tmpdir.mkdir()
+
+    class FakeTmp:
+        def __init__(self, prefix=""):
+            pass
+
+        def __enter__(self):
+            return str(tmpdir)
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(dispatch.tempfile, "TemporaryDirectory", FakeTmp)
+
+    bundle = {"proposal": {"continuous_improvement": {"spec": 1}}}
+
+    def fake_run(cmd, **kw):
+        return FakeProc(stdout=json.dumps(bundle), returncode=0)
+
+    monkeypatch.setattr(dispatch.subprocess, "run", fake_run)
+
+    config_path = tmp_path / "cfg.yaml"
+    config_path.write_text("x: 1")
+
+    labels = [{"name": "repo: myrepo"}, {"name": "task-kind: improve_campaign"}]
+    out = dispatch.dispatch_issue(
+        _make_issue(labels=labels), "improve", config_path, settings, MagicMock()
+    )
+    assert out is True
+    assert run_ci.called
+
+
+# ── _dispatch_spec_author ────────────────────────────────────────────────────
+
+
+def test_dispatch_spec_author_no_payload(monkeypatch):
+    _install_common_patches(monkeypatch)
+    ft = MagicMock()
+    monkeypatch.setattr(dispatch, "fail_task", ft)
+
+    import operations_center.entrypoints.board_worker._text as text_mod
+
+    monkeypatch.setattr(text_mod, "parse_spec_author_payload", lambda d: None)
+
+    out = dispatch._dispatch_spec_author(
+        issue=_make_issue(),
+        role="goal",
+        settings=_make_settings(),
+        client=MagicMock(),
+        config_path="/cfg.yaml",
+        description="no yaml",
+        labels=[],
+        task_id="t1",
+    )
+    assert out is False
+    assert "payload missing" in ft.call_args[0][3]
+
+
+def test_dispatch_spec_author_happy(monkeypatch):
+    _install_common_patches(monkeypatch)
+    monkeypatch.setattr(dispatch, "venv_python", lambda r: "/py")
+    monkeypatch.setattr(dispatch, "build_env", lambda r: {})
+
+    import operations_center.entrypoints.board_worker._text as text_mod
+
+    payload = {
+        "target_path": "specs/x.md",
+        "spec_slug": "x",
+        "trigger_source": "cron",
+        "task_phase": "draft",
+    }
+    monkeypatch.setattr(text_mod, "parse_spec_author_payload", lambda d: payload)
+    monkeypatch.setattr(text_mod, "build_spec_author_goal_text", lambda p, rid: "GOAL")
+
+    proc = MagicMock(return_value=True)
+    monkeypatch.setattr(dispatch, "process_spec_author", proc)
+
+    repo_cfg = _make_repo_cfg(clone_url="git://spec", sandbox_base_branch="sbx")
+    settings = _make_settings({dispatch.SPEC_AUTHOR_REPO_KEY: repo_cfg})
+
+    out = dispatch._dispatch_spec_author(
+        issue=_make_issue(),
+        role="goal",
+        settings=settings,
+        client=MagicMock(),
+        config_path="/cfg.yaml",
+        description="yaml here",
+        labels=[],
+        task_id="abcdef0123",
+    )
+    assert out is True
+    kwargs = proc.call_args.kwargs
+    assert kwargs["clone_url"] == "git://spec"
+    assert kwargs["base_branch"] == "sbx"
+    assert kwargs["goal_text"] == "GOAL"
+    assert kwargs["spec_slug"] == "x"
+
+
+def test_dispatch_spec_author_no_repo_cfg_uses_file_url(monkeypatch):
+    _install_common_patches(monkeypatch)
+    monkeypatch.setattr(dispatch, "venv_python", lambda r: "/py")
+    monkeypatch.setattr(dispatch, "build_env", lambda r: {})
+
+    import operations_center.entrypoints.board_worker._text as text_mod
+
+    monkeypatch.setattr(
+        text_mod, "parse_spec_author_payload", lambda d: {"target_path": "p", "spec_slug": "s"}
+    )
+    monkeypatch.setattr(text_mod, "build_spec_author_goal_text", lambda p, rid: "G")
+
+    proc = MagicMock(return_value=False)
+    monkeypatch.setattr(dispatch, "process_spec_author", proc)
+
+    out = dispatch._dispatch_spec_author(
+        issue=_make_issue(),
+        role="goal",
+        settings=_make_settings({}),
+        client=MagicMock(),
+        config_path="/cfg.yaml",
+        description="d",
+        labels=[],
+        task_id="t1",
+    )
+    assert out is False
+    assert proc.call_args.kwargs["clone_url"].startswith("file://")
+    assert proc.call_args.kwargs["base_branch"] == "main"

--- a/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
@@ -1,0 +1,963 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.entrypoints.board_worker import outcomes
+from operations_center.entrypoints.board_worker.labels import (
+    LIFECYCLE_EXPANDED,
+    STATE_BLOCKED,
+    STATE_DONE,
+    STATE_REVIEW,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_client(create_id="new-1"):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": create_id}
+    client.list_issues.return_value = []
+    return client
+
+
+def _make_settings(repos=None):
+    return SimpleNamespace(repos=repos or {})
+
+
+def _make_repo_cfg(await_review=False, local_path=None, validation_commands=None):
+    kw = {"await_review": await_review}
+    if local_path is not None:
+        kw["local_path"] = local_path
+    if validation_commands is not None:
+        kw["validation_commands"] = validation_commands
+    return SimpleNamespace(**kw)
+
+
+# ── fail_task ───────────────────────────────────────────────────────────────
+
+
+def test_fail_task_happy():
+    client = _make_client()
+    outcomes.fail_task(client, "t1", "goal", "boom")
+    client.transition_issue.assert_called_once_with("t1", STATE_BLOCKED)
+    client.comment_issue.assert_called_once()
+    assert "boom" in client.comment_issue.call_args[0][1]
+
+
+def test_fail_task_swallows_exception(caplog):
+    client = _make_client()
+    client.transition_issue.side_effect = RuntimeError("net down")
+    # Should not raise; the exception is swallowed and logged.
+    result = outcomes.fail_task(client, "t1", "goal", "boom")
+    assert result is None
+    client.transition_issue.assert_called_once_with("t1", STATE_BLOCKED)
+    # comment_issue is in the same try block after the failing transition, so it
+    # never runs.
+    client.comment_issue.assert_not_called()
+
+
+# ── read_improve_output ───────────────────────────────────────────────────────
+
+
+def test_read_improve_output_missing(tmp_path):
+    assert outcomes.read_improve_output(tmp_path) == []
+
+
+def test_read_improve_output_malformed(tmp_path):
+    (tmp_path / "improve-output.json").write_text("not json{", encoding="utf-8")
+    assert outcomes.read_improve_output(tmp_path) == []
+
+
+def test_read_improve_output_suggestions_not_list(tmp_path):
+    (tmp_path / "improve-output.json").write_text(
+        json.dumps({"suggestions": "nope"}), encoding="utf-8"
+    )
+    assert outcomes.read_improve_output(tmp_path) == []
+
+
+def test_read_improve_output_missing_key(tmp_path):
+    (tmp_path / "improve-output.json").write_text(json.dumps({}), encoding="utf-8")
+    assert outcomes.read_improve_output(tmp_path) == []
+
+
+def test_read_improve_output_filters_and_caps(tmp_path):
+    suggestions = [{"title": f"t{i}"} for i in range(8)]
+    # Add a non-dict and a dict without title — both filtered out.
+    suggestions.append("string-item")
+    suggestions.append({"no_title": 1})
+    (tmp_path / "improve-output.json").write_text(
+        json.dumps({"suggestions": suggestions}), encoding="utf-8"
+    )
+    out = outcomes.read_improve_output(tmp_path)
+    # Only first 5 considered; all have titles.
+    assert len(out) == 5
+    assert all(item["title"] for item in out)
+
+
+# ── handle_success ────────────────────────────────────────────────────────────
+
+
+def test_handle_success_goal_needs_verification():
+    client = _make_client(create_id="follow-9")
+    issue = {"id": "g1", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg(await_review=False)})
+    outcomes.handle_success(client, issue, "goal", "goal", True, settings)
+    # transition to DONE and a verification follow-up comment.
+    client.transition_issue.assert_any_call("g1", STATE_DONE)
+    create_call = client.create_issue.call_args
+    assert create_call.kwargs["label_names"][0] == "task-kind: test"
+    assert any("verification task #follow-9" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_goal_await_review_with_pr():
+    client = _make_client()
+    issue = {"id": "g2", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg(await_review=True)})
+    outcomes.handle_success(client, issue, "goal", "goal", False, settings, pr_url="http://pr/1")
+    client.transition_issue.assert_any_call("g2", STATE_REVIEW)
+    # add_label sets the pr-url through update_issue_labels.
+    assert client.update_issue_labels.called
+    labels_set = client.update_issue_labels.call_args[0][1]
+    assert "pr-url: http://pr/1" in labels_set
+
+
+def test_handle_success_goal_await_review_no_pr():
+    client = _make_client()
+    issue = {"id": "g3", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg(await_review=True)})
+    outcomes.handle_success(client, issue, "goal", "goal", False, settings, pr_url=None)
+    client.transition_issue.assert_any_call("g3", STATE_REVIEW)
+    # No pr-url label added.
+    if client.update_issue_labels.called:
+        assert all(
+            "pr-url" not in lbl
+            for call in client.update_issue_labels.mock_calls
+            for lbl in call.args[1]
+        )
+
+
+def test_handle_success_goal_plain_done():
+    client = _make_client()
+    issue = {"id": "g4", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg(await_review=False)})
+    outcomes.handle_success(client, issue, "goal", "goal", False, settings)
+    client.transition_issue.assert_any_call("g4", STATE_DONE)
+    assert any("Implementation complete" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_goal_no_repo_key():
+    client = _make_client()
+    issue = {"id": "g5", "labels": []}
+    settings = _make_settings({})
+    outcomes.handle_success(client, issue, "goal", "goal", False, settings)
+    client.transition_issue.assert_any_call("g5", STATE_DONE)
+
+
+def test_handle_success_goal_repo_key_missing_in_settings():
+    # repo_key present but settings.repos.get returns None → await_review False.
+    client = _make_client()
+    issue = {"id": "g6", "labels": [{"name": "repo: ghost"}]}
+    settings = _make_settings({})
+    outcomes.handle_success(client, issue, "goal", "goal", False, settings)
+    client.transition_issue.assert_any_call("g6", STATE_DONE)
+
+
+def test_handle_success_test_role():
+    client = _make_client()
+    issue = {"id": "t1", "labels": []}
+    settings = _make_settings()
+    outcomes.handle_success(client, issue, "test", "test", False, settings)
+    client.transition_issue.assert_any_call("t1", STATE_DONE)
+    assert any("Verification passed" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_improve_with_suggestions():
+    client = _make_client(create_id="imp-1")
+    issue = {"id": "i1", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg()})
+    suggestions = [{"title": "Add tests"}, {"title": "Refactor"}]
+    outcomes.handle_success(
+        client, issue, "improve", "improve", False, settings, improve_suggestions=suggestions
+    )
+    client.transition_issue.assert_any_call("i1", STATE_DONE)
+    assert any("focused follow-up task(s)" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_improve_suggestions_none_enqueued(monkeypatch):
+    client = _make_client()
+    issue = {"id": "i2", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings({"web": _make_repo_cfg()})
+    # Force create_improve_follow_up to return None (no ids).
+    monkeypatch.setattr(outcomes, "create_improve_follow_up", lambda *a, **k: None)
+    outcomes.handle_success(
+        client,
+        issue,
+        "improve",
+        "improve",
+        False,
+        settings,
+        improve_suggestions=[{"title": "x"}],
+    )
+    assert any("none could be enqueued" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_improve_no_suggestions():
+    client = _make_client()
+    issue = {"id": "i3", "labels": []}
+    settings = _make_settings()
+    outcomes.handle_success(client, issue, "improve", "improve", False, settings)
+    assert any("no actionable suggestions" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_success_transition_exception_swallowed():
+    client = _make_client()
+    client.transition_issue.side_effect = RuntimeError("api down")
+    issue = {"id": "g7", "labels": []}
+    settings = _make_settings()
+    # Should not raise; the transition error is swallowed and logged.
+    result = outcomes.handle_success(client, issue, "goal", "goal", False, settings)
+    assert result is None
+    client.transition_issue.assert_any_call("g7", STATE_DONE)
+    # The exception is raised before the success comment is posted.
+    client.comment_issue.assert_not_called()
+
+
+def test_handle_success_close_parent_exception_swallowed(monkeypatch):
+    client = _make_client()
+    issue = {"id": "g8", "labels": []}
+    settings = _make_settings()
+    closer = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(outcomes, "maybe_close_split_parent", closer)
+    # Should not raise despite close-parent failing.
+    result = outcomes.handle_success(client, issue, "goal", "goal", False, settings)
+    assert result is None
+    # The success path still ran to completion before the swallowed close failure.
+    client.transition_issue.assert_any_call("g8", STATE_DONE)
+    closer.assert_called_once_with(client, issue)
+
+
+# ── maybe_close_split_parent ──────────────────────────────────────────────────
+
+
+def test_maybe_close_not_a_split_child():
+    client = _make_client()
+    issue = {"id": "c1", "labels": [{"name": "task-kind: goal"}]}
+    outcomes.maybe_close_split_parent(client, issue)
+    client.list_issues.assert_not_called()
+
+
+def test_maybe_close_no_parent_id():
+    client = _make_client()
+    issue = {"id": "c1", "labels": [{"name": "source: scope-split"}]}
+    outcomes.maybe_close_split_parent(client, issue)
+    client.list_issues.assert_not_called()
+
+
+def test_maybe_close_list_issues_raises():
+    client = _make_client()
+    client.list_issues.side_effect = RuntimeError("net")
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+    }
+    # No raise; just returns.
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_not_called()
+
+
+def test_maybe_close_parent_not_found():
+    client = _make_client()
+    client.list_issues.return_value = [{"id": "other", "labels": []}]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_not_called()
+
+
+def test_maybe_close_parent_not_blocked():
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Done"}},
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        "state": {"name": "Done"},
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_not_called()
+
+
+def test_maybe_close_sibling_not_done():
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+        {
+            "id": "sib",
+            "labels": [
+                {"name": "source: scope-split"},
+                {"name": "original-task-id: P"},
+            ],
+            "state": {"name": "Running"},
+        },
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        "state": {"name": "Done"},
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_not_called()
+
+
+def test_maybe_close_this_state_invalid():
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        "state": {"name": "Blocked"},  # not in allowed set
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_not_called()
+
+
+def test_maybe_close_success():
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+        {
+            "id": "sib",
+            "labels": [
+                {"name": "source: scope-split"},
+                {"name": "original-task-id: P"},
+            ],
+            "state": {"name": "Done"},
+        },
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        "state": {"name": "Done"},
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_called_once_with("P", STATE_DONE)
+    assert any("Auto-closed" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_maybe_close_success_empty_this_state():
+    # this_state == "" is allowed (the `if this_state and ...` short circuits).
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        # no state → ""
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_called_once_with("P", STATE_DONE)
+
+
+def test_maybe_close_transition_raises():
+    client = _make_client()
+    client.transition_issue.side_effect = RuntimeError("api")
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+    ]
+    issue = {
+        "id": "c1",
+        "labels": [{"name": "source: scope-split"}, {"name": "original-task-id: P"}],
+        "state": {"name": "Done"},
+    }
+    # No raise; the failing parent transition is swallowed.
+    result = outcomes.maybe_close_split_parent(client, issue)
+    assert result is None
+    # The auto-close transition on the parent was still attempted.
+    client.transition_issue.assert_called_once_with("P", STATE_DONE)
+
+
+def test_maybe_close_sibling_string_labels():
+    # Exercise the str(lab) branch for non-dict labels.
+    client = _make_client()
+    client.list_issues.return_value = [
+        {"id": "P", "labels": [], "state": {"name": "Blocked"}},
+        {
+            "id": "sib",
+            "labels": ["source: scope-split", "original-task-id: P"],
+            "state": {"name": "Done"},
+        },
+    ]
+    issue = {
+        "id": "c1",
+        "labels": ["source: scope-split", "original-task-id: P"],
+        "state": {"name": "Done"},
+    }
+    outcomes.maybe_close_split_parent(client, issue)
+    client.transition_issue.assert_called_once_with("P", STATE_DONE)
+
+
+# ── split_files_into_chunks ───────────────────────────────────────────────────
+
+
+def test_split_files_empty():
+    assert outcomes.split_files_into_chunks([]) == []
+
+
+def test_split_files_single_group():
+    files = ["a.py", "b.py", "c.py"]
+    chunks = outcomes.split_files_into_chunks(files, chunk_size=2)
+    assert chunks == [["a.py", "b.py"], ["c.py"]]
+
+
+def test_split_files_groups_by_top_dir():
+    files = ["src/a.py", "src/b.py", "tests/c.py"]
+    chunks = outcomes.split_files_into_chunks(files, chunk_size=15)
+    # Two top-level groups → two chunks.
+    assert len(chunks) == 2
+
+
+def test_split_files_merge_to_max_chunks():
+    # Many distinct top dirs each one file → many chunks merged down to max_chunks.
+    files = [f"d{i}/f.py" for i in range(10)]
+    chunks = outcomes.split_files_into_chunks(files, chunk_size=1, max_chunks=3)
+    assert len(chunks) == 3
+    flat = sorted(f for c in chunks for f in c)
+    assert flat == sorted(files)
+
+
+# ── create_split_followups ────────────────────────────────────────────────────
+
+
+def test_create_split_followups_retry_exhausted():
+    client = _make_client()
+    parent = {"id": "P", "name": "Big", "labels": [{"name": "retry-count: 2"}]}
+    result = outcomes.create_split_followups(client, parent, None, ["a.py"], "r")
+    assert result == []
+    client.create_issue.assert_not_called()
+
+
+def test_create_split_followups_no_chunks():
+    client = _make_client()
+    parent = {"id": "P", "name": "Big", "labels": []}
+    result = outcomes.create_split_followups(client, parent, None, [], "r")
+    assert result == []
+
+
+def test_create_split_followups_happy():
+    client = _make_client(create_id="child-1")
+    parent = {
+        "id": "P",
+        "name": "Big Task",
+        "labels": [
+            {"name": "repo: web"},
+            {"name": "source: campaign-x"},
+            {"name": "source: board_worker"},
+        ],
+    }
+    result = outcomes.create_split_followups(
+        client, parent, None, ["src/a.py", "src/b.py"], "scope_too_wide_split"
+    )
+    assert result == ["child-1"]
+    labels = client.create_issue.call_args.kwargs["label_names"]
+    assert "task-kind: goal" in labels
+    assert "source: scope-split" in labels
+    assert "source: campaign-x" in labels  # inherited
+    assert "source: board_worker" in [
+        lbl for lbl in labels
+    ]  # explicit, not duplicated as inherited
+    assert "original-task-id: P" in labels
+    assert "retry-count: 1" in labels
+    # LIFECYCLE_EXPANDED applied via add_label → update_issue_labels.
+    applied = [lbl for c in client.update_issue_labels.mock_calls for lbl in c.args[1]]
+    assert LIFECYCLE_EXPANDED in applied
+
+
+def test_create_split_followups_create_raises():
+    client = _make_client()
+    client.create_issue.side_effect = RuntimeError("api down")
+    parent = {"id": "P", "name": "Big", "labels": [{"name": "repo: web"}]}
+    result = outcomes.create_split_followups(client, parent, None, ["a.py"], "r")
+    assert result == []
+    # No expansion label since nothing created.
+    assert not client.update_issue_labels.called
+
+
+def test_create_split_followups_blank_new_id():
+    client = _make_client(create_id="")
+    parent = {"id": "P", "name": "Big", "labels": [{"name": "repo: web"}]}
+    result = outcomes.create_split_followups(client, parent, None, ["a.py"], "r")
+    assert result == []
+
+
+# ── handle_failure ────────────────────────────────────────────────────────────
+
+
+def test_handle_failure_test_role_creates_follow_up():
+    client = _make_client(create_id="g-9")
+    issue = {"id": "t1", "labels": [{"name": "repo: web"}]}
+    settings = _make_settings()
+    result = {"status": "fail", "failure_category": "test_failure", "failure_reason": "nope"}
+    outcomes.handle_failure(client, issue, "test", "test", result, settings)
+    client.transition_issue.assert_any_call("t1", STATE_BLOCKED)
+    create_labels = client.create_issue.call_args.kwargs["label_names"]
+    assert create_labels[0] == "task-kind: goal"
+    assert any("follow-up goal task #g-9" in c.args[1] for c in client.comment_issue.mock_calls)
+
+
+def test_handle_failure_goal_basic():
+    client = _make_client()
+    issue = {"id": "g1", "labels": []}
+    settings = _make_settings()
+    result = {}  # all defaults
+    outcomes.handle_failure(client, issue, "goal", "goal", result, settings)
+    client.transition_issue.assert_called_once_with("g1", STATE_BLOCKED)
+    comment = client.comment_issue.call_args[0][1]
+    assert "unknown" in comment
+    assert "(no reason provided)" in comment
+
+
+def test_handle_failure_scope_split():
+    client = _make_client(create_id="child-1")
+    issue = {
+        "id": "g2",
+        "labels": [{"name": "repo: web"}],
+        "name": "Wide",
+    }
+    settings = _make_settings()
+    result = {"failure_category": "scope_too_wide"}
+    outcomes.handle_failure(
+        client, issue, "goal", "goal", result, settings, scope_files=["src/a.py"]
+    )
+    comment = client.comment_issue.call_args[0][1]
+    assert "Auto-split into 1 focused task(s)" in comment
+
+
+def test_handle_failure_scope_split_spawn_raises(monkeypatch):
+    client = _make_client()
+    monkeypatch.setattr(
+        outcomes,
+        "create_split_followups",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+    issue = {"id": "g3", "labels": [], "name": "Wide"}
+    settings = _make_settings()
+    result = {"failure_category": "scope_too_wide"}
+    # Should not raise; split_ids stays empty.
+    outcomes.handle_failure(client, issue, "goal", "goal", result, settings, scope_files=["a.py"])
+    client.transition_issue.assert_any_call("g3", STATE_BLOCKED)
+
+
+def test_handle_failure_executor_exit_and_signal_sigkill():
+    client = _make_client()
+    issue = {"id": "g4", "labels": []}
+    settings = _make_settings()
+    result = {
+        "executor_exit_code": 137,
+        "executor_signal": "SIGKILL",
+    }
+    outcomes.handle_failure(client, issue, "goal", "goal", result, settings)
+    comment = client.comment_issue.call_args[0][1]
+    assert "executor-exit-code: 137" in comment
+    assert "executor-signal: SIGKILL" in comment
+    # add_label for exit code & signal, plus increment_retry_count → update_issue_labels.
+    applied = [lbl for c in client.update_issue_labels.mock_calls for lbl in c.args[1]]
+    assert "executor-exit-code: 137" in applied
+    assert "executor-signal: SIGKILL" in applied
+    # increment_retry_count adds retry-count: 1.
+    assert any("retry-count: 1" in lbl for lbl in applied)
+
+
+def test_handle_failure_exit_code_zero_no_signal():
+    client = _make_client()
+    issue = {"id": "g5", "labels": []}
+    settings = _make_settings()
+    result = {"executor_exit_code": 0}
+    outcomes.handle_failure(client, issue, "goal", "goal", result, settings)
+    comment = client.comment_issue.call_args[0][1]
+    assert "executor-exit-code: 0" in comment
+    assert "executor-signal" not in comment
+
+
+def test_handle_failure_signal_non_sigkill_no_retry_bump():
+    client = _make_client()
+    issue = {"id": "g6", "labels": []}
+    settings = _make_settings()
+    result = {"executor_exit_code": 1, "executor_signal": "SIGTERM"}
+    outcomes.handle_failure(client, issue, "goal", "goal", result, settings)
+    applied = [lbl for c in client.update_issue_labels.mock_calls for lbl in c.args[1]]
+    # No retry-count bump for non-sigkill.
+    assert not any("retry-count" in lbl for lbl in applied)
+
+
+def test_handle_failure_transition_raises():
+    client = _make_client()
+    client.transition_issue.side_effect = RuntimeError("api")
+    issue = {"id": "g7", "labels": []}
+    settings = _make_settings()
+    # No raise; the failing transition is swallowed.
+    result = outcomes.handle_failure(client, issue, "goal", "goal", {}, settings)
+    assert result is None
+    client.transition_issue.assert_called_once_with("g7", STATE_BLOCKED)
+    # The block comment is never posted because the transition raised first.
+    client.comment_issue.assert_not_called()
+
+
+# ── create_improve_follow_up ──────────────────────────────────────────────────
+
+
+def test_create_improve_follow_up_happy():
+    client = _make_client(create_id="imp-7")
+    parent = {
+        "id": "P",
+        "labels": [{"name": "repo: web"}, {"name": "source: camp"}],
+    }
+    suggestion = {
+        "title": "Fix X",
+        "rationale": "because",
+        "files": ["a.py", "b.py", 123],  # non-str filtered
+        "complexity": "Medium",
+    }
+    new_id = outcomes.create_improve_follow_up(client, parent, None, suggestion)
+    assert new_id == "imp-7"
+    kwargs = client.create_issue.call_args.kwargs
+    assert kwargs["name"] == "Fix X"
+    assert "complexity: medium" in kwargs["label_names"]
+    assert "source: improve-suggestion" in kwargs["label_names"]
+    assert "source: camp" in kwargs["label_names"]
+    assert "- a.py" in kwargs["description"]
+    assert "because" in kwargs["description"]
+
+
+def test_create_improve_follow_up_defaults_and_no_files():
+    client = _make_client(create_id="imp-8")
+    parent = {"id": "P", "labels": []}
+    suggestion = {}  # no title, no rationale, no files, bad complexity
+    new_id = outcomes.create_improve_follow_up(client, parent, None, suggestion)
+    assert new_id == "imp-8"
+    kwargs = client.create_issue.call_args.kwargs
+    assert kwargs["name"] == "Improve follow-up"
+    assert "(none provided)" in kwargs["description"]
+    # No complexity label for empty/invalid complexity.
+    assert not any(lbl.startswith("complexity:") for lbl in kwargs["label_names"])
+
+
+def test_create_improve_follow_up_files_not_list():
+    client = _make_client(create_id="imp-9")
+    parent = {"id": "P", "labels": []}
+    suggestion = {"title": "T", "files": "notalist"}
+    outcomes.create_improve_follow_up(client, parent, None, suggestion)
+    kwargs = client.create_issue.call_args.kwargs
+    assert "allowed_paths" not in kwargs["description"]
+
+
+def test_create_improve_follow_up_blank_id_returns_none():
+    client = _make_client(create_id="")
+    parent = {"id": "P", "labels": []}
+    result = outcomes.create_improve_follow_up(client, parent, None, {"title": "T"})
+    assert result is None
+
+
+def test_create_improve_follow_up_create_raises():
+    client = _make_client()
+    client.create_issue.side_effect = RuntimeError("api")
+    parent = {"id": "P", "labels": []}
+    result = outcomes.create_improve_follow_up(client, parent, None, {"title": "T"})
+    assert result is None
+
+
+# ── create_follow_up ──────────────────────────────────────────────────────────
+
+
+def test_create_follow_up_happy_with_base_branch():
+    client = _make_client(create_id="f-1")
+    parent = {
+        "id": "P",
+        "name": "Parent Task",
+        "labels": [
+            {"name": "repo: web"},
+            {"name": "base-branch: main"},
+            {"name": "source: camp"},
+        ],
+    }
+    new_id = outcomes.create_follow_up(client, parent, None, "test", "verification_needed")
+    assert new_id == "f-1"
+    kwargs = client.create_issue.call_args.kwargs
+    assert kwargs["name"] == "[test] Parent Task"
+    assert "base_branch: main" in kwargs["description"]
+    assert "verification needed" in kwargs["description"]
+    assert "task-kind: test" in kwargs["label_names"]
+    assert "retry-count: 1" in kwargs["label_names"]
+    assert "source: camp" in kwargs["label_names"]
+
+
+def test_create_follow_up_no_base_branch():
+    client = _make_client(create_id="f-2")
+    parent = {"id": "P", "name": "PT", "labels": [{"name": "repo: web"}]}
+    outcomes.create_follow_up(client, parent, None, "goal", "verification_failed")
+    desc = client.create_issue.call_args.kwargs["description"]
+    assert "base_branch" not in desc
+
+
+def test_create_follow_up_retry_cap():
+    client = _make_client()
+    parent = {"id": "P", "name": "PT", "labels": [{"name": "retry-count: 3"}]}
+    new_id = outcomes.create_follow_up(client, parent, None, "goal", "r")
+    assert new_id == ""
+    client.create_issue.assert_not_called()
+
+
+def test_create_follow_up_missing_id_returns_question_mark():
+    client = MagicMock()
+    client.create_issue.return_value = {}  # no id key
+    parent = {"id": "P", "name": "PT", "labels": []}
+    new_id = outcomes.create_follow_up(client, parent, None, "goal", "r")
+    assert new_id == "?"
+
+
+# ── run_ci_loop ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ci_modules(monkeypatch):
+    """Stub out the heavy CI collaborators imported inside run_ci_loop."""
+    import sys
+    import types as _types
+
+    # Build a registry of fakes we can configure per-test.
+    state = {}
+
+    # contracts.enums.RefinementStatus
+    enums_mod = _types.ModuleType("operations_center.contracts.enums")
+
+    class RefinementStatus:
+        ACCEPTED = SimpleNamespace(value="accepted")
+        ESCALATED = SimpleNamespace(value="escalated")
+        REJECTED = SimpleNamespace(value="rejected")
+
+    enums_mod.RefinementStatus = RefinementStatus
+
+    # contracts.ci.ContinuousImprovementSpec
+    ci_mod = _types.ModuleType("operations_center.contracts.ci")
+
+    class ContinuousImprovementSpec:
+        @staticmethod
+        def model_validate(raw):
+            if state.get("spec_invalid"):
+                raise ValueError("bad spec")
+            return SimpleNamespace(raw=raw)
+
+    ci_mod.ContinuousImprovementSpec = ContinuousImprovementSpec
+
+    # execution.ci_coordinator
+    coord_mod = _types.ModuleType("operations_center.execution.ci_coordinator")
+
+    class CiRunContext:
+        def __init__(self, **kw):
+            self.kw = kw
+
+    class CiCoordinator:
+        def __init__(self, store):
+            self.store = store
+
+        def run(self, ctx, execute):
+            if state.get("coordinator_raises"):
+                raise RuntimeError("coordinator boom")
+            # Optionally invoke execute to exercise the inner closure.
+            if state.get("invoke_execute"):
+                state["execute_return"] = execute(
+                    attempt_number=1, strategy=None, proposal_id="prop"
+                )
+            return state["ci_result"]
+
+    coord_mod.CiCoordinator = CiCoordinator
+    coord_mod.CiRunContext = CiRunContext
+
+    # execution.ci_store
+    store_mod = _types.ModuleType("operations_center.execution.ci_store")
+
+    class CiStore:
+        def __init__(self, path):
+            self.path = path
+
+    store_mod.CiStore = CiStore
+
+    monkeypatch.setitem(sys.modules, "operations_center.contracts.enums", enums_mod)
+    monkeypatch.setitem(sys.modules, "operations_center.contracts.ci", ci_mod)
+    monkeypatch.setitem(sys.modules, "operations_center.execution.ci_coordinator", coord_mod)
+    monkeypatch.setitem(sys.modules, "operations_center.execution.ci_store", store_mod)
+
+    return state, RefinementStatus
+
+
+def _ci_kwargs(tmp_path, **overrides):
+    base = dict(
+        ci_spec_raw={"foo": "bar"},
+        client=_make_client(),
+        issue={"id": "task-123456789012", "labels": [{"name": "repo: web"}]},
+        role="improve",
+        task_kind="improve_campaign",
+        task_id="task-123456789012",
+        repo_key="web",
+        settings=_make_settings({"web": _make_repo_cfg(local_path="/tmp/repo")}),
+        python="python3",
+        oc_root=tmp_path / "oc",
+        env={"X": "1"},
+        bundle_file=tmp_path / "props" / "p1" / "bundle.json",
+        config_file=tmp_path / "config.json",
+        tmp=tmp_path / "work",
+        short_id="abc123",
+    )
+    base.update(overrides)
+    (base["tmp"]).mkdir(parents=True, exist_ok=True)
+    (base["bundle_file"].parent).mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def test_run_ci_loop_invalid_spec(ci_modules, tmp_path):
+    state, RS = ci_modules
+    state["spec_invalid"] = True
+    kw = _ci_kwargs(tmp_path)
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is False
+    kw["client"].transition_issue.assert_any_call("task-123456789012", STATE_BLOCKED)
+
+
+def test_run_ci_loop_coordinator_raises(ci_modules, tmp_path):
+    state, RS = ci_modules
+    state["coordinator_raises"] = True
+    kw = _ci_kwargs(tmp_path)
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is False
+    kw["client"].transition_issue.assert_any_call("task-123456789012", STATE_BLOCKED)
+
+
+def test_run_ci_loop_accepted(ci_modules, tmp_path, monkeypatch):
+    state, RS = ci_modules
+    state["ci_result"] = SimpleNamespace(final_status=RS.ACCEPTED, total_attempts=2)
+    # Spy on handle_success to confirm the accepted path.
+    spy = MagicMock()
+    monkeypatch.setattr(outcomes, "handle_success", spy)
+    kw = _ci_kwargs(tmp_path)
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is True
+    spy.assert_called_once()
+    # ci-status / ci-attempts labels applied.
+    applied = [lbl for c in kw["client"].update_issue_labels.mock_calls for lbl in c.args[1]]
+    assert any("ci-status: accepted" in lbl for lbl in applied)
+    assert any("ci-attempts: 2" in lbl for lbl in applied)
+
+
+def test_run_ci_loop_escalated(ci_modules, tmp_path):
+    state, RS = ci_modules
+    state["ci_result"] = SimpleNamespace(final_status=RS.ESCALATED, total_attempts=3)
+    kw = _ci_kwargs(tmp_path)
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is False
+    kw["client"].transition_issue.assert_any_call("task-123456789012", STATE_BLOCKED)
+
+
+def test_run_ci_loop_rejected_calls_handle_failure(ci_modules, tmp_path, monkeypatch):
+    state, RS = ci_modules
+    state["ci_result"] = SimpleNamespace(final_status=RS.REJECTED, total_attempts=1)
+    spy = MagicMock()
+    monkeypatch.setattr(outcomes, "handle_failure", spy)
+    kw = _ci_kwargs(tmp_path)
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is False
+    spy.assert_called_once()
+    failure_result = spy.call_args[0][4]
+    assert failure_result["status"] == "rejected"
+    assert "CI refinement loop ended" in failure_result["failure_reason"]
+
+
+def test_run_ci_loop_execute_closure(ci_modules, tmp_path, monkeypatch):
+    """Drive the inner execute() closure: parse a result file successfully."""
+    state, RS = ci_modules
+    state["invoke_execute"] = True
+    state["ci_result"] = SimpleNamespace(final_status=RS.ESCALATED, total_attempts=1)
+
+    kw = _ci_kwargs(tmp_path)
+
+    # Patch subprocess.run inside the module to write a result file.
+    result_path = kw["tmp"] / "result-ci-1.json"
+
+    def fake_run(cmd, **kwargs):
+        result_path.write_text(
+            json.dumps(
+                {
+                    "result": {
+                        "success": True,
+                        "run_id": "real-run",
+                        "changed_files": [{"path": "a.py"}, {"no_path": 1}],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(outcomes.subprocess, "run", fake_run)
+    outcomes.run_ci_loop(**kw)
+    run_id, changed, success = state["execute_return"]
+    assert run_id == "real-run"
+    assert changed == ["a.py"]
+    assert success is True
+
+
+def test_run_ci_loop_execute_no_result_file(ci_modules, tmp_path, monkeypatch):
+    state, RS = ci_modules
+    state["invoke_execute"] = True
+    state["ci_result"] = SimpleNamespace(final_status=RS.ESCALATED, total_attempts=1)
+    kw = _ci_kwargs(tmp_path)
+
+    monkeypatch.setattr(
+        outcomes.subprocess,
+        "run",
+        lambda cmd, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    outcomes.run_ci_loop(**kw)
+    run_id, changed, success = state["execute_return"]
+    # Falls back to generated run_id, no changed files, not successful.
+    assert run_id == "ci-task-123-attempt-1"
+    assert changed == []
+    assert success is False
+
+
+def test_run_ci_loop_execute_malformed_result(ci_modules, tmp_path, monkeypatch):
+    state, RS = ci_modules
+    state["invoke_execute"] = True
+    state["ci_result"] = SimpleNamespace(final_status=RS.ESCALATED, total_attempts=1)
+    kw = _ci_kwargs(tmp_path)
+    result_path = kw["tmp"] / "result-ci-1.json"
+
+    def fake_run(cmd, **kwargs):
+        result_path.write_text("not-json{", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(outcomes.subprocess, "run", fake_run)
+    outcomes.run_ci_loop(**kw)
+    run_id, changed, success = state["execute_return"]
+    assert run_id == "ci-task-123-attempt-1"
+    assert success is False
+
+
+def test_run_ci_loop_repo_path_fallback(ci_modules, tmp_path):
+    # repo_key not in settings.repos → repo_path = Path(repo_key); no validation cmds.
+    state, RS = ci_modules
+    state["ci_result"] = SimpleNamespace(final_status=RS.ESCALATED, total_attempts=1)
+    kw = _ci_kwargs(tmp_path, settings=_make_settings({}), repo_key="ghost-repo")
+    ok = outcomes.run_ci_loop(**kw)
+    assert ok is False

--- a/tests/unit/entrypoints/board_worker/test_spec_author_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_spec_author_cov.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.entrypoints.board_worker import spec_author
+from operations_center.entrypoints.board_worker.labels import STATE_DONE
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_settings(repos=None, project_id="proj-1"):
+    return SimpleNamespace(
+        plane=SimpleNamespace(project_id=project_id),
+        repos=repos or {},
+    )
+
+
+def _make_issue(issue_id="123", labels=None):
+    return {"id": issue_id, "labels": labels or []}
+
+
+def _make_proc(returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _base_kwargs(**overrides):
+    kw = dict(
+        issue=_make_issue(),
+        role="spec-author",
+        settings=_make_settings(),
+        client=MagicMock(),
+        config_path=None,  # filled by tests that need a real file
+        goal_text="write a spec",
+        repo_key="OperationsCenter",
+        clone_url="https://example/repo.git",
+        base_branch="main",
+        spec_slug="my-spec",
+        target_path="docs/specs/my-spec.md",
+        trigger_source="trigger-x",
+        task_phase="",
+        python="python3",
+        oc_root=None,
+        env={"FOO": "bar"},
+        short_id="abc123",
+    )
+    kw.update(overrides)
+    return kw
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    cfg = tmp_path / "ops.yaml"
+    cfg.write_text("config: yes\n", encoding="utf-8")
+    return cfg
+
+
+# ── process_spec_author ───────────────────────────────────────────────────────
+
+
+def test_planning_no_json_fails(monkeypatch, tmp_path, config_file):
+    """plan_proc.stdout not JSON -> fail_task, return False."""
+    fail = MagicMock()
+    monkeypatch.setattr(spec_author, "fail_task", fail)
+    proc = _make_proc(returncode=0, stdout="not json", stderr="boom")
+    monkeypatch.setattr(spec_author.subprocess, "run", lambda *a, **k: proc)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    fail.assert_called_once()
+    assert "no JSON" in fail.call_args.args[3]
+
+
+def test_planning_nonzero_returncode_fails(monkeypatch, tmp_path, config_file):
+    """Valid JSON but returncode != 0 -> fail with bundle message."""
+    fail = MagicMock()
+    monkeypatch.setattr(spec_author, "fail_task", fail)
+    proc = _make_proc(returncode=2, stdout=json.dumps({"message": "bad plan"}))
+    monkeypatch.setattr(spec_author.subprocess, "run", lambda *a, **k: proc)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    assert "bad plan" in fail.call_args.args[3]
+
+
+def test_planning_nonzero_default_message(monkeypatch, tmp_path, config_file):
+    """returncode != 0 with no message key -> 'unknown planning error'."""
+    fail = MagicMock()
+    monkeypatch.setattr(spec_author, "fail_task", fail)
+    proc = _make_proc(returncode=1, stdout=json.dumps({}))
+    monkeypatch.setattr(spec_author.subprocess, "run", lambda *a, **k: proc)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    assert "unknown planning error" in fail.call_args.args[3]
+
+
+class _ProcSequencer:
+    """Mimics subprocess.run for plan then execute, writing result file."""
+
+    def __init__(self, plan_proc, *, write_result=None, result_path_key="--output"):
+        self.plan_proc = plan_proc
+        self.write_result = write_result
+        self.result_path_key = result_path_key
+        self.calls = 0
+        self.cmds = []
+
+    def __call__(self, cmd, *a, **k):
+        self.cmds.append(cmd)
+        self.calls += 1
+        if self.calls == 1:
+            return self.plan_proc
+        # execute call: optionally write the result file
+        if self.write_result is not None:
+            idx = cmd.index(self.result_path_key)
+            from pathlib import Path
+
+            Path(cmd[idx + 1]).write_text(self.write_result, encoding="utf-8")
+        return _make_proc(returncode=0, stdout="")
+
+
+def test_execute_no_result_file_fails(monkeypatch, tmp_path, config_file):
+    """Execute writes nothing -> result_file missing -> fail."""
+    fail = MagicMock()
+    monkeypatch.setattr(spec_author, "fail_task", fail)
+    seq = _ProcSequencer(_make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result=None)
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    assert "no result file" in fail.call_args.args[3]
+
+
+def test_execute_result_bad_json_fails(monkeypatch, tmp_path, config_file):
+    fail = MagicMock()
+    monkeypatch.setattr(spec_author, "fail_task", fail)
+    seq = _ProcSequencer(
+        _make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result="{ broken"
+    )
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    assert "parse failed" in fail.call_args.args[3]
+
+
+def test_execute_empty_result_treated_as_failure(monkeypatch, tmp_path, config_file):
+    """Empty result file -> '{}' -> success False -> handle_failure path."""
+    handle = MagicMock()
+    monkeypatch.setattr(spec_author, "handle_failure", handle)
+    seq = _ProcSequencer(_make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result="")
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    handle.assert_called_once()
+
+
+def test_execute_failure_calls_handle_failure(monkeypatch, tmp_path, config_file):
+    handle = MagicMock()
+    monkeypatch.setattr(spec_author, "handle_failure", handle)
+    result = json.dumps({"result": {"success": False, "run_id": "r1"}})
+    seq = _ProcSequencer(
+        _make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result=result
+    )
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is False
+    handle.assert_called_once()
+
+
+def test_success_invokes_handle_success(monkeypatch, tmp_path, config_file):
+    success_handler = MagicMock()
+    monkeypatch.setattr(spec_author, "handle_spec_author_success", success_handler)
+    result = json.dumps({"result": {"success": True, "run_id": "run-99"}})
+    seq = _ProcSequencer(
+        _make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result=result
+    )
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path)
+    assert spec_author.process_spec_author(**kw) is True
+    success_handler.assert_called_once()
+    assert success_handler.call_args.kwargs["run_id"] == "run-99"
+
+
+def test_forwarded_labels_and_cmd_shape(monkeypatch, tmp_path, config_file):
+    """source: labels forwarded; plan cmd carries expected flags."""
+    monkeypatch.setattr(spec_author, "handle_spec_author_success", MagicMock())
+    result = json.dumps({"result": {"success": True, "run_id": "r"}})
+    seq = _ProcSequencer(
+        _make_proc(returncode=0, stdout=json.dumps({"ok": 1})), write_result=result
+    )
+    monkeypatch.setattr(spec_author.subprocess, "run", seq)
+
+    issue = _make_issue(
+        labels=[
+            {"name": "source: github"},
+            {"name": "other"},
+            "source: plane",  # non-dict label form
+            "ignore",
+        ]
+    )
+    kw = _base_kwargs(config_path=config_file, oc_root=tmp_path, issue=issue)
+    assert spec_author.process_spec_author(**kw) is True
+
+    plan_cmd = seq.cmds[0]
+    # both source: labels forwarded as --label
+    label_args = [plan_cmd[i + 1] for i, v in enumerate(plan_cmd) if v == "--label"]
+    assert "source: github" in label_args
+    assert "source: plane" in label_args
+    assert "other" not in label_args
+    # spec-specific constraints present
+    assert "--max-changed-files" in plan_cmd
+    assert "docs/specs/" in plan_cmd
+    assert str(spec_author.SPEC_AUTHOR_TIMEOUT_SECONDS) in plan_cmd
+    # exec cmd carries the spec-author branch + source tag
+    exec_cmd = seq.cmds[1]
+    assert f"spec-author/{kw['short_id']}" in exec_cmd
+    src_idx = exec_cmd.index("--source")
+    assert exec_cmd[src_idx + 1].startswith("board_worker_spec_author|spec_slug=my-spec")
+
+
+# ── handle_spec_author_success: phase-advance branch ──────────────────────────
+
+
+def test_phase_advance_done(monkeypatch, tmp_path):
+    monkeypatch.setattr(spec_author, "summarize_prompt_diff_block", lambda **k: (3, "parsed ok"))
+    client = MagicMock()
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("t9"),
+        settings=_make_settings(),
+        workspace=tmp_path,
+        target_path="docs/specs/x.md",
+        spec_slug="x",
+        run_id="r1",
+        task_phase="phase2",
+    )
+    client.transition_issue.assert_called_once_with("t9", STATE_DONE)
+    assert "phase-advance" in client.comment_issue.call_args.args[1]
+
+
+def test_phase_advance_edit_count_none(monkeypatch, tmp_path):
+    """edit_count None branch in the log line."""
+    monkeypatch.setattr(spec_author, "summarize_prompt_diff_block", lambda **k: (None, "no diff"))
+    client = MagicMock()
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("t9"),
+        settings=_make_settings(),
+        workspace=tmp_path,
+        target_path="docs/specs/x.md",
+        spec_slug="x",
+        run_id="r1",
+        task_phase="phaseX",
+    )
+    client.transition_issue.assert_called_once_with("t9", STATE_DONE)
+    assert "phase-advance" in client.comment_issue.call_args.args[1]
+
+
+def test_phase_advance_transition_exception_swallowed(monkeypatch, tmp_path):
+    monkeypatch.setattr(spec_author, "summarize_prompt_diff_block", lambda **k: (1, "ok"))
+    client = MagicMock()
+    client.transition_issue.side_effect = RuntimeError("plane down")
+    # should not raise even though the transition blew up
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("t9"),
+        settings=_make_settings(),
+        workspace=tmp_path,
+        target_path="docs/specs/x.md",
+        spec_slug="x",
+        run_id="r1",
+        task_phase="p",
+    )
+    # transition was attempted; the raised error was swallowed
+    client.transition_issue.assert_called_once_with("t9", STATE_DONE)
+
+
+# ── handle_spec_author_success: spec-missing branch ───────────────────────────
+
+
+def test_spec_missing_done_with_comment(tmp_path):
+    client = MagicMock()
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("m1"),
+        settings=_make_settings(),
+        workspace=tmp_path,
+        target_path="docs/specs/missing.md",
+        spec_slug="missing",
+        run_id="r2",
+        task_phase="",
+    )
+    client.transition_issue.assert_called_once_with("m1", STATE_DONE)
+    assert "not found" in client.comment_issue.call_args.args[1]
+
+
+def test_spec_missing_transition_exception_swallowed(tmp_path):
+    client = MagicMock()
+    client.transition_issue.side_effect = RuntimeError("x")
+    # transition raising must be swallowed (no exception propagates)
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("m1"),
+        settings=_make_settings(),
+        workspace=tmp_path,
+        target_path="docs/specs/missing.md",
+        spec_slug="missing",
+        run_id="r2",
+        task_phase="",
+    )
+    client.transition_issue.assert_called_once_with("m1", STATE_DONE)
+
+
+# ── handle_spec_author_success: full campaign-build branch ────────────────────
+
+
+def _install_fake_campaign(monkeypatch, *, created_ids, fm_repos=None, fm_raises=False):
+    """Install fake operations_center.spec_author.* modules used lazily."""
+    pkg = ModuleType("operations_center.spec_author")
+    cb_mod = ModuleType("operations_center.spec_author.campaign_builder")
+    models_mod = ModuleType("operations_center.spec_author.models")
+
+    class FakeBuilder:
+        def __init__(self, *, client, project_id):
+            self.client = client
+            self.project_id = project_id
+
+        def build(self, *, spec_text, repo_key, base_branch):
+            FakeBuilder.last = SimpleNamespace(
+                spec_text=spec_text, repo_key=repo_key, base_branch=base_branch
+            )
+            return list(created_ids)
+
+    class FakeFrontMatter:
+        repos = fm_repos or []
+
+        @classmethod
+        def from_spec_text(cls, text):
+            if fm_raises:
+                raise ValueError("bad frontmatter")
+            inst = cls()
+            inst.repos = fm_repos or []
+            return inst
+
+    cb_mod.CampaignBuilder = FakeBuilder
+    models_mod.SpecFrontMatter = FakeFrontMatter
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author", pkg)
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author.campaign_builder", cb_mod)
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author.models", models_mod)
+    return FakeBuilder
+
+
+def _write_spec(tmp_path, target_path="docs/specs/x.md", text="# spec\n"):
+    p = tmp_path / target_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return target_path
+
+
+def test_campaign_build_with_children_and_parent_labels(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    builder = _install_fake_campaign(monkeypatch, created_ids=["c1", "c2"], fm_repos=["RepoA"])
+    add_label = MagicMock()
+    monkeypatch.setattr(spec_author, "add_label", add_label)
+
+    repo_cfg = SimpleNamespace(sandbox_base_branch="sandbox", default_branch="main")
+    settings = _make_settings(repos={"RepoA": repo_cfg})
+
+    client = MagicMock()
+    client.list_issues.return_value = [{"id": "c1"}, {"id": "c2"}, {"id": "other"}]
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p1"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="run-7",
+        task_phase="",
+    )
+
+    # repo_key resolved from frontmatter, base from sandbox_base_branch
+    assert builder.last.repo_key == "RepoA"
+    assert builder.last.base_branch == "sandbox"
+    # parent_run labels added for each created child found in list_issues
+    assert add_label.call_count == 2
+    client.transition_issue.assert_called_once_with("p1", STATE_DONE)
+    comment = client.comment_issue.call_args.args[1]
+    assert "created 2 campaign task(s)" in comment
+    assert "#c1" in comment and "#c2" in comment
+
+
+def test_campaign_build_default_branch_when_no_sandbox(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    builder = _install_fake_campaign(monkeypatch, created_ids=["c1"], fm_repos=["RepoB"])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    repo_cfg = SimpleNamespace(sandbox_base_branch=None, default_branch="develop")
+    settings = _make_settings(repos={"RepoB": repo_cfg})
+    client = MagicMock()
+    client.list_issues.return_value = [{"id": "c1"}]
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p2"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    assert builder.last.base_branch == "develop"
+
+
+def test_campaign_build_no_repo_cfg_defaults_main(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    builder = _install_fake_campaign(monkeypatch, created_ids=["c1"], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    # repos empty -> repo_cfg None -> base_branch "main"; fm.repos empty -> SPEC_AUTHOR_REPO_KEY
+    settings = _make_settings(repos={})
+    client = MagicMock()
+    client.list_issues.return_value = [{"id": "c1"}]
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p3"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    assert builder.last.repo_key == spec_author.SPEC_AUTHOR_REPO_KEY
+    assert builder.last.base_branch == "main"
+
+
+def test_campaign_build_frontmatter_raises_uses_default_repo(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    builder = _install_fake_campaign(monkeypatch, created_ids=["c1"], fm_raises=True)
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    repo_cfg = SimpleNamespace(sandbox_base_branch=None, default_branch="main")
+    settings = _make_settings(repos={spec_author.SPEC_AUTHOR_REPO_KEY: repo_cfg})
+    client = MagicMock()
+    client.list_issues.return_value = [{"id": "c1"}]
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p4"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    assert builder.last.repo_key == spec_author.SPEC_AUTHOR_REPO_KEY
+
+
+def test_campaign_build_no_children_comment(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    _install_fake_campaign(monkeypatch, created_ids=[], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    settings = _make_settings(repos={})
+    client = MagicMock()
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p5"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    # no children -> list_issues never consulted, "no children" comment
+    client.list_issues.assert_not_called()
+    assert "no children" in client.comment_issue.call_args.args[1]
+
+
+def test_campaign_build_exception_then_done(monkeypatch, tmp_path):
+    """CampaignBuilder.build raises -> created_ids stays [] -> still transitions Done."""
+    target = _write_spec(tmp_path)
+    pkg = ModuleType("operations_center.spec_author")
+    cb_mod = ModuleType("operations_center.spec_author.campaign_builder")
+    models_mod = ModuleType("operations_center.spec_author.models")
+
+    class BoomBuilder:
+        def __init__(self, **k):
+            pass
+
+        def build(self, **k):
+            raise RuntimeError("build exploded")
+
+    class FM:
+        @classmethod
+        def from_spec_text(cls, text):
+            inst = cls()
+            inst.repos = []
+            return inst
+
+    cb_mod.CampaignBuilder = BoomBuilder
+    models_mod.SpecFrontMatter = FM
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author", pkg)
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author.campaign_builder", cb_mod)
+    monkeypatch.setitem(sys.modules, "operations_center.spec_author.models", models_mod)
+
+    client = MagicMock()
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p6"),
+        settings=_make_settings(repos={}),
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    client.transition_issue.assert_called_once_with("p6", STATE_DONE)
+    assert "no children" in client.comment_issue.call_args.args[1]
+
+
+def test_parent_label_tagging_exception_swallowed(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    _install_fake_campaign(monkeypatch, created_ids=["c1"], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    settings = _make_settings(repos={})
+    client = MagicMock()
+    client.list_issues.side_effect = RuntimeError("list failed")
+
+    # exception inside parent_run tagging must be swallowed; Done still happens
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p7"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="run-z",
+        task_phase="",
+    )
+    client.transition_issue.assert_called_once_with("p7", STATE_DONE)
+
+
+def test_post_success_transition_exception_swallowed(monkeypatch, tmp_path):
+    target = _write_spec(tmp_path)
+    _install_fake_campaign(monkeypatch, created_ids=[], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    settings = _make_settings(repos={})
+    client = MagicMock()
+    client.transition_issue.side_effect = RuntimeError("boom")
+    # final try/except must swallow the transition error
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p8"),
+        settings=settings,
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    client.transition_issue.assert_called_once_with("p8", STATE_DONE)
+
+
+def test_spec_read_oserror_falls_back_to_empty(monkeypatch, tmp_path):
+    """spec_path.exists() True but read raises OSError -> spec_text=''."""
+    target = "docs/specs/x.md"
+    p = tmp_path / target
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("data", encoding="utf-8")
+
+    builder = _install_fake_campaign(monkeypatch, created_ids=[], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+
+    orig_read = spec_author.Path.read_text
+
+    def fake_read(self, *a, **k):
+        if str(self).endswith("x.md"):
+            raise OSError("read denied")
+        return orig_read(self, *a, **k)
+
+    monkeypatch.setattr(spec_author.Path, "read_text", fake_read)
+
+    client = MagicMock()
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p9"),
+        settings=_make_settings(repos={}),
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="r",
+        task_phase="",
+    )
+    assert builder.last.spec_text == ""
+    client.transition_issue.assert_called_once_with("p9", STATE_DONE)
+
+
+def test_run_id_falsy_skips_parent_labels(monkeypatch, tmp_path):
+    """created_ids present but run_id empty -> parent label block skipped."""
+    target = _write_spec(tmp_path)
+    _install_fake_campaign(monkeypatch, created_ids=["c1"], fm_repos=[])
+    monkeypatch.setattr(spec_author, "add_label", MagicMock())
+    client = MagicMock()
+
+    spec_author.handle_spec_author_success(
+        client=client,
+        issue=_make_issue("p10"),
+        settings=_make_settings(repos={}),
+        workspace=tmp_path,
+        target_path=target,
+        spec_slug="x",
+        run_id="",
+        task_phase="",
+    )
+    client.list_issues.assert_not_called()
+    client.transition_issue.assert_called_once_with("p10", STATE_DONE)

--- a/tests/unit/entrypoints/maintenance/__init__.py
+++ b/tests/unit/entrypoints/maintenance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
@@ -1,0 +1,850 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+import operations_center.entrypoints.maintenance.board_unblock as bu
+
+_NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+_FRESH = "2026-05-28T11:59:00+00:00"  # 1 minute ago relative to _NOW
+_STALE = "2026-05-28T05:00:00+00:00"  # 7 hours ago
+
+
+def _issue(
+    task_id: str,
+    *,
+    state: str,
+    labels: list[str] | None = None,
+    name: str | None = None,
+    updated_at: str | None = _STALE,
+) -> dict:
+    issue: dict = {
+        "id": task_id,
+        "name": name if name is not None else f"Task {task_id}",
+        "state": {"name": state},
+        "labels": [{"name": label} for label in (labels or [])],
+    }
+    if updated_at is not None:
+        issue["updated_at"] = updated_at
+    return issue
+
+
+def _run(issues, **kwargs):
+    params = dict(
+        now=_NOW,
+        stale_blocked_hours=4,
+        stale_running_hours=2,
+        clean_blocked_min_minutes=5,
+        mem_available_gb=16.0,
+    )
+    params.update(kwargs)
+    return bu._apply_rules(issues, **params)
+
+
+def _by_rule(actions, rule):
+    return [a for a in actions if a["rule"] == rule]
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def test_labels_handles_dicts_strings_and_blanks():
+    issue = {"labels": [{"name": " a "}, "b", {"name": ""}, {"nope": 1}, None]}
+    assert bu._labels(issue) == ["a", "b"]
+
+
+def test_labels_none_labels():
+    assert bu._labels({"labels": None}) == []
+    assert bu._labels({}) == []
+
+
+def test_state_name_dict_and_string_and_none():
+    assert bu._state_name({"state": {"name": " Blocked "}}) == "Blocked"
+    assert bu._state_name({"state": "Running"}) == "Running"
+    assert bu._state_name({"state": None}) == ""
+    assert bu._state_name({}) == ""
+
+
+def test_label_value_case_insensitive_prefix():
+    labels = ["Retry-Count: 5", "other"]
+    assert bu._label_value(labels, "retry-count:") == "5"
+    assert bu._label_value(labels, "missing:") is None
+
+
+def test_has_label_and_prefix():
+    labels = ["Task-Kind: goal", "self-modify: approved"]
+    assert bu._has_label(labels, "task-kind: goal")
+    assert not bu._has_label(labels, "task-kind: improve")
+    assert bu._has_label_prefix(labels, "self-modify:")
+    assert not bu._has_label_prefix(labels, "blocked-by:")
+
+
+def test_parse_updated_at_variants():
+    assert bu._parse_updated_at({"updated_at": "2026-05-28T05:00:00Z"}) == datetime(
+        2026, 5, 28, 5, 0, 0, tzinfo=UTC
+    )
+    # naive datetime gets UTC attached
+    assert bu._parse_updated_at({"updated_at": "2026-05-28T05:00:00"}).tzinfo == UTC
+    # falls back to created_at
+    assert bu._parse_updated_at({"created_at": "2026-05-28T05:00:00Z"}) is not None
+    # missing
+    assert bu._parse_updated_at({}) is None
+    # invalid
+    assert bu._parse_updated_at({"updated_at": "not-a-date"}) is None
+
+
+def test_retry_count():
+    assert bu._retry_count(["retry-count: 3"]) == 3
+    assert bu._retry_count([]) == 0
+    assert bu._retry_count(["retry-count: abc"]) == 0
+
+
+def test_is_terminal():
+    assert bu._is_terminal("Done")
+    assert bu._is_terminal("CANCELLED")
+    assert not bu._is_terminal("Blocked")
+
+
+def test_blocker_task_id():
+    assert bu._blocker_task_id(["blocked-by: T-1"]) == "T-1"
+    assert bu._blocker_task_id([]) is None
+
+
+def test_build_id_state_map():
+    issues = [_issue("1", state="Done"), _issue("2", state="Blocked")]
+    assert bu._build_id_state_map(issues) == {"1": "Done", "2": "Blocked"}
+
+
+# ---------------------------------------------------------------------------
+# _mem_available_gb
+# ---------------------------------------------------------------------------
+
+
+def test_mem_available_gb_reads_proc(monkeypatch, tmp_path):
+    fake = tmp_path / "meminfo"
+    fake.write_text("MemTotal: 100\nMemAvailable: 2097152 kB\n", encoding="utf-8")
+    monkeypatch.setattr(bu, "Path", lambda p: fake)
+    assert bu._mem_available_gb() == pytest.approx(2.0)
+
+
+def test_mem_available_gb_no_match(monkeypatch, tmp_path):
+    fake = tmp_path / "meminfo"
+    fake.write_text("MemTotal: 100\n", encoding="utf-8")
+    monkeypatch.setattr(bu, "Path", lambda p: fake)
+    assert bu._mem_available_gb() == float("inf")
+
+
+def test_mem_available_gb_read_error(monkeypatch):
+    def boom(_):
+        raise OSError("no /proc")
+
+    monkeypatch.setattr(bu, "Path", boom)
+    assert bu._mem_available_gb() == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# _allowed_worker_backends
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_backends_default(monkeypatch):
+    monkeypatch.delenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", raising=False)
+    assert bu._allowed_worker_backends() == {"claude_code"}
+
+
+def test_allowed_backends_mapping(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude, codex")
+    assert bu._allowed_worker_backends() == {"claude_code", "codex_cli"}
+
+
+def test_allowed_backends_unknown_falls_back(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "weird, ")
+    assert bu._allowed_worker_backends() == {"claude_code"}
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_cooldown_reason
+# ---------------------------------------------------------------------------
+
+
+def _store(snapshot):
+    store = mock.Mock()
+    store.current_worker_backend_cooldowns.return_value = snapshot
+    return store
+
+
+def test_cooldown_reason_none_when_backend_free(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _store({"claude_code": {"cooling_down": False}})
+    assert bu._dispatch_cooldown_reason(store, now=_NOW) is None
+
+
+def test_cooldown_reason_returns_message(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _store({"claude_code": {"cooling_down": True, "reset_at": "2026-05-28T13:00:00+00:00"}})
+    reason = bu._dispatch_cooldown_reason(store, now=_NOW)
+    assert reason is not None
+    assert "claude_code until 2026-05-28T13:00:00+00:00" in reason
+    assert "promotion deferred" in reason
+
+
+def test_cooldown_reason_without_reset_at(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _store({"claude_code": {"cooling_down": True}})
+    reason = bu._dispatch_cooldown_reason(store, now=_NOW)
+    assert "claude_code);" in reason or "claude_code)" in reason
+
+
+def test_cooldown_reason_partial_free(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude, codex")
+    store = _store(
+        {
+            "claude_code": {"cooling_down": True},
+            "codex_cli": {"cooling_down": False},
+        }
+    )
+    assert bu._dispatch_cooldown_reason(store, now=_NOW) is None
+
+
+def test_cooldown_reason_exception_returns_none():
+    store = mock.Mock()
+    store.current_worker_backend_cooldowns.side_effect = RuntimeError("boom")
+    assert bu._dispatch_cooldown_reason(store, now=_NOW) is None
+
+
+def test_cooldown_reason_refresh_clears_stale(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = mock.Mock()
+    # first call: cooling; after refresh: free
+    store.current_worker_backend_cooldowns.side_effect = [
+        {"claude_code": {"cooling_down": True}},
+        {"claude_code": {"cooling_down": False}},
+    ]
+    refresh = mock.Mock()
+    assert bu._dispatch_cooldown_reason(store, now=_NOW, refresh=refresh) is None
+    refresh.assert_called_once()
+
+
+def test_cooldown_reason_refresh_still_cooling(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = mock.Mock()
+    store.current_worker_backend_cooldowns.side_effect = [
+        {"claude_code": {"cooling_down": True}},
+        {"claude_code": {"cooling_down": True, "reset_at": "later"}},
+    ]
+    refresh = mock.Mock()
+    reason = bu._dispatch_cooldown_reason(store, now=_NOW, refresh=refresh)
+    assert reason is not None
+    refresh.assert_called_once()
+
+
+def test_cooldown_reason_refresh_raises(monkeypatch):
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = mock.Mock()
+    # both snapshot reads return cooling; refresh raises but is swallowed
+    store.current_worker_backend_cooldowns.return_value = {"claude_code": {"cooling_down": True}}
+    refresh = mock.Mock(side_effect=RuntimeError("probe failed"))
+    reason = bu._dispatch_cooldown_reason(store, now=_NOW, refresh=refresh)
+    assert reason is not None
+
+
+def test_cooldown_reason_empty_cooling_returns_none(monkeypatch):
+    # No allowed backend present in snapshot at all -> status empty -> not cooling -> None
+    monkeypatch.setenv("OPERATIONS_CENTER_ALLOWED_PROVIDERS", "claude")
+    store = _store({})
+    assert bu._dispatch_cooldown_reason(store, now=_NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — DEAD_REMEDIATION_CANCEL
+# ---------------------------------------------------------------------------
+
+
+def test_rule1_dead_remediation_label():
+    actions = _run([_issue("1", state="Blocked", labels=["dead-remediation"])])
+    a = _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+    assert a and a[0]["to_state"] == "Cancelled"
+    assert a[0]["reason"] == "labelled dead-remediation"
+
+
+def test_rule1_sigkill_exhausted():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Running",
+                labels=["executor-signal: SIGKILL", "retry-count: 3"],
+            )
+        ]
+    )
+    a = _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+    assert a and "≥3 SIGKILL" in a[0]["reason"]
+
+
+def test_rule1_sigkill_under_threshold_not_cancelled():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Running",
+                labels=["executor-signal: SIGKILL", "retry-count: 2"],
+                updated_at=_FRESH,
+            )
+        ]
+    )
+    assert not _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+
+
+def test_rule1_skips_terminal_state():
+    actions = _run([_issue("1", state="Done", labels=["dead-remediation"])])
+    assert not _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — INVESTIGATE_DEPRIORITISE
+# ---------------------------------------------------------------------------
+
+
+def test_rule2_investigate_demoted():
+    actions = _run([_issue("1", state="Ready for AI", labels=["task-kind: investigate"])])
+    a = _by_rule(actions, "INVESTIGATE_DEPRIORITISE")
+    assert a and a[0]["to_state"] == "Backlog"
+
+
+def test_rule2_not_in_r4ai_ignored():
+    actions = _run([_issue("1", state="Backlog", labels=["task-kind: investigate"])])
+    assert not _by_rule(actions, "INVESTIGATE_DEPRIORITISE")
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — IMPROVE_UNBLOCK
+# ---------------------------------------------------------------------------
+
+
+def test_rule3_blocker_terminal():
+    issues = [
+        _issue("dep", state="Done"),
+        _issue(
+            "1",
+            state="Blocked",
+            labels=["task-kind: improve", "blocked-by: dep"],
+            updated_at=_FRESH,
+        ),
+    ]
+    actions = _run(issues)
+    a = _by_rule(actions, "IMPROVE_UNBLOCK")
+    assert a and a[0]["to_state"] == "Backlog"
+    assert "is now Done" in a[0]["reason"]
+
+
+def test_rule3_stale_blocked_no_blocker():
+    actions = _run([_issue("1", state="Blocked", labels=["task-kind: goal"], updated_at=_STALE)])
+    a = _by_rule(actions, "IMPROVE_UNBLOCK")
+    assert a and "stale in Blocked" in a[0]["reason"]
+
+
+def test_rule3_blocker_not_terminal_and_fresh_no_action():
+    issues = [
+        _issue("dep", state="Running"),
+        _issue(
+            "1",
+            state="Blocked",
+            labels=["task-kind: improve", "blocked-by: dep"],
+            updated_at=_FRESH,
+        ),
+    ]
+    assert not _by_rule(_run(issues), "IMPROVE_UNBLOCK")
+
+
+def test_rule3_self_modify_excluded():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["task-kind: improve", "self-modify: approved"],
+                updated_at=_STALE,
+            )
+        ]
+    )
+    assert not _by_rule(actions, "IMPROVE_UNBLOCK")
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — SELF_MODIFY_REQUEUE
+# ---------------------------------------------------------------------------
+
+
+def test_rule4_requeue_no_blocker():
+    actions = _run([_issue("1", state="Blocked", labels=["self-modify: approved"])])
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["to_state"] == "Ready for AI"
+    assert "no blocking dependency" in a[0]["reason"]
+    assert "skipped" not in a[0]
+
+
+def test_rule4_requeue_blocker_terminal():
+    issues = [
+        _issue("dep", state="Cancelled"),
+        _issue("1", state="Blocked", labels=["self-modify: approved", "blocked-by: dep"]),
+    ]
+    a = _by_rule(_run(issues), "SELF_MODIFY_REQUEUE")
+    assert a and "is now Cancelled" in a[0]["reason"]
+
+
+def test_rule4_blocker_active_no_action():
+    issues = [
+        _issue("dep", state="Running"),
+        _issue("1", state="Blocked", labels=["self-modify: approved", "blocked-by: dep"]),
+    ]
+    assert not _by_rule(_run(issues), "SELF_MODIFY_REQUEUE")
+
+
+def test_rule4_sigkill_skipped():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["self-modify: approved", "executor-signal: SIGKILL", "retry-count: 1"],
+            )
+        ]
+    )
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["skipped"] is True
+    assert "SIGKILL" in a[0]["reason"]
+
+
+def test_rule4_exit_code_zero_no_signal_skipped():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["self-modify: approved", "executor-exit-code: 0"],
+            )
+        ]
+    )
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["skipped"] is True
+    assert "empty result.json" in a[0]["reason"]
+
+
+def test_rule4_low_mem_skipped():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["self-modify: approved"])],
+        mem_available_gb=1.0,
+    )
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["skipped"] is True
+    assert "GB threshold" in a[0]["reason"]
+
+
+def test_rule4_cooldown_skipped():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["self-modify: approved"])],
+        cooldown_skip_reason="cooling",
+    )
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["skipped"] is True
+    assert "SKIPPED — cooling" in a[0]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — STALE_IN_REVIEW
+# ---------------------------------------------------------------------------
+
+
+def test_rule5_stale_in_review():
+    actions = _run([_issue("1", state="In Review", updated_at=_STALE)])
+    a = _by_rule(actions, "STALE_IN_REVIEW")
+    assert a and a[0]["to_state"] == "Backlog"
+
+
+def test_rule5_pr_url_skipped():
+    actions = _run([_issue("1", state="In Review", labels=["pr-url: http://x"], updated_at=_STALE)])
+    assert not _by_rule(actions, "STALE_IN_REVIEW")
+
+
+def test_rule5_fresh_no_action():
+    actions = _run([_issue("1", state="In Review", updated_at=_FRESH)])
+    assert not _by_rule(actions, "STALE_IN_REVIEW")
+
+
+def test_rule5_no_updated_at_no_action():
+    actions = _run([_issue("1", state="In Review", updated_at=None)])
+    assert not _by_rule(actions, "STALE_IN_REVIEW")
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — STALE_RUNNING_REQUEUE
+# ---------------------------------------------------------------------------
+
+
+def test_rule6_stale_running():
+    actions = _run([_issue("1", state="Running", updated_at=_STALE)])
+    a = _by_rule(actions, "STALE_RUNNING_REQUEUE")
+    assert a and a[0]["to_state"] == "Ready for AI"
+    assert "executor likely died" in a[0]["reason"]
+
+
+def test_rule6_cooldown_skipped():
+    actions = _run(
+        [_issue("1", state="Running", updated_at=_STALE)],
+        cooldown_skip_reason="cooling",
+    )
+    a = _by_rule(actions, "STALE_RUNNING_REQUEUE")
+    assert a and a[0]["skipped"] is True
+
+
+def test_rule6_fresh_no_action():
+    actions = _run([_issue("1", state="Running", updated_at=_FRESH)])
+    assert not _by_rule(actions, "STALE_RUNNING_REQUEUE")
+
+
+# ---------------------------------------------------------------------------
+# Rule 7 — GOAL_BACKLOG_PROMOTE
+# ---------------------------------------------------------------------------
+
+
+def _goal_backlog(labels, parent_state="Done"):
+    return [
+        _issue("parent", state=parent_state),
+        _issue("1", state="Backlog", labels=labels + ["original-task-id: parent"]),
+    ]
+
+
+def test_rule7_pattern_a_promote():
+    actions = _run(
+        _goal_backlog(["task-kind: goal", "source: autonomy", "source: improve-suggestion"])
+    )
+    a = _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+    assert a and a[0]["to_state"] == "Ready for AI"
+    assert "parent improve task" in a[0]["reason"]
+
+
+def test_rule7_pattern_b_promote():
+    actions = _run(
+        _goal_backlog(
+            ["task-kind: goal", "source: board_worker", "handoff-reason: improvement_applied"]
+        )
+    )
+    assert _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_cooldown_skipped():
+    actions = _run(
+        _goal_backlog(["task-kind: goal", "source: autonomy", "source: improve-suggestion"]),
+        cooldown_skip_reason="cooling",
+    )
+    a = _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+    assert a and a[0]["skipped"] is True
+
+
+def test_rule7_parent_not_terminal_no_action():
+    actions = _run(
+        _goal_backlog(
+            ["task-kind: goal", "source: autonomy", "source: improve-suggestion"],
+            parent_state="Running",
+        )
+    )
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_thin_goal_skipped():
+    actions = _run(
+        _goal_backlog(
+            ["task-kind: goal", "source: autonomy", "source: improve-suggestion", "thin-goal"]
+        )
+    )
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_sigkill_skipped():
+    actions = _run(
+        _goal_backlog(
+            [
+                "task-kind: goal",
+                "source: autonomy",
+                "source: improve-suggestion",
+                "executor-signal: SIGKILL",
+            ]
+        )
+    )
+    # Rule 7 skipped; but Rule 1 won't fire (terminal? no; sigkill but retry<3) — check rule7 only
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_low_mem_skipped():
+    actions = _run(
+        _goal_backlog(["task-kind: goal", "source: autonomy", "source: improve-suggestion"]),
+        mem_available_gb=1.0,
+    )
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_no_parent_label_no_action():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Backlog",
+                labels=["task-kind: goal", "source: autonomy", "source: improve-suggestion"],
+            )
+        ]
+    )
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+def test_rule7_no_matching_source_pattern():
+    actions = _run(
+        _goal_backlog(["task-kind: goal", "source: autonomy"])  # missing improve-suggestion
+    )
+    assert not _by_rule(actions, "GOAL_BACKLOG_PROMOTE")
+
+
+# ---------------------------------------------------------------------------
+# Rule 8 — CLEAN_BLOCKED_RETRY
+# ---------------------------------------------------------------------------
+
+
+def test_rule8_clean_blocked_retry():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["task-kind: spec-author"], updated_at=_STALE)]
+    )
+    a = _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+    assert a and a[0]["to_state"] == "Backlog"
+
+
+def test_rule8_too_young_no_action():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["task-kind: goal"], updated_at=_FRESH)],
+        clean_blocked_min_minutes=5,
+    )
+    assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+
+
+def test_rule8_blocked_by_excluded():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["task-kind: goal", "blocked-by: x"],
+                updated_at=_STALE,
+            )
+        ]
+    )
+    assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+
+
+def test_rule8_exit_code_excluded():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["task-kind: improve", "executor-exit-code: 1"],
+                updated_at=_STALE,
+            )
+        ]
+    )
+    assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+
+
+def test_rule8_no_updated_at_no_action():
+    actions = _run([_issue("1", state="Blocked", labels=["task-kind: goal"], updated_at=None)])
+    assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+
+
+# ---------------------------------------------------------------------------
+# Rule 9 — SPEC_AUTHOR_BACKLOG_PROMOTE
+# ---------------------------------------------------------------------------
+
+
+def test_rule9_promote():
+    actions = _run([_issue("1", state="Backlog", labels=["task-kind: spec-author"])])
+    a = _by_rule(actions, "SPEC_AUTHOR_BACKLOG_PROMOTE")
+    assert a and a[0]["to_state"] == "Ready for AI"
+    assert "skipped" not in a[0]
+
+
+def test_rule9_cooldown_skipped():
+    actions = _run(
+        [_issue("1", state="Backlog", labels=["task-kind: spec-author"])],
+        cooldown_skip_reason="cooling",
+    )
+    a = _by_rule(actions, "SPEC_AUTHOR_BACKLOG_PROMOTE")
+    assert a and a[0]["skipped"] is True
+
+
+def test_rule9_low_mem_skipped():
+    actions = _run(
+        [_issue("1", state="Backlog", labels=["task-kind: spec-author"])],
+        mem_available_gb=1.0,
+    )
+    assert not _by_rule(actions, "SPEC_AUTHOR_BACKLOG_PROMOTE")
+
+
+def test_no_actions_for_unrelated_issue():
+    actions = _run([_issue("1", state="Done")])
+    assert actions == []
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.transitions = []
+        self.comments = []
+        self.closed = False
+        self._issues = []
+        self._raise = None
+
+    def list_issues(self):
+        if self._raise:
+            raise self._raise
+        return self._issues
+
+    def transition_issue(self, task_id, to_state):
+        self.transitions.append((task_id, to_state))
+
+    def comment_issue(self, task_id, body):
+        self.comments.append((task_id, body))
+
+    def close(self):
+        self.closed = True
+
+
+def _patch_main(monkeypatch, *, client, mem=16.0, cooldown_reason=None):
+    monkeypatch.setattr(bu, "_mem_available_gb", lambda: mem)
+    monkeypatch.setattr(bu, "PlaneClient", lambda **kw: client)
+    fake_settings = SimpleNamespace(
+        plane=SimpleNamespace(base_url="http://x", workspace_slug="ws", project_id="p"),
+        plane_token=lambda: "tok",
+    )
+    monkeypatch.setattr(bu, "load_settings", lambda cfg: fake_settings)
+    monkeypatch.setattr(bu, "UsageStore", lambda *a, **k: mock.Mock())
+    monkeypatch.setattr(bu, "_dispatch_cooldown_reason", lambda *a, **k: cooldown_reason)
+    # ensure worker_backend_probe import inside main resolves
+    probe = SimpleNamespace(refresh_cooldowns=lambda *a, **k: None)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "operations_center.backends.worker_backend_probe",
+        probe,
+    )
+
+
+def _argv(monkeypatch, args):
+    monkeypatch.setattr(__import__("sys"), "argv", ["board_unblock", "--config", "cfg.yaml", *args])
+
+
+def test_main_low_mem_skips(monkeypatch, capsys):
+    client = _FakeClient()
+    _patch_main(monkeypatch, client=client, mem=1.0)
+    _argv(monkeypatch, [])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["skipped"] is True
+    assert client.closed is True
+
+
+def test_main_list_issues_error(monkeypatch, capsys):
+    client = _FakeClient()
+    client._raise = RuntimeError("plane down")
+    _patch_main(monkeypatch, client=client)
+    _argv(monkeypatch, [])
+    assert bu.main() == 1
+    out = json.loads(capsys.readouterr().out)
+    assert "plane_fetch_failed" in out["error"]
+    assert client.closed is True
+
+
+def test_main_dry_run(monkeypatch, capsys):
+    client = _FakeClient()
+    client._issues = [_issue("1", state="Backlog", labels=["task-kind: spec-author"])]
+    _patch_main(monkeypatch, client=client)
+    _argv(monkeypatch, [])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["apply"] is False
+    assert out["actions"]
+    assert out["actions"][0]["action"] == "would_apply"
+    assert client.transitions == []
+
+
+def test_main_apply(monkeypatch, capsys):
+    client = _FakeClient()
+    client._issues = [_issue("1", state="Backlog", labels=["task-kind: spec-author"])]
+    _patch_main(monkeypatch, client=client)
+    _argv(monkeypatch, ["--apply"])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["actions"][0]["action"] == "applied"
+    assert client.transitions == [("1", "Ready for AI")]
+    assert len(client.comments) == 1
+
+
+def test_main_apply_transition_error(monkeypatch, capsys):
+    client = _FakeClient()
+    client._issues = [_issue("1", state="Backlog", labels=["task-kind: spec-author"])]
+
+    def boom(task_id, to_state):
+        raise RuntimeError("transition failed")
+
+    client.transition_issue = boom
+    _patch_main(monkeypatch, client=client)
+    _argv(monkeypatch, ["--apply"])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["actions"][0]["action"] == "error"
+    assert "transition failed" in out["actions"][0]["error"]
+
+
+def test_main_skipped_action_passthrough(monkeypatch, capsys):
+    client = _FakeClient()
+    client._issues = [_issue("1", state="Backlog", labels=["task-kind: spec-author"])]
+    _patch_main(monkeypatch, client=client, cooldown_reason="cooling")
+    _argv(monkeypatch, ["--apply"])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["actions"][0]["skipped"] is True
+    assert client.transitions == []  # skipped actions never transition
+
+
+def test_main_cooldown_import_error(monkeypatch, capsys):
+    client = _FakeClient()
+    client._issues = []
+    _patch_main(monkeypatch, client=client)
+    # Make the in-main import raise by removing the module and blocking import
+    monkeypatch.setattr(
+        bu,
+        "_dispatch_cooldown_reason",
+        mock.Mock(side_effect=RuntimeError("should be guarded")),
+    )
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "operations_center.backends.worker_backend_probe":
+            raise ImportError("no probe")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    _argv(monkeypatch, [])
+    assert bu.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["cooldown_skip_reason"] is None

--- a/tests/unit/entrypoints/maintenance/test_triage_scan_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_triage_scan_cov.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from operations_center.entrypoints.maintenance import triage_scan as mod
+from operations_center.queue_healing import (
+    QueueHealingDecision,
+    QueueHealingTask,
+    QueueTransition,
+)
+
+MODPATH = "operations_center.entrypoints.maintenance.triage_scan"
+
+
+# ── _labels ──────────────────────────────────────────────────────────────────
+
+
+def test_labels_handles_dicts_strings_and_blanks():
+    issue = {
+        "labels": [
+            {"name": " retry_safe "},
+            "lifecycle: escalated",
+            {"name": ""},  # blank name dropped
+            {"name": None},  # None dropped
+            None,  # falsy raw dropped
+            {"nope": "x"},  # missing name -> None -> dropped
+        ]
+    }
+    assert mod._labels(issue) == ("retry_safe", "lifecycle: escalated")
+
+
+def test_labels_missing_key_and_none():
+    assert mod._labels({}) == ()
+    assert mod._labels({"labels": None}) == ()
+
+
+# ── _label_value ───────────────────────────────────────────────────────────
+
+
+def test_label_value_prefix_match_case_insensitive_and_stripped():
+    labels = ("Retry-Lineage:  abc123  ",)
+    assert mod._label_value(labels, "retry-lineage:") == "abc123"
+
+
+def test_label_value_multiple_prefixes_first_wins():
+    labels = ("dedup: zzz",)
+    # first prefix has no match, second does
+    assert mod._label_value(labels, "duplicate:", "dedup:") == "zzz"
+
+
+def test_label_value_no_match_returns_none():
+    assert mod._label_value(("foo", "bar"), "missing:") is None
+
+
+# ── _state_name ─────────────────────────────────────────────────────────────
+
+
+def test_state_name_dict_form():
+    assert mod._state_name({"state": {"name": " Blocked "}}) == "Blocked"
+
+
+def test_state_name_dict_missing_name():
+    assert mod._state_name({"state": {}}) == ""
+
+
+def test_state_name_string_form_and_none():
+    assert mod._state_name({"state": " Backlog "}) == "Backlog"
+    assert mod._state_name({}) == ""
+    assert mod._state_name({"state": None}) == ""
+
+
+# ── _parse_updated_at ───────────────────────────────────────────────────────
+
+
+def test_parse_updated_at_uses_updated_then_created():
+    dt = mod._parse_updated_at({"updated_at": "2026-01-01T00:00:00Z"})
+    assert dt == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def test_parse_updated_at_falls_back_to_created_at():
+    dt = mod._parse_updated_at({"created_at": "2026-02-02T00:00:00+00:00"})
+    assert dt == datetime(2026, 2, 2, tzinfo=UTC)
+
+
+def test_parse_updated_at_naive_gets_utc():
+    dt = mod._parse_updated_at({"updated_at": "2026-03-03T00:00:00"})
+    assert dt is not None and dt.tzinfo == UTC
+
+
+def test_parse_updated_at_missing_returns_none():
+    assert mod._parse_updated_at({}) is None
+    assert mod._parse_updated_at({"updated_at": ""}) is None
+
+
+def test_parse_updated_at_invalid_returns_none():
+    assert mod._parse_updated_at({"updated_at": "not-a-date"}) is None
+
+
+# ── _parse_int ──────────────────────────────────────────────────────────────
+
+
+def test_parse_int_variants():
+    assert mod._parse_int(None) == 0
+    assert mod._parse_int("7") == 7
+    assert mod._parse_int("bad") == 0
+
+
+# ── _parse_executor_exit_code ──────────────────────────────────────────────
+
+
+def test_parse_executor_exit_code_present():
+    assert mod._parse_executor_exit_code(("executor-exit-code: 137",)) == 137
+
+
+def test_parse_executor_exit_code_absent_returns_none():
+    assert mod._parse_executor_exit_code(("other",)) is None
+
+
+def test_parse_executor_exit_code_invalid_returns_none():
+    assert mod._parse_executor_exit_code(("executor-exit-code: x",)) is None
+
+
+# ── _duplicate_blocked_keys ─────────────────────────────────────────────────
+
+
+def test_duplicate_blocked_keys_only_blocked_and_count_gt_one():
+    items = [
+        {"state": "Blocked", "labels": ["duplicate: k1"]},
+        {"state": {"name": "blocked"}, "labels": ["dedup: k1"]},  # second prefix
+        {"state": "Blocked", "labels": ["duplicate: solo"]},  # only once
+        {"state": "Backlog", "labels": ["duplicate: k1"]},  # not blocked, ignored
+        {"state": "Blocked", "labels": ["no-key"]},  # no duplicate key
+    ]
+    assert mod._duplicate_blocked_keys(items) == {"k1"}
+
+
+def test_duplicate_blocked_keys_empty():
+    assert mod._duplicate_blocked_keys([]) == set()
+
+
+# ── _queue_task_from_issue ──────────────────────────────────────────────────
+
+
+def test_queue_task_from_issue_full_metadata():
+    issue = {
+        "id": 42,
+        "name": "Fix it",
+        "state": "Blocked",
+        "labels": [
+            "duplicate: dk",
+            "retry-lineage: lin1",
+            "retry-safe",
+            "queue-deadlock",
+            "retry-count: 4",
+            "recovery-attempts: 2",
+            "blocked-reason: backend down",
+            "blocked-by-backend: claude",
+            "backend: codex",
+        ],
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+    task, no_consumer = mod._queue_task_from_issue(issue, duplicate_blocked_keys={"dk"})
+    assert isinstance(task, QueueHealingTask)
+    assert task.task_id == "42"
+    assert task.title == "Fix it"
+    assert task.state == "Blocked"
+    assert task.duplicate_key == "dk"
+    assert task.duplicate_exists_in_blocked is True
+    assert task.retry_safe is True
+    assert task.blocked_reason == "backend down"
+    assert task.blocked_by_backend == "claude"
+    assert task.backend_dependency == "codex"
+    assert task.retry_lineage_id == "lin1"
+    assert task.retry_count == 4
+    assert task.recovery_attempt_count == 2
+    assert task.updated_at == datetime(2026, 1, 1, tzinfo=UTC)
+    assert no_consumer is True
+
+
+def test_queue_task_from_issue_minimal_defaults():
+    issue = {"id": "x1"}
+    task, no_consumer = mod._queue_task_from_issue(issue, duplicate_blocked_keys=set())
+    assert task.task_id == "x1"
+    assert task.title == ""
+    assert task.duplicate_key is None
+    assert task.duplicate_exists_in_blocked is False
+    assert task.retry_safe is False
+    assert task.retry_count == 0
+    assert no_consumer is False
+
+
+def test_queue_task_from_issue_dup_key_not_in_blocked_set():
+    issue = {"id": "1", "state": "Blocked", "labels": ["duplicate: other"]}
+    task, _ = mod._queue_task_from_issue(issue, duplicate_blocked_keys={"different"})
+    assert task.duplicate_key == "other"
+    assert task.duplicate_exists_in_blocked is False
+
+
+# ── _queue_healing_actions ──────────────────────────────────────────────────
+
+
+def test_queue_healing_actions_filters_non_blocked_and_none_decisions():
+    items = [
+        {"id": "skip", "state": "Backlog", "labels": []},  # not blocked
+        {"id": "noop", "state": "Blocked", "labels": []},  # decision NONE
+        {"id": "act", "state": "Blocked", "labels": ["retry-safe"]},  # transition
+        {"id": "esc", "state": "Blocked", "labels": []},  # escalate
+    ]
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+
+    def fake_decide(task, *, no_consumer_can_execute, now):
+        if task.task_id == "noop":
+            return QueueHealingDecision(task.task_id, QueueTransition.NONE, "none")
+        if task.task_id == "act":
+            return QueueHealingDecision(
+                task.task_id, QueueTransition.BLOCKED_TO_READY_FOR_AI, "r", safe=True
+            )
+        return QueueHealingDecision(task.task_id, QueueTransition.NONE, "esc-reason", escalate=True)
+
+    with mock.patch.object(mod, "QueueHealingEngine") as Eng:
+        Eng.return_value.decide.side_effect = fake_decide
+        out = mod._queue_healing_actions(items, now=now)
+
+    ids = sorted(t.task_id for t, _ in out)
+    assert ids == ["act", "esc"]
+
+
+# ── main() ──────────────────────────────────────────────────────────────────
+
+
+def _settings():
+    return SimpleNamespace(
+        plane=SimpleNamespace(
+            base_url="http://plane",
+            workspace_slug="ws",
+            project_id="proj",
+        ),
+        plane_token=lambda: "tok",
+    )
+
+
+def _make_client():
+    client = mock.MagicMock()
+    client.workspace_slug = "ws"
+    client.project_id = "proj"
+    return client
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch all main() collaborators; return a control namespace."""
+    client = _make_client()
+    monkeypatch.setattr(mod, "load_settings", lambda cfg: _settings())
+    monkeypatch.setattr(mod, "PlaneClient", lambda **kw: client)
+    monkeypatch.setattr(mod, "handle_priority_rescore_scan", lambda items, now: [])
+    monkeypatch.setattr(mod, "handle_awaiting_input_scan", lambda items, c, state_name: [])
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [])
+    return SimpleNamespace(client=client)
+
+
+def _run_main(args):
+    with mock.patch("sys.argv", ["prog", *args]):
+        return mod.main()
+
+
+def _capture(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+def test_main_plane_fetch_failure_returns_1(patched, capsys):
+    patched.client.list_issues.side_effect = RuntimeError("boom")
+    rc = _run_main(["--config", "c.yaml"])
+    assert rc == 1
+    patched.client.close.assert_called_once()
+    out = json.loads(capsys.readouterr().out)
+    assert "plane_fetch_failed: boom" in out["error"]
+
+
+def test_main_dry_run_emits_would_actions(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    rescore = SimpleNamespace(
+        task_id="t1",
+        title="T1",
+        current_priority="low",
+        proposed_priority="high",
+        reason="old",
+    )
+    awaiting = SimpleNamespace(task_id="a1", title="A1", new_comment_count=3)
+    task = QueueHealingTask(task_id="q1", title="Q1", state="Blocked")
+    decision = QueueHealingDecision(
+        "q1", QueueTransition.BLOCKED_TO_READY_FOR_AI, "stale", safe=True
+    )
+    monkeypatch.setattr(mod, "handle_priority_rescore_scan", lambda items, now: [rescore])
+    monkeypatch.setattr(mod, "handle_awaiting_input_scan", lambda items, c, state_name: [awaiting])
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+
+    rc = _run_main(["--config", "c.yaml"])
+    assert rc == 0
+    out = _capture(capsys)
+    assert out["apply"] is False
+    assert out["rescore"][0]["action"] == "would_apply"
+    assert out["awaiting"][0]["action"] == "would_transition"
+    assert out["queue_healing"][0]["action"] == "would_transition"
+    # raw patch never used in dry run
+    patched.client._client.patch.assert_not_called()
+    patched.client.transition_issue.assert_not_called()
+    patched.client.close.assert_called_once()
+
+
+def test_main_apply_rescore_success_and_error(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    ok = SimpleNamespace(
+        task_id="ok", title="", current_priority="a", proposed_priority="b", reason="r"
+    )
+    bad = SimpleNamespace(
+        task_id="bad", title="", current_priority="a", proposed_priority="b", reason="r"
+    )
+    monkeypatch.setattr(mod, "handle_priority_rescore_scan", lambda items, now: [ok, bad])
+
+    def patch_side(path, json):
+        if "bad" in path:
+            raise RuntimeError("patch failed")
+
+    patched.client._client.patch.side_effect = patch_side
+
+    rc = _run_main(["--config", "c.yaml", "--apply"])
+    assert rc == 0
+    out = _capture(capsys)
+    actions = {e["task_id"]: e for e in out["rescore"]}
+    assert actions["ok"]["action"] == "applied"
+    assert actions["bad"]["action"] == "error"
+    assert "patch failed" in actions["bad"]["error"]
+
+
+def test_main_apply_awaiting_success_and_error(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    ok = SimpleNamespace(task_id="ok", title="", new_comment_count=1)
+    bad = SimpleNamespace(task_id="bad", title="", new_comment_count=2)
+    monkeypatch.setattr(mod, "handle_awaiting_input_scan", lambda items, c, state_name: [ok, bad])
+
+    def transition_side(task_id, state):
+        if task_id == "bad":
+            raise RuntimeError("transition failed")
+
+    patched.client.transition_issue.side_effect = transition_side
+
+    rc = _run_main(["--config", "c.yaml", "--apply"])
+    assert rc == 0
+    out = _capture(capsys)
+    actions = {e["task_id"]: e for e in out["awaiting"]}
+    assert actions["ok"]["action"] == "transitioned"
+    assert actions["bad"]["action"] == "error"
+    assert "transition failed" in actions["bad"]["error"]
+
+
+def test_main_awaiting_input_state_arg_passed_through(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    seen = {}
+
+    def fake_awaiting(items, c, state_name):
+        seen["state"] = state_name
+        return []
+
+    monkeypatch.setattr(mod, "handle_awaiting_input_scan", fake_awaiting)
+    _run_main(["--config", "c.yaml", "--awaiting-input-state", "Custom State"])
+    assert seen["state"] == "Custom State"
+
+
+def test_main_queue_healing_none_action(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.NONE, "nothing")
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    assert out["queue_healing"][0]["action"] == "none"
+
+
+def test_main_queue_healing_escalate_apply_success(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(
+        task_id="q",
+        title="",
+        state="Blocked",
+        labels=("executor-exit-code: 1", "executor-signal: SIGKILL"),
+    )
+    decision = QueueHealingDecision(
+        "q", QueueTransition.ESCALATE, "boom", retry_lineage_id="lin", escalate=True
+    )
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    entry = out["queue_healing"][0]
+    assert entry["action"] == "escalation_commented"
+    assert entry["executor_exit_code"] == 1
+    assert entry["executor_signal"] == "SIGKILL"
+    patched.client.comment_issue.assert_called_once()
+
+
+def test_main_queue_healing_escalate_dry_run(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.ESCALATE, "boom", escalate=True)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml"])
+    out = _capture(capsys)
+    assert out["queue_healing"][0]["action"] == "escalate"
+    patched.client.comment_issue.assert_not_called()
+
+
+def test_main_queue_healing_escalate_apply_error(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.ESCALATE, "boom", escalate=True)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    patched.client.comment_issue.side_effect = RuntimeError("comment failed")
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    entry = out["queue_healing"][0]
+    assert entry["action"] == "error"
+    assert "comment failed" in entry["error"]
+
+
+def test_main_queue_healing_transition_to_backlog_success(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.BLOCKED_TO_BACKLOG, "dup", safe=True)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    assert out["queue_healing"][0]["action"] == "transitioned"
+    patched.client.transition_issue.assert_called_once_with("q", "Backlog")
+
+
+def test_main_queue_healing_transition_to_ready_success(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.BLOCKED_TO_READY_FOR_AI, "ok", safe=True)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    assert out["queue_healing"][0]["action"] == "transitioned"
+    patched.client.transition_issue.assert_called_once_with("q", "Ready for AI")
+
+
+def test_main_queue_healing_transition_apply_error(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.BLOCKED_TO_BACKLOG, "dup", safe=True)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    patched.client.transition_issue.side_effect = RuntimeError("nope")
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    entry = out["queue_healing"][0]
+    assert entry["action"] == "error"
+    assert "nope" in entry["error"]
+
+
+def test_main_queue_healing_unsafe_transition_would_transition(patched, capsys, monkeypatch):
+    patched.client.list_issues.return_value = []
+    # transition set but not safe and not escalate -> else branch even with apply
+    task = QueueHealingTask(task_id="q", title="", state="Blocked")
+    decision = QueueHealingDecision("q", QueueTransition.BLOCKED_TO_BACKLOG, "unsafe", safe=False)
+    monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [(task, decision)])
+    _run_main(["--config", "c.yaml", "--apply"])
+    out = _capture(capsys)
+    assert out["queue_healing"][0]["action"] == "would_transition"
+    patched.client.transition_issue.assert_not_called()
+
+
+def test_main_module_entrypoint_exists():
+    assert callable(mod.main)

--- a/tests/unit/execution/__init__.py
+++ b/tests/unit/execution/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/execution/test_campaign_store_cov.py
+++ b/tests/unit/execution/test_campaign_store_cov.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from operations_center.execution.campaign_store import (
+    CampaignRecord,
+    CampaignStore,
+    _compute_status,
+    _refresh_computed,
+)
+
+
+def _fixed(year: int = 2026, month: int = 6, day: int = 2) -> datetime:
+    return datetime(year, month, day, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def store_path(tmp_path: Path) -> Path:
+    return tmp_path / "state" / "campaigns.json"
+
+
+@pytest.fixture
+def store(store_path: Path) -> CampaignStore:
+    return CampaignStore(path=store_path)
+
+
+# --------------------------------------------------------------------------
+# CampaignRecord
+# --------------------------------------------------------------------------
+def _record(**kw) -> CampaignRecord:
+    base = dict(
+        source_task_id="t1",
+        title="Title",
+        step_task_ids=["a", "b", "c"],
+        done_step_ids=[],
+        cancelled_step_ids=[],
+        created_at="2026-06-02T12:00:00+00:00",
+        updated_at="2026-06-02T12:00:00+00:00",
+        status="in_progress",
+    )
+    base.update(kw)
+    return CampaignRecord(**base)
+
+
+def test_record_properties_with_steps():
+    rec = _record(done_step_ids=["a", "b"])
+    assert rec.total_steps == 3
+    assert rec.completed_steps == 2
+    assert rec.progress_pct == pytest.approx(66.7)
+
+
+def test_record_progress_pct_empty_steps():
+    rec = _record(step_task_ids=[])
+    assert rec.total_steps == 0
+    assert rec.completed_steps == 0
+    assert rec.progress_pct == 0.0
+
+
+def test_record_to_dict_includes_computed():
+    rec = _record(done_step_ids=["a"])
+    d = rec.to_dict()
+    assert d["source_task_id"] == "t1"
+    assert d["total_steps"] == 3
+    assert d["completed_steps"] == 1
+    assert d["progress_pct"] == pytest.approx(33.3)
+    # base dataclass fields preserved
+    assert d["step_task_ids"] == ["a", "b", "c"]
+    assert d["status"] == "in_progress"
+
+
+# --------------------------------------------------------------------------
+# CampaignStore.create
+# --------------------------------------------------------------------------
+def test_create_new_campaign(store: CampaignStore, store_path: Path):
+    cid = store.create(
+        source_task_id="abc",
+        title="Refactor",
+        step_task_ids=["s1", "s2"],
+        now=_fixed(),
+    )
+    assert cid == "abc"
+    assert store_path.exists()
+    rec = store.get("abc")
+    assert rec is not None
+    assert rec["title"] == "Refactor"
+    assert rec["step_task_ids"] == ["s1", "s2"]
+    assert rec["done_step_ids"] == []
+    assert rec["cancelled_step_ids"] == []
+    assert rec["status"] == "in_progress"
+    assert rec["created_at"] == _fixed().isoformat()
+    assert rec["updated_at"] == _fixed().isoformat()
+    assert rec["total_steps"] == 2
+    assert rec["completed_steps"] == 0
+    assert rec["progress_pct"] == 0.0
+
+
+def test_create_idempotent_noop_returns_existing(store: CampaignStore):
+    store.create(source_task_id="abc", title="First", step_task_ids=["s1"], now=_fixed())
+    cid = store.create(source_task_id="abc", title="Second", step_task_ids=["x"], now=_fixed(2027))
+    assert cid == "abc"
+    rec = store.get("abc")
+    # unchanged: still the first campaign
+    assert rec["title"] == "First"
+    assert rec["step_task_ids"] == ["s1"]
+
+
+def test_create_uses_now_default(monkeypatch, store: CampaignStore):
+    import operations_center.execution.campaign_store as mod
+
+    class _DT:
+        @staticmethod
+        def now(tz=None):
+            return _fixed(2025)
+
+    monkeypatch.setattr(mod, "datetime", _DT)
+    store.create(source_task_id="d", title="T", step_task_ids=[])
+    rec = store.get("d")
+    assert rec["created_at"] == _fixed(2025).isoformat()
+
+
+def test_create_copies_step_list(store: CampaignStore):
+    steps = ["s1", "s2"]
+    store.create(source_task_id="c", title="T", step_task_ids=steps, now=_fixed())
+    steps.append("mutated")
+    rec = store.get("c")
+    assert rec["step_task_ids"] == ["s1", "s2"]
+
+
+# --------------------------------------------------------------------------
+# record_step_done
+# --------------------------------------------------------------------------
+def test_record_step_done_marks_and_completes(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1", "s2"], now=_fixed())
+    store.record_step_done("c", step_task_id="s1", now=_fixed())
+    rec = store.get("c")
+    assert rec["done_step_ids"] == ["s1"]
+    assert rec["status"] == "partial"
+    assert rec["completed_steps"] == 1
+    assert rec["progress_pct"] == pytest.approx(50.0)
+
+    store.record_step_done("c", step_task_id="s2", now=_fixed())
+    rec = store.get("c")
+    assert rec["status"] == "completed"
+    assert rec["progress_pct"] == 100.0
+
+
+def test_record_step_done_unknown_campaign_noop(store: CampaignStore):
+    # no campaigns exist; should not raise and not create anything
+    store.record_step_done("missing", step_task_id="s1", now=_fixed())
+    assert store.get("missing") is None
+
+
+def test_record_step_done_duplicate_not_appended(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1", "s2"], now=_fixed())
+    store.record_step_done("c", step_task_id="s1", now=_fixed())
+    store.record_step_done("c", step_task_id="s1", now=_fixed())
+    rec = store.get("c")
+    assert rec["done_step_ids"] == ["s1"]
+
+
+def test_record_step_done_default_now(monkeypatch, store: CampaignStore):
+    import operations_center.execution.campaign_store as mod
+
+    store.create(source_task_id="c", title="T", step_task_ids=["s1"], now=_fixed())
+
+    class _DT:
+        @staticmethod
+        def now(tz=None):
+            return _fixed(2099)
+
+    monkeypatch.setattr(mod, "datetime", _DT)
+    store.record_step_done("c", step_task_id="s1")
+    rec = store.get("c")
+    assert rec["updated_at"] == _fixed(2099).isoformat()
+
+
+# --------------------------------------------------------------------------
+# record_step_cancelled
+# --------------------------------------------------------------------------
+def test_record_step_cancelled_partial(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1", "s2"], now=_fixed())
+    store.record_step_cancelled("c", step_task_id="s1", now=_fixed())
+    rec = store.get("c")
+    assert rec["cancelled_step_ids"] == ["s1"]
+    assert rec["status"] == "partial"
+
+
+def test_record_step_cancelled_all_cancelled(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1", "s2"], now=_fixed())
+    store.record_step_cancelled("c", step_task_id="s1", now=_fixed())
+    store.record_step_cancelled("c", step_task_id="s2", now=_fixed())
+    rec = store.get("c")
+    assert rec["status"] == "cancelled"
+
+
+def test_record_step_cancelled_unknown_noop(store: CampaignStore):
+    store.record_step_cancelled("nope", step_task_id="s1", now=_fixed())
+    assert store.get("nope") is None
+
+
+def test_record_step_cancelled_duplicate_not_appended(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1", "s2"], now=_fixed())
+    store.record_step_cancelled("c", step_task_id="s1", now=_fixed())
+    store.record_step_cancelled("c", step_task_id="s1", now=_fixed())
+    rec = store.get("c")
+    assert rec["cancelled_step_ids"] == ["s1"]
+
+
+def test_record_step_cancelled_default_now(monkeypatch, store: CampaignStore):
+    import operations_center.execution.campaign_store as mod
+
+    store.create(source_task_id="c", title="T", step_task_ids=["s1"], now=_fixed())
+
+    class _DT:
+        @staticmethod
+        def now(tz=None):
+            return _fixed(2088)
+
+    monkeypatch.setattr(mod, "datetime", _DT)
+    store.record_step_cancelled("c", step_task_id="s1")
+    rec = store.get("c")
+    assert rec["updated_at"] == _fixed(2088).isoformat()
+
+
+# --------------------------------------------------------------------------
+# get
+# --------------------------------------------------------------------------
+def test_get_missing_returns_none(store: CampaignStore):
+    assert store.get("none") is None
+
+
+def test_get_returns_copy(store: CampaignStore):
+    store.create(source_task_id="c", title="T", step_task_ids=["s1"], now=_fixed())
+    rec = store.get("c")
+    rec["title"] = "mutated"
+    assert store.get("c")["title"] == "T"
+
+
+# --------------------------------------------------------------------------
+# list_campaigns
+# --------------------------------------------------------------------------
+def test_list_empty(store: CampaignStore):
+    assert store.list_campaigns() == []
+
+
+def test_list_sorted_by_created_desc(store: CampaignStore):
+    store.create(source_task_id="old", title="Old", step_task_ids=["s"], now=_fixed(2024))
+    store.create(source_task_id="new", title="New", step_task_ids=["s"], now=_fixed(2026))
+    rows = store.list_campaigns()
+    assert [r["source_task_id"] for r in rows] == ["new", "old"]
+
+
+def test_list_filter_by_status(store: CampaignStore):
+    store.create(source_task_id="a", title="A", step_task_ids=["s1"], now=_fixed())
+    store.create(source_task_id="b", title="B", step_task_ids=["s1"], now=_fixed())
+    store.record_step_done("a", step_task_id="s1", now=_fixed())  # completed
+    completed = store.list_campaigns(status="completed")
+    assert [r["source_task_id"] for r in completed] == ["a"]
+    in_prog = store.list_campaigns(status="in_progress")
+    assert [r["source_task_id"] for r in in_prog] == ["b"]
+
+
+# --------------------------------------------------------------------------
+# _load error handling / persistence
+# --------------------------------------------------------------------------
+def test_load_missing_file_returns_empty(store: CampaignStore):
+    assert store._load() == {}
+
+
+def test_load_corrupt_json_warns_and_returns_empty(store_path: Path, caplog):
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text("{ not valid json", encoding="utf-8")
+    store = CampaignStore(path=store_path)
+    with caplog.at_level("WARNING"):
+        result = store._load()
+    assert result == {}
+    assert "campaign_store_load_failed" in caplog.text
+
+
+def test_save_creates_parent_dirs(tmp_path: Path):
+    path = tmp_path / "deep" / "nested" / "campaigns.json"
+    store = CampaignStore(path=path)
+    store.create(source_task_id="c", title="T", step_task_ids=["s1"], now=_fixed())
+    assert path.exists()
+
+
+def test_persistence_across_instances(store_path: Path):
+    s1 = CampaignStore(path=store_path)
+    s1.create(source_task_id="c", title="T", step_task_ids=["s1"], now=_fixed())
+    s2 = CampaignStore(path=store_path)
+    assert s2.get("c")["title"] == "T"
+
+
+# --------------------------------------------------------------------------
+# _compute_status
+# --------------------------------------------------------------------------
+def test_compute_status_in_progress():
+    assert (
+        _compute_status(
+            {"step_task_ids": ["a", "b"], "done_step_ids": [], "cancelled_step_ids": []}
+        )
+        == "in_progress"
+    )
+
+
+def test_compute_status_completed():
+    assert (
+        _compute_status(
+            {"step_task_ids": ["a", "b"], "done_step_ids": ["a", "b"], "cancelled_step_ids": []}
+        )
+        == "completed"
+    )
+
+
+def test_compute_status_cancelled():
+    assert (
+        _compute_status(
+            {"step_task_ids": ["a", "b"], "done_step_ids": [], "cancelled_step_ids": ["a", "b"]}
+        )
+        == "cancelled"
+    )
+
+
+def test_compute_status_partial():
+    assert (
+        _compute_status(
+            {"step_task_ids": ["a", "b", "c"], "done_step_ids": ["a"], "cancelled_step_ids": ["b"]}
+        )
+        == "partial"
+    )
+
+
+def test_compute_status_zero_total_in_progress():
+    # total == 0 => never completed/cancelled; with no done/cancelled => in_progress
+    assert (
+        _compute_status({"step_task_ids": [], "done_step_ids": [], "cancelled_step_ids": []})
+        == "in_progress"
+    )
+
+
+def test_compute_status_completed_precedence_over_cancelled():
+    # done >= total checked first
+    assert (
+        _compute_status(
+            {"step_task_ids": ["a"], "done_step_ids": ["a"], "cancelled_step_ids": ["a"]}
+        )
+        == "completed"
+    )
+
+
+def test_compute_status_missing_keys_defaults():
+    assert _compute_status({}) == "in_progress"
+
+
+# --------------------------------------------------------------------------
+# _refresh_computed
+# --------------------------------------------------------------------------
+def test_refresh_computed_with_steps():
+    rec = {"step_task_ids": ["a", "b", "c"], "done_step_ids": ["a", "b"]}
+    _refresh_computed(rec)
+    assert rec["total_steps"] == 3
+    assert rec["completed_steps"] == 2
+    assert rec["progress_pct"] == pytest.approx(66.7)
+
+
+def test_refresh_computed_zero_total():
+    rec = {"step_task_ids": [], "done_step_ids": []}
+    _refresh_computed(rec)
+    assert rec["total_steps"] == 0
+    assert rec["completed_steps"] == 0
+    assert rec["progress_pct"] == 0.0

--- a/tests/unit/execution/test_coordinator_cov.py
+++ b/tests/unit/execution/test_coordinator_cov.py
@@ -1,0 +1,1285 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+
+from operations_center.config.settings import (
+    BackendCapSettings,
+    ResourceGateSettings,
+)
+from operations_center.contracts.common import ValidationSummary
+from operations_center.contracts.enums import (
+    BackendName,
+    ExecutionStatus,
+    FailureReasonCategory,
+    LaneName,
+    ValidationStatus,
+)
+from operations_center.contracts.execution import (
+    ExecutionResult,
+    RuntimeBindingSummary,
+)
+from operations_center.contracts.routing import LaneDecision
+from operations_center.execution import coordinator as coord_mod
+from operations_center.execution.coordinator import (
+    ExecutionCoordinator,
+    _adapter_crash_result,
+    _attach_lifecycle_outcome,
+    _backend_capped_result,
+    _evaluate_runtime_drift,
+    _policy_blocked_result,
+    _policy_engine_crash_result,
+    _recovery_engine_crash_result,
+    _resource_gate_blocked_result,
+    _runtime_metadata_from_capture,
+    _workspace_prep_failed_result,
+)
+from operations_center.execution.handoff import ExecutionRuntimeContext
+from operations_center.execution.models import BudgetDecision
+from operations_center.execution.recovery_loop import (
+    RecoveryAction,
+    RecoveryDecision,
+    RecoveryPolicy,
+)
+from operations_center.execution.recovery_loop.models import (
+    ExecutionFailureKind,
+    RecoveryOutcome,
+)
+from operations_center.planning.models import PlanningContext, ProposalDecisionBundle
+from operations_center.planning.proposal_builder import build_proposal
+from operations_center.policy.models import PolicyDecision, PolicyStatus
+
+
+# ---------------------------------------------------------------------------
+# Shared test doubles / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _AllowPolicy:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def evaluate(self, *_a, **_k) -> PolicyDecision:
+        self.calls += 1
+        return PolicyDecision(status=PolicyStatus.ALLOW)
+
+
+class _RecordingAdapter:
+    def __init__(self, result: ExecutionResult) -> None:
+        self.result = result
+        self.calls = 0
+        self.last_request = None
+
+    def execute(self, request):
+        self.calls += 1
+        self.last_request = request
+        return self.result
+
+
+class _CrashAdapter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def execute(self, request):
+        self.calls += 1
+        raise RuntimeError("adapter exploded")
+
+
+class _Registry:
+    def __init__(self, adapter) -> None:
+        self._a = adapter
+
+    def for_backend(self, _backend):
+        return self._a
+
+
+def _bundle() -> ProposalDecisionBundle:
+    proposal = build_proposal(
+        PlanningContext(
+            goal_text="Fix lint failures",
+            task_type="lint_fix",
+            repo_key="svc",
+            clone_url="https://example.invalid/svc.git",
+        )
+    )
+    decision = LaneDecision(
+        proposal_id=proposal.proposal_id,
+        selected_lane=LaneName.AIDER_LOCAL,
+        selected_backend=BackendName.DIRECT_LOCAL,
+    )
+    return ProposalDecisionBundle(proposal=proposal, decision=decision)
+
+
+def _runtime(**kw) -> ExecutionRuntimeContext:
+    return ExecutionRuntimeContext(
+        workspace_path=Path("/tmp/workspace"),
+        task_branch="auto/lint-fix",
+        **kw,
+    )
+
+
+def _success(bundle, run_id="run-1") -> ExecutionResult:
+    return ExecutionResult(
+        run_id=run_id,
+        proposal_id=bundle.proposal.proposal_id,
+        decision_id=bundle.decision.decision_id,
+        status=ExecutionStatus.SUCCEEDED,
+        success=True,
+        validation=ValidationSummary(status=ValidationStatus.SKIPPED),
+    )
+
+
+def _backend_failure(bundle, reason: str) -> ExecutionResult:
+    return ExecutionResult(
+        run_id="run-1",
+        proposal_id=bundle.proposal.proposal_id,
+        decision_id=bundle.decision.decision_id,
+        status=ExecutionStatus.FAILED,
+        success=False,
+        validation=ValidationSummary(status=ValidationStatus.SKIPPED),
+        failure_category=FailureReasonCategory.BACKEND_ERROR,
+        failure_reason=reason,
+    )
+
+
+def _real_request(bundle) -> object:
+    """Build a real ExecutionRequest for use as a recovery next_request."""
+    from operations_center.execution.handoff import ExecutionRequestBuilder
+
+    return ExecutionRequestBuilder().build(bundle, _runtime())
+
+
+class _FakeRequest:
+    """Minimal stand-in for ExecutionRequest used by module-level helpers."""
+
+    def __init__(self) -> None:
+        self.run_id = "r-1"
+        self.proposal_id = "p-1"
+        self.decision_id = "d-1"
+        self.repo_key = "svc"
+        self.runtime_binding = None
+        self.lifecycle = None
+
+
+# ---------------------------------------------------------------------------
+# Module-level result builders
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_prep_failed_result() -> None:
+    res = _workspace_prep_failed_result(_FakeRequest(), RuntimeError("clone failed"))
+    assert res.success is False
+    assert res.status == ExecutionStatus.FAILED
+    assert res.failure_category == FailureReasonCategory.BACKEND_ERROR
+    assert "clone failed" in res.failure_reason
+
+
+def test_adapter_crash_result() -> None:
+    res = _adapter_crash_result(_FakeRequest(), ValueError("kaboom"))
+    assert res.failure_category == FailureReasonCategory.BACKEND_ERROR
+    assert "kaboom" in res.failure_reason
+
+
+def test_recovery_engine_crash_result() -> None:
+    res = _recovery_engine_crash_result(_FakeRequest(), RuntimeError("re boom"))
+    assert res.failure_category == FailureReasonCategory.BACKEND_ERROR
+    assert "re boom" in res.failure_reason
+
+
+def test_policy_engine_crash_result() -> None:
+    res = _policy_engine_crash_result(_FakeRequest(), RuntimeError("pe boom"))
+    assert res.failure_category == FailureReasonCategory.POLICY_BLOCKED
+    assert "pe boom" in res.failure_reason
+
+
+def test_policy_blocked_result_block_vs_review() -> None:
+    blocked = _policy_blocked_result(
+        _FakeRequest(), PolicyDecision(status=PolicyStatus.BLOCK, notes="nope")
+    )
+    assert "execution blocked by policy" in blocked.failure_reason
+    review = _policy_blocked_result(
+        _FakeRequest(), PolicyDecision(status=PolicyStatus.REQUIRE_REVIEW, notes="check")
+    )
+    assert "requires review" in review.failure_reason
+    assert review.failure_category == FailureReasonCategory.POLICY_BLOCKED
+
+
+def test_resource_gate_blocked_result_with_and_without_detail() -> None:
+    full = _resource_gate_blocked_result(
+        _FakeRequest(),
+        BudgetDecision(
+            allowed=False,
+            reason="global_concurrency_exceeded",
+            window="now",
+            current=3,
+            limit=2,
+        ),
+    )
+    assert full.status == ExecutionStatus.SKIPPED
+    assert full.failure_category == FailureReasonCategory.BUDGET_EXHAUSTED
+    assert "global_concurrency_exceeded" in full.failure_reason
+    assert "window=now" in full.failure_reason
+    assert "current=3 limit=2" in full.failure_reason
+
+    minimal = _resource_gate_blocked_result(
+        _FakeRequest(),
+        BudgetDecision(allowed=False, reason="global_memory_insufficient"),
+    )
+    assert "window=" not in minimal.failure_reason
+    assert "current=" not in minimal.failure_reason
+
+
+def test_backend_capped_result_with_and_without_detail() -> None:
+    full = _backend_capped_result(
+        _FakeRequest(),
+        BudgetDecision(
+            allowed=False,
+            reason="backend_budget_exceeded",
+            window="day",
+            current=5,
+            limit=5,
+        ),
+        "direct_local",
+    )
+    assert "direct_local" in full.failure_reason
+    assert "window=day" in full.failure_reason
+    assert "current=5 limit=5" in full.failure_reason
+
+    minimal = _backend_capped_result(
+        _FakeRequest(),
+        BudgetDecision(allowed=False, reason="x"),
+        "direct_local",
+    )
+    assert "window=" not in minimal.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# _runtime_metadata_from_capture
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_metadata_from_capture_none() -> None:
+    assert _runtime_metadata_from_capture(None) == {}
+
+
+def test_runtime_metadata_from_capture_full() -> None:
+    cap = type(
+        "Cap",
+        (),
+        {
+            "duration_ms": 99,
+            "observed_runtime": {"model": "x"},
+            "used_capabilities": ["b", "a"],
+        },
+    )()
+    meta = _runtime_metadata_from_capture(cap)
+    assert meta["duration_ms"] == 99
+    assert meta["observed_runtime"] == {"model": "x"}
+    assert meta["used_capabilities"] == ["a", "b"]
+
+
+def test_runtime_metadata_from_capture_bad_duration_swallowed() -> None:
+    cap = type("Cap", (), {"duration_ms": "not-a-number"})()
+    meta = _runtime_metadata_from_capture(cap)
+    assert "duration_ms" not in meta
+
+
+def test_runtime_metadata_from_capture_ignores_wrong_types() -> None:
+    cap = type(
+        "Cap",
+        (),
+        {"observed_runtime": "notdict", "used_capabilities": "notseq"},
+    )()
+    meta = _runtime_metadata_from_capture(cap)
+    assert "observed_runtime" not in meta
+    assert "used_capabilities" not in meta
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_runtime_drift
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_runtime_drift_no_binding_returns_none() -> None:
+    req = _FakeRequest()
+    assert _evaluate_runtime_drift(backend_id="b", request=req, runtime_metadata={}) is None
+
+
+def test_evaluate_runtime_drift_no_drift_returns_none() -> None:
+    req = _FakeRequest()
+    req.runtime_binding = RuntimeBindingSummary(
+        kind="hosted_api", selection_mode="policy_selected", model="m1", provider="p1"
+    )
+    out = _evaluate_runtime_drift(
+        backend_id="direct_local",
+        request=req,
+        runtime_metadata={"observed_runtime": {"model": "m1", "provider": "p1"}},
+    )
+    assert out is None
+
+
+def test_evaluate_runtime_drift_detected_returns_dict() -> None:
+    req = _FakeRequest()
+    req.runtime_binding = RuntimeBindingSummary(
+        kind="hosted_api", selection_mode="policy_selected", model="m1", provider="p1"
+    )
+    out = _evaluate_runtime_drift(
+        backend_id="direct_local",
+        request=req,
+        runtime_metadata={"observed_runtime": {"model": "DIFFERENT", "provider": "p1"}},
+    )
+    assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# _attach_lifecycle_outcome
+# ---------------------------------------------------------------------------
+
+
+def _lifecycle_metadata():
+    from operations_center.lifecycle.models import LifecycleMetadata
+
+    return LifecycleMetadata()
+
+
+def test_attach_lifecycle_outcome_none_metadata_returns_unchanged() -> None:
+    bundle = _bundle()
+    result = _success(bundle)
+    req = _FakeRequest()
+    req.lifecycle = None
+    out = _attach_lifecycle_outcome(request=req, result=result, repo_graph_context=None)
+    assert out is result
+
+
+def test_attach_lifecycle_outcome_runs_and_sets_outcome() -> None:
+    bundle = _bundle()
+    result = _success(bundle)
+    req = _FakeRequest()
+    req.lifecycle = _lifecycle_metadata()
+    out = _attach_lifecycle_outcome(request=req, result=result, repo_graph_context=None)
+    assert out.lifecycle_outcome is not None
+
+
+def test_attach_lifecycle_outcome_with_resolving_repo_graph() -> None:
+    bundle = _bundle()
+    result = _success(bundle)
+    req = _FakeRequest()
+    req.lifecycle = _lifecycle_metadata()
+
+    class _Node:
+        canonical_name = "svc/module"
+
+    class _Graph:
+        def resolve(self, _key):
+            return _Node()
+
+    out = _attach_lifecycle_outcome(request=req, result=result, repo_graph_context=_Graph())
+    assert out.lifecycle_outcome is not None
+
+
+def test_attach_lifecycle_outcome_runner_raises_returns_original(monkeypatch) -> None:
+    bundle = _bundle()
+    result = _success(bundle)
+    req = _FakeRequest()
+    req.lifecycle = _lifecycle_metadata()
+
+    import operations_center.lifecycle as lc
+
+    class _BoomRunner:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def run(self, **_k):
+            raise RuntimeError("lifecycle boom")
+
+    monkeypatch.setattr(lc, "LifecycleRunner", _BoomRunner)
+    out = _attach_lifecycle_outcome(request=req, result=result, repo_graph_context=None)
+    assert out is result
+
+
+# ---------------------------------------------------------------------------
+# Coordinator.execute — resource gate
+# ---------------------------------------------------------------------------
+
+
+class _FakeUsageStore:
+    """In-memory usage store recording event kinds, with tunable decisions."""
+
+    def __init__(
+        self,
+        *,
+        global_conc=None,
+        global_rate=None,
+        global_mem=None,
+        backend_rate=None,
+        backend_conc=None,
+        backend_mem=None,
+    ) -> None:
+        self.events: list[str] = []
+        self.quota_events = 0
+        self.outcomes: list[bool] = []
+        self._global_conc = global_conc
+        self._global_rate = global_rate
+        self._global_mem = global_mem
+        self._backend_rate = backend_rate
+        self._backend_conc = backend_conc
+        self._backend_mem = backend_mem
+
+    def record_execution_started(self, **_k):
+        self.events.append("started")
+
+    def record_execution_finished(self, **_k):
+        self.events.append("finished")
+
+    def record_execution(self, **_k):
+        self.events.append("execution")
+
+    def record_quota_event(self, **_k):
+        self.quota_events += 1
+
+    def record_execution_outcome(self, *, succeeded, **_k):
+        self.outcomes.append(succeeded)
+
+    def global_concurrency_decision(self, **_k):
+        return self._global_conc
+
+    def global_rate_decision(self, **_k):
+        return self._global_rate
+
+    def global_memory_decision(self, **_k):
+        return self._global_mem
+
+    def budget_decision_for_backend(self, *_a, **_k):
+        return self._backend_rate
+
+    def concurrency_decision_for_backend(self, *_a, **_k):
+        return self._backend_conc
+
+    def memory_decision_for_backend(self, *_a, **_k):
+        return self._backend_mem
+
+
+_ALLOW = BudgetDecision(allowed=True)
+
+
+def test_resource_gate_concurrency_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        global_conc=BudgetDecision(allowed=False, reason="global_concurrency_exceeded")
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        resource_gate=ResourceGateSettings(max_concurrent=1),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert adapter.calls == 0
+    assert out.result.failure_category == FailureReasonCategory.BUDGET_EXHAUSTED
+    assert "global_concurrency_exceeded" in out.result.failure_reason
+
+
+def test_resource_gate_rate_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        global_conc=_ALLOW,
+        global_rate=BudgetDecision(allowed=False, reason="global_rate_exceeded"),
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        resource_gate=ResourceGateSettings(max_concurrent=1, max_per_hour=2),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert "global_rate_exceeded" in out.result.failure_reason
+
+
+def test_resource_gate_memory_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        global_conc=_ALLOW,
+        global_rate=_ALLOW,
+        global_mem=BudgetDecision(allowed=False, reason="global_memory_insufficient"),
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        resource_gate=ResourceGateSettings(
+            max_concurrent=1, max_per_hour=2, min_available_memory_mb=4096
+        ),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert "global_memory_insufficient" in out.result.failure_reason
+
+
+def test_resource_gate_all_pass_dispatches() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(global_conc=_ALLOW, global_rate=_ALLOW, global_mem=_ALLOW)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        resource_gate=ResourceGateSettings(
+            max_concurrent=2, max_per_hour=4, min_available_memory_mb=1
+        ),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert adapter.calls == 1
+    assert "started" in store.events and "finished" in store.events
+    assert store.outcomes == [True]
+
+
+def test_resource_gate_none_when_no_gate_settings() -> None:
+    # usage_store present but resource_gate None -> _evaluate_resource_gate None
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+    )
+    assert coord._evaluate_resource_gate() is None
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+
+
+# ---------------------------------------------------------------------------
+# Coordinator.execute — backend caps via fake store
+# ---------------------------------------------------------------------------
+
+
+def test_backend_cap_rate_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        backend_rate=BudgetDecision(allowed=False, reason="backend_budget_exceeded")
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        backend_caps={"direct_local": BackendCapSettings(max_per_day=1)},
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert "backend_budget_exceeded" in out.result.failure_reason
+
+
+def test_backend_cap_concurrency_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        backend_rate=_ALLOW,
+        backend_conc=BudgetDecision(allowed=False, reason="backend_concurrency_exceeded"),
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        backend_caps={"direct_local": BackendCapSettings(max_per_day=10, max_concurrent=1)},
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert "backend_concurrency_exceeded" in out.result.failure_reason
+
+
+def test_backend_cap_memory_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore(
+        backend_rate=_ALLOW,
+        backend_conc=_ALLOW,
+        backend_mem=BudgetDecision(allowed=False, reason="backend_memory_insufficient"),
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        backend_caps={
+            "direct_local": BackendCapSettings(
+                max_per_day=10, max_concurrent=4, min_available_memory_mb=4096
+            )
+        },
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert "backend_memory_insufficient" in out.result.failure_reason
+
+
+def test_backend_cap_no_entry_passes() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    store = _FakeUsageStore()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+        backend_caps={"some_other_backend": BackendCapSettings(max_per_day=1)},
+    )
+    assert coord._evaluate_backend_caps("direct_local") is None
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+
+
+def test_evaluate_backend_caps_no_usage_store() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+    assert coord._evaluate_backend_caps("direct_local") is None
+
+
+# ---------------------------------------------------------------------------
+# Capacity exhaustion -> quota event vs normal outcome
+# ---------------------------------------------------------------------------
+
+
+def test_capacity_exhaustion_records_quota_event() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(
+        _backend_failure(bundle, "Backend error: you've hit your limit for today")
+    )
+    store = _FakeUsageStore()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert store.quota_events == 1
+    assert store.outcomes == []
+
+
+def test_non_capacity_failure_records_outcome() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "syntax error in patch"))
+    store = _FakeUsageStore()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        usage_store=store,
+    )
+    coord.execute(bundle, _runtime())
+    assert store.quota_events == 0
+    assert store.outcomes == [False]
+
+
+# ---------------------------------------------------------------------------
+# Workspace prepare / finalize
+# ---------------------------------------------------------------------------
+
+
+class _Workspace:
+    def __init__(self, *, prep_raises=False, finalize_raises=False) -> None:
+        self.prep_raises = prep_raises
+        self.finalize_raises = finalize_raises
+        self.prepared = False
+        self.finalized = False
+
+    def prepare(self, request):
+        self.prepared = True
+        if self.prep_raises:
+            raise RuntimeError("clone failed")
+
+    def finalize(self, request, result):
+        self.finalized = True
+        if self.finalize_raises:
+            raise RuntimeError("push failed")
+        return result.model_copy(update={"failure_reason": "finalized"})
+
+
+def test_workspace_prep_failure_short_circuits() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    ws = _Workspace(prep_raises=True)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        workspace_manager=ws,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is False
+    assert adapter.calls == 0
+    assert "Workspace preparation failed" in out.result.failure_reason
+
+
+def test_workspace_finalize_runs_on_success() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    ws = _Workspace()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        workspace_manager=ws,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert ws.prepared and ws.finalized
+    assert out.result.failure_reason == "finalized"
+
+
+def test_workspace_finalize_failure_is_non_fatal() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    ws = _Workspace(finalize_raises=True)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        workspace_manager=ws,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert out.result.success is True
+
+
+def test_workspace_finalize_skipped_on_failure_result() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    ws = _Workspace()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        workspace_manager=ws,
+    )
+    coord.execute(bundle, _runtime())
+    assert ws.prepared is True
+    assert ws.finalized is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime binding policy
+# ---------------------------------------------------------------------------
+
+
+class _Binding:
+    def __init__(self) -> None:
+        self.kind = type("K", (), {"value": "hosted_api"})()
+        self.selection_mode = type("M", (), {"value": "policy_selected"})()
+        self.model = "m1"
+        self.provider = "p1"
+        self.endpoint = None
+        self.config_ref = None
+
+
+class _BindingPolicy:
+    def __init__(self, binding) -> None:
+        self._b = binding
+
+    def select(self, proposal, decision):
+        return self._b
+
+
+class _RaisingBindingPolicy:
+    def select(self, proposal, decision):
+        raise RuntimeError("select boom")
+
+
+def test_runtime_binding_policy_none_passthrough() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+    )
+    rt = _runtime()
+    assert coord._apply_runtime_binding_policy(bundle, rt) is rt
+
+
+def test_runtime_binding_policy_respects_existing_binding() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        runtime_binding_policy=_BindingPolicy(_Binding()),
+    )
+    rt = _runtime(
+        runtime_binding=RuntimeBindingSummary(
+            kind="cli_subscription",
+            selection_mode="explicit_request",
+            provider="anthropic",
+            model="caller",
+        )
+    )
+    assert coord._apply_runtime_binding_policy(bundle, rt) is rt
+
+
+def test_runtime_binding_policy_select_raises_falls_back() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        runtime_binding_policy=_RaisingBindingPolicy(),
+    )
+    rt = _runtime()
+    assert coord._apply_runtime_binding_policy(bundle, rt) is rt
+
+
+def test_runtime_binding_policy_returns_none_passthrough() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        runtime_binding_policy=_BindingPolicy(None),
+    )
+    rt = _runtime()
+    assert coord._apply_runtime_binding_policy(bundle, rt) is rt
+
+
+def test_runtime_binding_policy_binds_and_dispatches() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        runtime_binding_policy=_BindingPolicy(_Binding()),
+    )
+    new_rt = coord._apply_runtime_binding_policy(bundle, _runtime())
+    assert new_rt.runtime_binding is not None
+    assert new_rt.runtime_binding.model == "m1"
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+
+
+# ---------------------------------------------------------------------------
+# Run memory indexing
+# ---------------------------------------------------------------------------
+
+
+def test_record_run_memory_none_dir_noop(monkeypatch) -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+
+    import operations_center.run_memory as rm
+
+    calls: list[object] = []
+
+    def _track(*_a, **_k):
+        calls.append(object())
+
+    monkeypatch.setattr(rm, "record_execution_result", _track)
+    # No run_memory_index_dir configured -> recorder must not be invoked.
+    out = coord._record_run_memory(request=_FakeRequest(), result=_success(bundle), bundle=bundle)
+    assert out is None
+    assert calls == []
+
+
+def test_record_run_memory_calls_recorder(monkeypatch, tmp_path: Path) -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    calls = {}
+
+    import operations_center.run_memory as rm
+
+    def _fake_record(result, index_dir, *, repo_id, tags):
+        calls["repo_id"] = repo_id
+        calls["tags"] = tags
+
+    monkeypatch.setattr(rm, "record_execution_result", _fake_record)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        run_memory_index_dir=tmp_path / "idx",
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert calls["repo_id"] == "svc"
+    assert calls["tags"][0] == "lint_fix"
+
+
+def test_record_run_memory_swallows_errors(monkeypatch, tmp_path: Path) -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+
+    import operations_center.run_memory as rm
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("index boom")
+
+    monkeypatch.setattr(rm, "record_execution_result", _boom)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        run_memory_index_dir=tmp_path / "idx",
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True  # error swallowed
+
+
+# ---------------------------------------------------------------------------
+# Contract impact hook
+# ---------------------------------------------------------------------------
+
+
+def test_log_contract_impact_no_graph_returns_empty() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+    assert coord._log_contract_impact(_FakeRequest()) == {}
+
+
+def test_log_contract_impact_non_repograph_returns_empty() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+        repo_graph=object(),  # not a RepoGraph
+    )
+    assert coord._log_contract_impact(_FakeRequest()) == {}
+
+
+def test_log_contract_impact_with_impact(monkeypatch) -> None:
+    bundle = _bundle()
+    from platform_manifest import RepoGraph
+
+    graph = RepoGraph()
+
+    class _Node:
+        def __init__(self, name, repo="r"):
+            self.canonical_name = name
+            self.repo_id = repo
+
+    class _Summary:
+        def __init__(self) -> None:
+            self.target = _Node("svc/api")
+            self.affected = [_Node("svc/a"), _Node("svc/b")]
+            self.public_affected = [_Node("svc/a")]
+            self.private_affected = [_Node("svc/b")]
+
+        def has_impact(self):
+            return True
+
+    import operations_center.impact_analysis as ia
+
+    monkeypatch.setattr(ia, "compute_contract_impact", lambda g, key: _Summary())
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+        repo_graph=graph,
+    )
+    meta = coord._log_contract_impact(_FakeRequest())
+    assert meta["contract_impact"]["affected_count"] == 2
+    assert meta["contract_impact"]["public_affected"] == ["svc/a"]
+
+
+def test_log_contract_impact_no_impact_returns_empty(monkeypatch) -> None:
+    bundle = _bundle()
+    from platform_manifest import RepoGraph
+
+    class _Summary:
+        def has_impact(self):
+            return False
+
+    import operations_center.impact_analysis as ia
+
+    monkeypatch.setattr(ia, "compute_contract_impact", lambda g, key: _Summary())
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+        repo_graph=RepoGraph(),
+    )
+    assert coord._log_contract_impact(_FakeRequest()) == {}
+
+
+def test_log_contract_impact_compute_raises_returns_empty(monkeypatch) -> None:
+    bundle = _bundle()
+    from platform_manifest import RepoGraph
+
+    import operations_center.impact_analysis as ia
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("impact boom")
+
+    monkeypatch.setattr(ia, "compute_contract_impact", _boom)
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+        repo_graph=RepoGraph(),
+    )
+    assert coord._log_contract_impact(_FakeRequest()) == {}
+
+
+# ---------------------------------------------------------------------------
+# Recovery loop branches via stub engine
+# ---------------------------------------------------------------------------
+
+
+def _action(decision, attempt=1, delay=None):
+    return RecoveryAction(
+        attempt=attempt,
+        failure_kind=ExecutionFailureKind.UNKNOWN,
+        decision=decision,
+        reason="r",
+        delay_seconds=delay,
+    )
+
+
+class _StubEngine:
+    """Yields a queue of RecoveryOutcomes; raises if exhausted."""
+
+    def __init__(self, outcomes) -> None:
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    def evaluate(self, result, ctx):
+        self.calls += 1
+        return self._outcomes.pop(0)
+
+
+class _RaisingEngine:
+    def evaluate(self, result, ctx):
+        raise RuntimeError("engine boom")
+
+
+def test_recovery_accept_first_attempt() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_success(bundle))
+    engine = _StubEngine(
+        [RecoveryOutcome(decision=RecoveryDecision.ACCEPT, action=_action(RecoveryDecision.ACCEPT))]
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        recovery_engine=engine,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.executed is True
+    assert adapter.calls == 1
+    # recovery action attached
+    assert out.result.recovery is not None
+
+
+def test_recovery_reject_no_next_request_stops() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    engine = _StubEngine(
+        [
+            RecoveryOutcome(
+                decision=RecoveryDecision.REJECT_UNRECOVERABLE,
+                action=_action(RecoveryDecision.REJECT_UNRECOVERABLE),
+                next_request=None,
+            )
+        ]
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        recovery_engine=engine,
+    )
+    out = coord.execute(bundle, _runtime())
+    assert adapter.calls == 1
+    assert out.result.success is False
+
+
+def test_recovery_engine_raises_synthesizes_crash_result() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        recovery_engine=_RaisingEngine(),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert "RecoveryEngine raised" in out.result.failure_reason
+
+
+def test_recovery_retry_same_request_then_accept() -> None:
+    bundle = _bundle()
+    # Adapter returns a failure both times; engine retries once, then accepts.
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    req_sentinel = object()
+    engine = _StubEngine(
+        [
+            RecoveryOutcome(
+                decision=RecoveryDecision.RETRY_SAME_REQUEST,
+                action=_action(RecoveryDecision.RETRY_SAME_REQUEST, delay=None),
+                next_request=req_sentinel,  # different object -> request_changed True
+                requires_policy_revalidation=False,
+            ),
+            RecoveryOutcome(
+                decision=RecoveryDecision.ACCEPT,
+                action=_action(RecoveryDecision.ACCEPT, attempt=2),
+            ),
+        ]
+    )
+    # request_changed True triggers policy re-eval; keep policy allowing.
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        recovery_engine=engine,
+        recovery_policy=RecoveryPolicy(max_attempts=3),
+    )
+    coord.execute(bundle, _runtime())
+    assert adapter.calls == 2
+    assert engine.calls == 2
+
+
+def test_recovery_retry_with_delay_records_actual(monkeypatch) -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    # Avoid real sleeping: patch bounded_sleep in coordinator module.
+    monkeypatch.setattr(coord_mod, "bounded_sleep", lambda d, m: 0.0)
+    engine = _StubEngine(
+        [
+            RecoveryOutcome(
+                decision=RecoveryDecision.RETRY_SAME_REQUEST,
+                action=_action(RecoveryDecision.RETRY_SAME_REQUEST, delay=5.0),
+                next_request=object(),
+                delay_seconds=5.0,
+            ),
+            RecoveryOutcome(
+                decision=RecoveryDecision.ACCEPT,
+                action=_action(RecoveryDecision.ACCEPT, attempt=2),
+            ),
+        ]
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+        recovery_engine=engine,
+        recovery_policy=RecoveryPolicy(max_attempts=2),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert adapter.calls == 2
+    assert out.result.recovery is not None
+
+
+def test_recovery_retry_policy_revalidation_blocks() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    engine = _StubEngine(
+        [
+            RecoveryOutcome(
+                decision=RecoveryDecision.RETRY_MODIFIED_REQUEST,
+                action=_action(RecoveryDecision.RETRY_MODIFIED_REQUEST),
+                next_request=_real_request(bundle),
+                requires_policy_revalidation=True,
+            )
+        ]
+    )
+    # Policy allows first eval (initial), then BLOCK on revalidation.
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_TwoPhasePolicy(),
+        recovery_engine=engine,
+        recovery_policy=RecoveryPolicy(max_attempts=2),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.result.failure_category == FailureReasonCategory.POLICY_BLOCKED
+
+
+class _TwoPhasePolicy:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def evaluate(self, *_a, **_k):
+        self.calls += 1
+        if self.calls <= 1:
+            return PolicyDecision(status=PolicyStatus.ALLOW)
+        return PolicyDecision(status=PolicyStatus.BLOCK, notes="blocked on retry")
+
+
+def test_recovery_retry_policy_engine_raises_during_revalidation() -> None:
+    bundle = _bundle()
+    adapter = _RecordingAdapter(_backend_failure(bundle, "boom"))
+    engine = _StubEngine(
+        [
+            RecoveryOutcome(
+                decision=RecoveryDecision.RETRY_MODIFIED_REQUEST,
+                action=_action(RecoveryDecision.RETRY_MODIFIED_REQUEST),
+                next_request=_real_request(bundle),
+                requires_policy_revalidation=True,
+            )
+        ]
+    )
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_RaisingPolicyTwoPhase(),
+        recovery_engine=engine,
+        recovery_policy=RecoveryPolicy(max_attempts=2),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert "PolicyEngine.evaluate raised mid-loop" in out.result.failure_reason
+
+
+class _RaisingPolicyTwoPhase:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def evaluate(self, *_a, **_k):
+        self.calls += 1
+        # first call (pre-dispatch) allows; revalidation raises
+        if self.calls <= 1:
+            return PolicyDecision(status=PolicyStatus.ALLOW)
+        raise RuntimeError("revalidation boom")
+
+
+def test_adapter_crash_through_recovery_loop_real_engine() -> None:
+    # Uses the default real engine; crashing adapter yields a crash result.
+    bundle = _bundle()
+    adapter = _CrashAdapter()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(adapter),
+        policy_engine=_AllowPolicy(),
+    )
+    out = coord.execute(bundle, _runtime())
+    assert out.result.success is False
+    assert "Adapter raised unexpected exception" in out.result.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# _build_detail_refs error path
+# ---------------------------------------------------------------------------
+
+
+def test_build_detail_refs_none_capture() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+    assert coord._build_detail_refs(object(), _FakeRequest(), None) == []
+
+
+def test_build_detail_refs_builder_raises_returns_empty() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+
+    class _Builder:
+        def build_backend_detail_refs(self, request, capture):
+            raise RuntimeError("ref boom")
+
+    assert coord._build_detail_refs(_Builder(), _FakeRequest(), {"x": 1}) == []
+
+
+def test_build_detail_refs_non_builder_adapter_returns_empty() -> None:
+    bundle = _bundle()
+    coord = ExecutionCoordinator(
+        adapter_registry=_Registry(_RecordingAdapter(_success(bundle))),
+        policy_engine=_AllowPolicy(),
+    )
+    assert coord._build_detail_refs(object(), _FakeRequest(), {"x": 1}) == []

--- a/tests/unit/execution/test_usage_store_cov.py
+++ b/tests/unit/execution/test_usage_store_cov.py
@@ -1,0 +1,1328 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from operations_center.execution import usage_store as us_mod
+from operations_center.execution.usage_store import UsageStore, _check_disk_space, _get_lock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+NOW = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> UsageStore:
+    return UsageStore(path=tmp_path / "usage.json")
+
+
+def _ts(now: datetime, **delta) -> str:
+    return (now + timedelta(**delta)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# module-level helpers
+# ---------------------------------------------------------------------------
+def test_get_lock_caches_same_lock(tmp_path: Path) -> None:
+    p = tmp_path / "u.json"
+    a = _get_lock(p)
+    b = _get_lock(p)
+    assert a is b
+
+
+def test_check_disk_space_ok(tmp_path: Path) -> None:
+    # Plenty of free space normally -> no raise, returns None.
+    assert _check_disk_space(tmp_path / "u.json") is None
+
+
+def test_check_disk_space_oserror_swallowed(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    def boom(_p):
+        calls.append(_p)
+        raise OSError("nope")
+
+    monkeypatch.setattr(us_mod.shutil, "disk_usage", boom)
+    # Should not raise — can't check, so allow the write (returns None).
+    assert _check_disk_space(tmp_path / "u.json") is None
+    # The OSError path was actually exercised.
+    assert len(calls) == 1
+
+
+class _Usage:
+    def __init__(self, free_bytes: int) -> None:
+        self.free = free_bytes
+
+
+def test_check_disk_space_critical_raises(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(us_mod.shutil, "disk_usage", lambda _p: _Usage(10 * 1024 * 1024))
+    with pytest.raises(OSError, match="disk_space_critical"):
+        _check_disk_space(tmp_path / "u.json")
+
+
+def test_check_disk_space_warn_logs(monkeypatch, tmp_path: Path, caplog) -> None:
+    monkeypatch.setattr(us_mod.shutil, "disk_usage", lambda _p: _Usage(100 * 1024 * 1024))
+    with caplog.at_level("WARNING"):
+        _check_disk_space(tmp_path / "u.json")
+    assert any("disk_space_low" in r.getMessage() for r in caplog.records)
+
+
+def test_check_disk_space_dir_path(monkeypatch, tmp_path: Path) -> None:
+    # Cover the path.is_dir() branch (use the dir itself, not parent).
+    captured = {}
+
+    def fake(p):
+        captured["p"] = p
+        return _Usage(500 * 1024 * 1024)
+
+    monkeypatch.setattr(us_mod.shutil, "disk_usage", fake)
+    _check_disk_space(tmp_path)
+    assert captured["p"] == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# load / save
+# ---------------------------------------------------------------------------
+def test_init_default_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "d.json"))
+    s = UsageStore()
+    assert s.path == tmp_path / "d.json"
+
+
+def test_load_missing_returns_default(store: UsageStore) -> None:
+    data = store.load()
+    assert data["events"] == []
+    assert data["hourly_exec_count"] == 0
+    assert data["task_attempts"] == {}
+
+
+def test_load_existing(store: UsageStore) -> None:
+    store.path.write_text(json.dumps({"events": [], "marker": 1}), encoding="utf-8")
+    assert store.load()["marker"] == 1
+
+
+def test_save_writes_counts_and_prunes(store: UsageStore) -> None:
+    old = (NOW - timedelta(days=10)).isoformat()
+    data = {
+        "events": [
+            {"kind": "execution", "timestamp": NOW.isoformat()},
+            {"kind": "skip_budget", "timestamp": NOW.isoformat()},
+            {"kind": "skip_noop", "timestamp": NOW.isoformat()},
+            {"kind": "skip_cooldown", "timestamp": NOW.isoformat()},
+            {"kind": "retry_cap_block", "timestamp": NOW.isoformat()},
+            {"kind": "proposal_budget_suppressed", "timestamp": NOW.isoformat()},
+            {"kind": "execution", "timestamp": old},  # pruned
+        ]
+    }
+    store.save(data, now=NOW)
+    out = json.loads(store.path.read_text(encoding="utf-8"))
+    assert len(out["events"]) == 6  # old pruned
+    assert out["hourly_exec_count"] == 1
+    assert out["daily_exec_count"] == 1
+    assert out["skipped_due_to_budget"] == 1
+    assert out["skipped_due_to_noop"] == 1
+    assert out["skipped_due_to_cooldown"] == 1
+    assert out["blocked_due_to_retry_cap"] == 1
+    assert out["suppressed_due_to_proposal_budget"] == 1
+    assert out["updated_at"] == NOW.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# budget_decision
+# ---------------------------------------------------------------------------
+def test_budget_decision_allowed_empty(store: UsageStore) -> None:
+    assert store.budget_decision(now=NOW).allowed
+
+
+def test_budget_decision_hourly_exceeded(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_EXEC_PER_HOUR", "2")
+    s = UsageStore(path=store.path)
+    evs = [{"kind": "execution", "timestamp": _ts(NOW, minutes=-i)} for i in range(3)]
+    s.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = s.budget_decision(now=NOW)
+    assert not d.allowed and d.window == "hourly" and d.reason == "budget_exceeded"
+
+
+def test_budget_decision_daily_exceeded(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_EXEC_PER_HOUR", "100")
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_EXEC_PER_DAY", "2")
+    s = UsageStore(path=store.path)
+    evs = [{"kind": "execution", "timestamp": _ts(NOW, hours=-i - 2)} for i in range(3)]
+    s.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = s.budget_decision(now=NOW)
+    assert not d.allowed and d.window == "daily"
+
+
+def test_budget_decision_circuit_breaker_open(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_outcome", "succeeded": False, "timestamp": _ts(NOW, minutes=-i)}
+        for i in range(4)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.budget_decision(now=NOW)
+    assert not d.allowed and d.reason == "circuit_breaker_open"
+
+
+def test_budget_decision_circuit_breaker_stale_ignored(store: UsageStore) -> None:
+    # All failures older than staleness window -> aged out -> allowed.
+    evs = [
+        {"kind": "execution_outcome", "succeeded": False, "timestamp": _ts(NOW, hours=-5 - i)}
+        for i in range(4)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.budget_decision(now=NOW).allowed
+
+
+def test_budget_decision_circuit_breaker_mixed_versions_skipped(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "execution_outcome",
+            "succeeded": False,
+            "backend_version": str(v),
+            "timestamp": _ts(NOW, minutes=-i),
+        }
+        for i, v in enumerate([1, 1, 2, 2])
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    # Two versions in window -> skip CB -> allowed.
+    assert store.budget_decision(now=NOW).allowed
+
+
+def test_budget_decision_too_few_outcomes(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_outcome", "succeeded": False, "timestamp": _ts(NOW, minutes=-i)}
+        for i in range(2)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.budget_decision(now=NOW).allowed
+
+
+# ---------------------------------------------------------------------------
+# remaining_exec_capacity
+# ---------------------------------------------------------------------------
+def test_remaining_exec_capacity(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_EXEC_PER_HOUR", "10")
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_EXEC_PER_DAY", "50")
+    s = UsageStore(path=store.path)
+    evs = [{"kind": "execution", "timestamp": _ts(NOW, minutes=-1)} for _ in range(3)]
+    s.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert s.remaining_exec_capacity(now=NOW) == 7  # 10-3 hourly is the min
+
+
+# ---------------------------------------------------------------------------
+# retry_decision + helpers
+# ---------------------------------------------------------------------------
+def test_retry_decision_allowed(store: UsageStore) -> None:
+    d = store.retry_decision(task_id="t1", now=NOW)
+    assert d.allowed and d.attempts == 0
+
+
+def test_retry_decision_capped_recent(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_RETRIES_PER_TASK", "2")
+    s = UsageStore(path=store.path)
+    data = {
+        "task_attempts": {"t1": 2},
+        "events": [
+            {"kind": "execution", "task_id": "t1", "timestamp": _ts(NOW, minutes=-5)},
+        ],
+    }
+    s.path.write_text(json.dumps(data), encoding="utf-8")
+    d = s.retry_decision(task_id="t1", now=NOW)
+    assert not d.allowed and d.reason == "retry_cap_exceeded"
+
+
+def test_retry_decision_auto_reset_old(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_RETRIES_PER_TASK", "2")
+    s = UsageStore(path=store.path)
+    data = {
+        "task_attempts": {"t1": 2},
+        "last_task_signatures": {"executor:t1": "sig"},
+        "events": [
+            {"kind": "execution", "task_id": "t1", "timestamp": _ts(NOW, hours=-2)},
+        ],
+    }
+    s.path.write_text(json.dumps(data), encoding="utf-8")
+    d = s.retry_decision(task_id="t1", now=NOW)
+    assert d.allowed and d.attempts == 0
+    out = json.loads(s.path.read_text(encoding="utf-8"))
+    assert "t1" not in out["task_attempts"]
+    assert "executor:t1" not in out["last_task_signatures"]
+
+
+def test_retry_decision_no_last_attempt_resets(store: UsageStore, monkeypatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_MAX_RETRIES_PER_TASK", "2")
+    s = UsageStore(path=store.path)
+    s.path.write_text(json.dumps({"task_attempts": {"t1": 5}, "events": []}), encoding="utf-8")
+    d = s.retry_decision(task_id="t1", now=NOW)
+    assert d.allowed and d.attempts == 0
+
+
+def test_retry_decision_default_now(store: UsageStore) -> None:
+    # now=None branch -> uses datetime.now; attempts under cap.
+    d = store.retry_decision(task_id="z")
+    assert d.allowed
+
+
+def test_last_attempt_timestamp_non_list(store: UsageStore) -> None:
+    assert store._last_attempt_timestamp({"events": "bad"}, "t1") is None
+
+
+def test_last_attempt_timestamp_naive_tz(store: UsageStore) -> None:
+    naive = "2026-06-01T10:00:00"
+    data = {"events": [{"kind": "execution", "task_id": "t1", "timestamp": naive}]}
+    dt = store._last_attempt_timestamp(data, "t1")
+    assert dt is not None and dt.tzinfo is not None
+
+
+def test_last_attempt_timestamp_bad_value(store: UsageStore) -> None:
+    data = {
+        "events": [
+            "notadict",
+            {"kind": "execution", "task_id": "t1", "timestamp": "garbage"},
+            {"kind": "execution", "task_id": "t1"},  # no timestamp
+        ]
+    }
+    assert store._last_attempt_timestamp(data, "t1") is None
+
+
+# ---------------------------------------------------------------------------
+# noop_decision
+# ---------------------------------------------------------------------------
+def test_noop_decision_skip(store: UsageStore) -> None:
+    store.path.write_text(
+        json.dumps({"last_task_signatures": {"executor:t1": "sig"}}), encoding="utf-8"
+    )
+    d = store.noop_decision(role="executor", task_id="t1", signature="sig")
+    assert d.should_skip and d.reason == "no_op"
+
+
+def test_noop_decision_no_skip(store: UsageStore) -> None:
+    d = store.noop_decision(role="executor", task_id="t1", signature="sig")
+    assert not d.should_skip
+
+
+# ---------------------------------------------------------------------------
+# record_execution & outcome
+# ---------------------------------------------------------------------------
+def test_record_execution(store: UsageStore) -> None:
+    store.record_execution(
+        role="executor",
+        task_id="t1",
+        signature="s",
+        now=NOW,
+        repo_key="r1",
+        backend="team_executor",
+    )
+    out = store.load()
+    assert out["task_attempts"]["t1"] == 1
+    assert out["last_task_signatures"]["executor:t1"] == "s"
+    ev = out["events"][-1]
+    assert ev["repo_key"] == "r1" and ev["backend"] == "team_executor"
+
+
+def test_record_execution_minimal(store: UsageStore) -> None:
+    store.record_execution(role="executor", task_id="t1", signature="s", now=NOW)
+    ev = store.load()["events"][-1]
+    assert "repo_key" not in ev and "backend" not in ev
+
+
+def test_record_execution_outcome_full(store: UsageStore) -> None:
+    store.record_execution_outcome(
+        task_id="t1", role="r", succeeded=True, now=NOW, backend="b", backend_version="1.0"
+    )
+    ev = store.load()["events"][-1]
+    assert ev["succeeded"] and ev["backend"] == "b" and ev["backend_version"] == "1.0"
+
+
+def test_record_execution_outcome_minimal(store: UsageStore) -> None:
+    store.record_execution_outcome(task_id="t1", role="r", succeeded=False, now=NOW)
+    ev = store.load()["events"][-1]
+    assert "backend" not in ev and "backend_version" not in ev
+
+
+# ---------------------------------------------------------------------------
+# misc record_* helpers
+# ---------------------------------------------------------------------------
+def test_record_quality_warning(store: UsageStore) -> None:
+    store.record_quality_warning(
+        task_id="t1", repo_key="r", suppression_counts={"noqa": 3}, now=NOW
+    )
+    assert store.load()["events"][-1]["suppression_counts"] == {"noqa": 3}
+
+
+def test_record_scope_violation_caps(store: UsageStore) -> None:
+    files = [f"f{i}" for i in range(15)]
+    store.record_scope_violation(task_id="t1", repo_key="r", violated_files=files, now=NOW)
+    assert len(store.load()["events"][-1]["violated_files"]) == 10
+
+
+def test_record_quota_event(store: UsageStore) -> None:
+    store.record_quota_event(task_id="t1", role="r", backend="b", now=NOW)
+    assert store.load()["events"][-1]["kind"] == "quota_event"
+
+
+# ---------------------------------------------------------------------------
+# worker backend cooldowns
+# ---------------------------------------------------------------------------
+def test_record_worker_backend_cooldown_and_until(store: UsageStore) -> None:
+    reset = NOW + timedelta(hours=5)
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code", reset_at=reset, now=NOW, limit_kind="session_5h"
+    )
+    got = store.worker_backend_cooldown_until("claude_code", now=NOW)
+    assert got == reset
+
+
+def test_worker_backend_cooldown_until_none(store: UsageStore) -> None:
+    assert store.worker_backend_cooldown_until("claude_code", now=NOW) is None
+
+
+def test_record_cooldown_coalesces(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=1),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+    cooldowns = [e for e in store.load()["events"] if e.get("kind") == "worker_backend_cooldown"]
+    assert len(cooldowns) == 1
+    assert cooldowns[0]["reset_at"] == (NOW + timedelta(hours=2)).isoformat()
+
+
+def test_worker_backend_cooldown_until_skips_invalid(store: UsageStore) -> None:
+    evs = [
+        {"kind": "worker_backend_cooldown", "worker_backend": "claude_code", "reset_at": 123},
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": "garbage",
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "other",
+            "reset_at": _ts(NOW, hours=5),
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": _ts(NOW, hours=-1),  # past
+            "timestamp": NOW.isoformat(),
+        },
+        {"kind": "execution", "timestamp": NOW.isoformat()},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.worker_backend_cooldown_until("claude_code", now=NOW) is None
+
+
+def test_worker_backend_cooldown_details(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=3),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="opus",
+    )
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=1),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+    details = store.worker_backend_cooldown_details("claude_code", now=NOW)
+    assert len(details) == 2
+    # sorted soonest-first -> sonnet first
+    assert details[0]["model"] == "sonnet"
+    assert details[0]["seconds_remaining"] > 0
+
+
+def test_worker_backend_cooldown_details_invalid_reset(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": 999,
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": "bad",
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": _ts(NOW, hours=-1),
+            "timestamp": NOW.isoformat(),
+        },
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.worker_backend_cooldown_details("claude_code", now=NOW) == []
+
+
+def test_worker_backend_blocked_until_account_wide(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=5),
+        now=NOW,
+        limit_kind="session_5h",
+    )
+    assert store.worker_backend_blocked_until("claude_code", now=NOW) == NOW + timedelta(hours=5)
+
+
+def test_worker_backend_blocked_until_single_model_not_blocked(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=5),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+    assert store.worker_backend_blocked_until("claude_code", now=NOW) is None
+
+
+def test_worker_backend_blocked_until_all_models(store: UsageStore) -> None:
+    for m, h in (("sonnet", 1), ("opus", 2), ("haiku", 3)):
+        store.record_worker_backend_cooldown(
+            worker_backend="claude_code",
+            reset_at=NOW + timedelta(hours=h),
+            now=NOW,
+            limit_kind="model_weekly",
+            model=m,
+        )
+    # all 3 models blocked -> soonest reset
+    assert store.worker_backend_blocked_until("claude_code", now=NOW) == NOW + timedelta(hours=1)
+
+
+def test_worker_backend_blocked_until_invalid_and_unknown(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": 1,
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": "bad",
+            "timestamp": NOW.isoformat(),
+        },
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "unknown_be",
+            "reset_at": _ts(NOW, hours=5),
+            "limit_kind": "model_weekly",
+            "model": "x",
+            "timestamp": NOW.isoformat(),
+        },
+        {"kind": "other", "timestamp": NOW.isoformat()},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    # unknown backend not in WORKER_BACKEND_MODELS -> None
+    assert store.worker_backend_blocked_until("unknown_be", now=NOW) is None
+
+
+def test_current_worker_backend_cooldowns(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="codex_cli",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="codex",
+    )
+    snap = store.current_worker_backend_cooldowns(now=NOW)
+    assert set(snap) == {"claude_code", "codex_cli"}
+    # codex_cli only runs "codex" -> all models blocked
+    assert snap["codex_cli"]["cooling_down"] is True
+    assert snap["codex_cli"]["seconds_remaining"] > 0
+    assert snap["claude_code"]["cooling_down"] is False
+    assert snap["claude_code"]["reset_at"] is None
+
+
+def test_clear_worker_backend_cooldown_model_weekly(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="sonnet",
+    )
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="model_weekly",
+        model="opus",
+    )
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model="sonnet", now=NOW
+    )
+    assert removed == 1
+    # opus preserved, audit event appended
+    kinds = [e["kind"] for e in store.load()["events"]]
+    assert "worker_backend_cooldown_cleared" in kinds
+
+
+def test_clear_worker_backend_cooldown_account_wide(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="session_5h",
+    )
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model=None, now=NOW, include_account_wide=True
+    )
+    assert removed == 1
+
+
+def test_clear_worker_backend_cooldown_account_wide_preserved(store: UsageStore) -> None:
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=NOW + timedelta(hours=2),
+        now=NOW,
+        limit_kind="session_5h",
+    )
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model=None, now=NOW, include_account_wide=False
+    )
+    assert removed == 0  # account-wide not dropped
+
+
+def test_clear_worker_backend_cooldown_nothing(store: UsageStore) -> None:
+    removed = store.clear_worker_backend_cooldown(
+        worker_backend="claude_code", model="sonnet", now=NOW
+    )
+    assert removed == 0
+    # save still persisted the (empty) data
+    assert store.path.exists()
+
+
+def test_is_active_cooldown_for_branches(store: UsageStore) -> None:
+    assert not store._is_active_cooldown_for({"kind": "other"}, "claude_code", now=NOW)
+    assert not store._is_active_cooldown_for(
+        {"kind": "worker_backend_cooldown", "worker_backend": "x"}, "claude_code", now=NOW
+    )
+    assert not store._is_active_cooldown_for(
+        {"kind": "worker_backend_cooldown", "worker_backend": "claude_code", "reset_at": 1},
+        "claude_code",
+        now=NOW,
+    )
+    assert not store._is_active_cooldown_for(
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": "bad",
+        },
+        "claude_code",
+        now=NOW,
+    )
+    assert store._is_active_cooldown_for(
+        {
+            "kind": "worker_backend_cooldown",
+            "worker_backend": "claude_code",
+            "reset_at": _ts(NOW, hours=5),
+        },
+        "claude_code",
+        now=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# per-repo / per-backend budgets
+# ---------------------------------------------------------------------------
+def test_budget_decision_for_repo(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "repo_key": "r1", "timestamp": _ts(NOW, hours=-1)},
+        {"kind": "execution", "repo_key": "r1", "timestamp": _ts(NOW, hours=-2)},
+        {"kind": "execution", "repo_key": "r2", "timestamp": _ts(NOW, hours=-1)},
+        {"kind": "execution", "repo_key": "r1", "timestamp": "bad"},  # skipped
+        {"kind": "skip_budget", "repo_key": "r1", "timestamp": _ts(NOW, hours=-1)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.budget_decision_for_repo("r1", 2, now=NOW)
+    assert not d.allowed and d.reason == "repo_budget_exceeded"
+    assert store.budget_decision_for_repo("r1", 5, now=NOW).allowed
+
+
+def test_budget_decision_for_backend_no_backend(store: UsageStore) -> None:
+    assert store.budget_decision_for_backend("", now=NOW).allowed
+
+
+def test_budget_decision_for_backend_no_limits(store: UsageStore) -> None:
+    assert store.budget_decision_for_backend("b", now=NOW).allowed
+
+
+def test_budget_decision_for_backend_hourly(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "backend": "b", "timestamp": _ts(NOW, minutes=-1)},
+        {"kind": "execution", "backend": "b", "timestamp": _ts(NOW, minutes=-2)},
+        {"kind": "execution", "backend": "other", "timestamp": _ts(NOW, minutes=-1)},
+        {"kind": "execution", "backend": "b", "timestamp": "bad"},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.budget_decision_for_backend("b", max_per_hour=2, now=NOW)
+    assert not d.allowed and d.window == "hourly"
+
+
+def test_budget_decision_for_backend_daily(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "backend": "b", "timestamp": _ts(NOW, hours=-2)},
+        {"kind": "execution", "backend": "b", "timestamp": _ts(NOW, hours=-3)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.budget_decision_for_backend("b", max_per_hour=10, max_per_day=2, now=NOW)
+    assert not d.allowed and d.window == "daily"
+
+
+def test_budget_decision_for_backend_allowed(store: UsageStore) -> None:
+    assert store.budget_decision_for_backend("b", max_per_hour=10, max_per_day=10, now=NOW).allowed
+
+
+# ---------------------------------------------------------------------------
+# concurrency
+# ---------------------------------------------------------------------------
+def test_concurrent_runs_for_backend(store: UsageStore) -> None:
+    store.record_execution_started(task_id="t1", backend="b", now=NOW)
+    store.record_execution_started(task_id="t2", backend="b", now=NOW)
+    store.record_execution_finished(task_id="t1", backend="b", now=NOW)
+    assert store.concurrent_runs_for_backend("b", now=NOW) == 1
+
+
+def test_concurrent_runs_filters(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_started", "task_id": "t1", "backend": "b", "timestamp": "bad"},
+        {
+            "kind": "execution_started",
+            "task_id": "old",
+            "backend": "b",
+            "timestamp": _ts(NOW, hours=-30),
+        },
+        {"kind": "execution_started", "backend": "b", "timestamp": NOW.isoformat()},  # no tid
+        {
+            "kind": "execution_started",
+            "task_id": "t9",
+            "backend": "other",
+            "timestamp": NOW.isoformat(),
+        },
+        {"kind": "execution_started", "task_id": 123, "backend": "b", "timestamp": NOW.isoformat()},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.concurrent_runs_for_backend("b", now=NOW) == 0
+
+
+def test_total_concurrent_runs(store: UsageStore) -> None:
+    store.record_execution_started(task_id="t1", backend="b1", now=NOW)
+    store.record_execution_started(task_id="t1", backend="b2", now=NOW)
+    store.record_execution_finished(task_id="t1", backend="b1", now=NOW)
+    assert store.total_concurrent_runs(now=NOW) == 1
+
+
+def test_total_concurrent_runs_filters(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_started", "task_id": "t1", "timestamp": "bad"},
+        {"kind": "execution_started", "task_id": "old", "timestamp": _ts(NOW, hours=-30)},
+        {"kind": "execution_started", "task_id": 5, "timestamp": NOW.isoformat()},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.total_concurrent_runs(now=NOW) == 0
+
+
+def test_global_concurrency_decision(store: UsageStore) -> None:
+    assert store.global_concurrency_decision(max_concurrent=None, now=NOW).allowed
+    store.record_execution_started(task_id="t1", backend="b", now=NOW)
+    store.record_execution_started(task_id="t2", backend="b", now=NOW)
+    d = store.global_concurrency_decision(max_concurrent=2, now=NOW)
+    assert not d.allowed and d.reason == "global_concurrency_exceeded"
+    assert store.global_concurrency_decision(max_concurrent=5, now=NOW).allowed
+
+
+def test_concurrency_decision_for_backend(store: UsageStore) -> None:
+    assert store.concurrency_decision_for_backend("", max_concurrent=1, now=NOW).allowed
+    assert store.concurrency_decision_for_backend("b", max_concurrent=None, now=NOW).allowed
+    store.record_execution_started(task_id="t1", backend="b", now=NOW)
+    d = store.concurrency_decision_for_backend("b", max_concurrent=1, now=NOW)
+    assert not d.allowed and d.reason == "backend_concurrency_exceeded"
+    assert store.concurrency_decision_for_backend("b", max_concurrent=5, now=NOW).allowed
+
+
+# ---------------------------------------------------------------------------
+# rate / memory decisions
+# ---------------------------------------------------------------------------
+def test_global_rate_decision(store: UsageStore) -> None:
+    assert store.global_rate_decision(max_per_hour=None, max_per_day=None, now=NOW).allowed
+    evs = [
+        {"kind": "execution", "timestamp": _ts(NOW, minutes=-1)},
+        {"kind": "execution", "timestamp": _ts(NOW, minutes=-2)},
+        {"kind": "execution", "timestamp": "bad"},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.global_rate_decision(max_per_hour=2, max_per_day=10, now=NOW)
+    assert not d.allowed and d.window == "hourly"
+
+
+def test_global_rate_decision_daily(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "timestamp": _ts(NOW, hours=-2)},
+        {"kind": "execution", "timestamp": _ts(NOW, hours=-3)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    d = store.global_rate_decision(max_per_hour=10, max_per_day=2, now=NOW)
+    assert not d.allowed and d.window == "daily"
+    assert store.global_rate_decision(max_per_hour=10, max_per_day=10, now=NOW).allowed
+
+
+def test_available_memory_mb_reads(monkeypatch, tmp_path: Path) -> None:
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       1000 kB\nMemAvailable:  2048000 kB\nSwapFree:      1024000 kB\n"
+    )
+    real_open = open
+
+    def fake_open(path, *a, **k):
+        if path == "/proc/meminfo":
+            return real_open(meminfo, *a, **k)
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    # 2048000//1024 + 1024000//1024 = 2000 + 1000
+    assert UsageStore.available_memory_mb() == 3000
+
+
+def test_available_memory_mb_bad_values(monkeypatch, tmp_path: Path) -> None:
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable:  notanumber kB\nSwapFree:  alsobad kB\nMemAvailable:\n")
+    real_open = open
+
+    def fake_open(path, *a, **k):
+        if path == "/proc/meminfo":
+            return real_open(meminfo, *a, **k)
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert UsageStore.available_memory_mb() == 0
+
+
+def test_available_memory_mb_oserror(monkeypatch) -> None:
+    def boom(*a, **k):
+        raise OSError("no /proc")
+
+    monkeypatch.setattr("builtins.open", boom)
+    assert UsageStore.available_memory_mb() == 0
+
+
+def test_global_memory_decision(store: UsageStore, monkeypatch) -> None:
+    assert store.global_memory_decision(min_available_memory_mb=None).allowed
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 0))
+    assert store.global_memory_decision(min_available_memory_mb=100).allowed
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 50))
+    d = store.global_memory_decision(min_available_memory_mb=100)
+    assert not d.allowed and d.reason == "global_memory_insufficient"
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 500))
+    assert store.global_memory_decision(min_available_memory_mb=100).allowed
+
+
+def test_memory_decision_for_backend(store: UsageStore, monkeypatch) -> None:
+    assert store.memory_decision_for_backend("", min_available_memory_mb=1, now=NOW).allowed
+    assert store.memory_decision_for_backend("b", min_available_memory_mb=None, now=NOW).allowed
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 0))
+    assert store.memory_decision_for_backend("b", min_available_memory_mb=100, now=NOW).allowed
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 50))
+    d = store.memory_decision_for_backend("b", min_available_memory_mb=100, now=NOW)
+    assert not d.allowed and d.reason == "backend_memory_insufficient"
+    monkeypatch.setattr(UsageStore, "available_memory_mb", staticmethod(lambda: 500))
+    assert store.memory_decision_for_backend("b", min_available_memory_mb=100, now=NOW).allowed
+
+
+# ---------------------------------------------------------------------------
+# failure rate / durations
+# ---------------------------------------------------------------------------
+def test_check_failure_rate_degradation_low_samples(store: UsageStore) -> None:
+    assert store.check_failure_rate_degradation(now=NOW) is None
+
+
+def test_check_failure_rate_degradation_degraded(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_outcome", "succeeded": i < 1, "timestamp": _ts(NOW, minutes=-i)}
+        for i in range(6)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    rate = store.check_failure_rate_degradation(now=NOW)
+    assert rate is not None and rate < 0.6
+
+
+def test_check_failure_rate_degradation_healthy(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution_outcome", "succeeded": True, "timestamp": _ts(NOW, minutes=-i)}
+        for i in range(6)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.check_failure_rate_degradation(now=NOW) is None
+
+
+def test_record_and_median_duration(store: UsageStore) -> None:
+    for d in (10.0, 30.0, 20.0):
+        store.record_execution_duration(task_id="t", role="exec", duration_seconds=d, now=NOW)
+    assert store.median_execution_duration("exec", now=NOW) == 20.0
+
+
+def test_median_duration_even(store: UsageStore) -> None:
+    for d in (10.0, 20.0, 30.0, 40.0):
+        store.record_execution_duration(task_id="t", role="exec", duration_seconds=d, now=NOW)
+    assert store.median_execution_duration("exec", now=NOW) == 25.0
+
+
+def test_median_duration_too_few(store: UsageStore) -> None:
+    store.record_execution_duration(task_id="t", role="exec", duration_seconds=10.0, now=NOW)
+    assert store.median_execution_duration("exec", now=NOW) is None
+
+
+def test_median_duration_default_now(store: UsageStore) -> None:
+    now = datetime.now(UTC)
+    for d in (10.0, 20.0, 30.0):
+        store.record_execution_duration(task_id="t", role="exec", duration_seconds=d, now=now)
+    assert store.median_execution_duration("exec") == 20.0
+
+
+# ---------------------------------------------------------------------------
+# audit_export
+# ---------------------------------------------------------------------------
+def test_audit_export(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "execution_duration",
+            "task_id": "t1",
+            "duration_seconds": 12.0,
+            "timestamp": _ts(NOW, minutes=-10),
+        },
+        {
+            "kind": "execution_outcome",
+            "task_id": "t1",
+            "role": "exec",
+            "succeeded": True,
+            "timestamp": _ts(NOW, minutes=-9),
+        },
+        {
+            "kind": "execution_outcome",
+            "task_id": "t2",
+            "succeeded": False,
+            "timestamp": _ts(NOW, minutes=-8),
+        },
+        {"kind": "quota_event", "task_id": "t3", "backend": "b", "timestamp": _ts(NOW, minutes=-7)},
+        {
+            "kind": "executor_quality_warning",
+            "task_id": "t4",
+            "repo_key": "r",
+            "suppression_counts": {"noqa": 1},
+            "timestamp": _ts(NOW, minutes=-6),
+        },
+        {
+            "kind": "scope_violation",
+            "task_id": "t5",
+            "repo_key": "r",
+            "violated_files": ["a"],
+            "timestamp": _ts(NOW, minutes=-5),
+        },
+        {
+            "kind": "escalation_sent",
+            "classification": "stuck",
+            "task_ids": ["t6"],
+            "timestamp": _ts(NOW, minutes=-4),
+        },
+        {"kind": "execution_outcome", "task_id": "old", "timestamp": _ts(NOW, days=-30)},
+        {"kind": "execution_outcome", "task_id": "tbad", "timestamp": "bad"},
+        {"kind": "noise", "timestamp": _ts(NOW, minutes=-1)},  # unhandled kind
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    rows = store.audit_export(now=NOW)
+    outcomes = {r["outcome"] for r in rows}
+    assert {
+        "succeeded",
+        "failed",
+        "quota_exhausted",
+        "quality_warning",
+        "scope_violation",
+        "escalated",
+    } <= outcomes
+    succ = next(r for r in rows if r["outcome"] == "succeeded")
+    assert succ["duration_seconds"] == 12.0
+    # sorted oldest first
+    assert rows == sorted(rows, key=lambda r: r["timestamp"])
+
+
+def test_audit_export_default_now(store: UsageStore) -> None:
+    assert store.audit_export() == []
+
+
+# ---------------------------------------------------------------------------
+# record_skip
+# ---------------------------------------------------------------------------
+def test_record_skip_noop_stores_signature(store: UsageStore) -> None:
+    store.record_skip(
+        role="exec",
+        task_id="t1",
+        signature="sig",
+        reason="no_op",
+        detail="d",
+        now=NOW,
+    )
+    out = store.load()
+    assert out["last_task_signatures"]["exec:t1"] == "sig"
+    assert out["events"][-1]["kind"] == "skip_noop"
+
+
+def test_record_skip_budget(store: UsageStore) -> None:
+    store.record_skip(
+        role="exec", task_id="t1", signature="s", reason="budget", detail=None, now=NOW
+    )
+    out = store.load()
+    assert "exec:t1" not in out.get("last_task_signatures", {})
+    assert out["events"][-1]["kind"] == "skip_budget"
+
+
+def test_record_skip_cooldown(store: UsageStore) -> None:
+    store.record_skip(
+        role="exec",
+        task_id="t1",
+        signature="s",
+        reason="cooldown_active",
+        detail=None,
+        now=NOW,
+        evidence={"x": 1},
+    )
+    ev = store.load()["events"][-1]
+    assert ev["kind"] == "skip_cooldown" and ev["evidence"] == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# retry cap / proposal cycle / satiation
+# ---------------------------------------------------------------------------
+def test_record_retry_cap(store: UsageStore) -> None:
+    store.record_retry_cap(role="exec", task_id="t1", now=NOW, attempts=3, limit=3)
+    ev = store.load()["events"][-1]
+    assert ev["kind"] == "retry_cap_block" and ev["attempts"] == 3
+
+
+def test_proposal_cycle_and_satiation_true(store: UsageStore) -> None:
+    for _ in range(5):
+        store.record_proposal_cycle(created=0, deduped=9, skipped=1, now=NOW)
+    assert store.is_proposal_satiated(now=NOW) is True
+
+
+def test_satiation_false_too_few(store: UsageStore) -> None:
+    store.record_proposal_cycle(created=0, deduped=1, skipped=0, now=NOW)
+    assert store.is_proposal_satiated(now=NOW) is False
+
+
+def test_satiation_false_created(store: UsageStore) -> None:
+    for _ in range(5):
+        store.record_proposal_cycle(created=2, deduped=1, skipped=0, now=NOW)
+    assert store.is_proposal_satiated(now=NOW) is False
+
+
+def test_satiation_false_zero_total(store: UsageStore) -> None:
+    for _ in range(5):
+        store.record_proposal_cycle(created=0, deduped=0, skipped=0, now=NOW)
+    assert store.is_proposal_satiated(now=NOW) is False
+
+
+def test_satiation_false_below_ratio(store: UsageStore) -> None:
+    for _ in range(5):
+        store.record_proposal_cycle(created=0, deduped=1, skipped=0, now=NOW)
+    # total_created 0, ratio 1.0 >= 0.9 -> True; force below with high threshold
+    assert store.is_proposal_satiated(now=NOW, dedup_ratio_threshold=2.0) is False
+
+
+def test_reset_satiation_window(store: UsageStore) -> None:
+    store.record_proposal_cycle(created=0, deduped=1, skipped=0, now=NOW)
+    store.record_execution(role="r", task_id="t", signature="s", now=NOW)
+    store.reset_satiation_window(now=NOW)
+    kinds = [e["kind"] for e in store.load()["events"]]
+    assert "proposal_cycle" not in kinds
+    assert "execution" in kinds
+
+
+# ---------------------------------------------------------------------------
+# proposal outcome / validation flaky
+# ---------------------------------------------------------------------------
+def test_proposal_success_rate(store: UsageStore) -> None:
+    for ok in (True, True, False, True):
+        store.record_proposal_outcome(category="c", succeeded=ok, now=NOW)
+    assert store.proposal_success_rate("c", now=NOW) == 0.75
+
+
+def test_proposal_success_rate_neutral(store: UsageStore) -> None:
+    store.record_proposal_outcome(category="c", succeeded=True, now=NOW)
+    assert store.proposal_success_rate("c", now=NOW) == 0.5
+
+
+def test_proposal_success_rate_default_now(store: UsageStore) -> None:
+    now = datetime.now(UTC)
+    for ok in (True, True, True):
+        store.record_proposal_outcome(category="c", succeeded=ok, now=now)
+    assert store.proposal_success_rate("c") == 1.0
+
+
+def test_is_command_flaky(store: UsageStore) -> None:
+    now = datetime.now(UTC)
+    for i in range(10):
+        store.record_validation_outcome(command="pytest", passed=(i % 2 == 0), now=now)
+    assert store.is_command_flaky("pytest", now=now) is True
+
+
+def test_is_command_flaky_too_few(store: UsageStore) -> None:
+    store.record_validation_outcome(command="pytest", passed=False, now=NOW)
+    assert store.is_command_flaky("pytest", now=NOW) is False
+
+
+def test_is_command_flaky_default_now(store: UsageStore) -> None:
+    now = datetime.now(UTC)
+    for _ in range(10):
+        store.record_validation_outcome(command="x", passed=True, now=now)
+    assert store.is_command_flaky("x") is False
+
+
+# ---------------------------------------------------------------------------
+# escalation
+# ---------------------------------------------------------------------------
+def test_should_escalate_fires(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "blocked_triage",
+            "task_id": f"t{i}",
+            "classification": "stuck",
+            "timestamp": _ts(NOW, minutes=-i),
+        }
+        for i in range(3)
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    fire, ids = store.should_escalate(
+        classification="stuck", threshold=3, cooldown_seconds=3600, now=NOW
+    )
+    assert fire and len(ids) == 3
+
+
+def test_should_escalate_cooldown_blocks(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "escalation_sent",
+            "classification": "stuck",
+            "timestamp": _ts(NOW, minutes=-1),
+        },
+        {
+            "kind": "blocked_triage",
+            "task_id": "t1",
+            "classification": "stuck",
+            "timestamp": _ts(NOW, minutes=-2),
+        },
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    fire, ids = store.should_escalate(
+        classification="stuck", threshold=1, cooldown_seconds=3600, now=NOW
+    )
+    assert not fire and ids == []
+
+
+def test_should_escalate_below_threshold(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "blocked_triage",
+            "task_id": "t1",
+            "classification": "stuck",
+            "timestamp": _ts(NOW, minutes=-1),
+        },
+        {  # empty task_id -> not appended
+            "kind": "blocked_triage",
+            "task_id": "",
+            "classification": "stuck",
+            "timestamp": _ts(NOW, minutes=-3),
+        },
+        {
+            "kind": "blocked_triage",
+            "task_id": "tbad",
+            "classification": "stuck",
+            "timestamp": "garbage",
+        },
+        {
+            "kind": "escalation_sent",
+            "classification": "stuck",
+            "timestamp": "garbage",
+        },
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    fire, ids = store.should_escalate(
+        classification="stuck", threshold=5, cooldown_seconds=3600, now=NOW
+    )
+    assert not fire
+
+
+def test_consecutive_blocks_for_task(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "execution_outcome",
+            "task_id": "t1",
+            "succeeded": True,
+            "timestamp": _ts(NOW, minutes=-5),
+        },
+        {"kind": "blocked_triage", "task_id": "t1", "timestamp": _ts(NOW, minutes=-4)},
+        {"kind": "blocked_triage", "task_id": "other", "timestamp": _ts(NOW, minutes=-3)},
+        {"kind": "blocked_triage", "task_id": "t1", "timestamp": _ts(NOW, minutes=-2)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.consecutive_blocks_for_task("t1", now=NOW) == 2
+
+
+def test_consecutive_blocks_stops_at_success(store: UsageStore) -> None:
+    evs = [
+        {"kind": "blocked_triage", "task_id": "t1", "timestamp": _ts(NOW, minutes=-5)},
+        {
+            "kind": "execution_outcome",
+            "task_id": "t1",
+            "succeeded": True,
+            "timestamp": _ts(NOW, minutes=-4),
+        },
+        {"kind": "blocked_triage", "task_id": "t1", "timestamp": _ts(NOW, minutes=-3)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    assert store.consecutive_blocks_for_task("t1", now=NOW) == 1
+
+
+def test_record_blocked_triage(store: UsageStore) -> None:
+    store.record_blocked_triage(task_id="t1", classification="stuck", now=NOW)
+    assert store.load()["events"][-1]["classification"] == "stuck"
+
+
+def test_record_escalation(store: UsageStore) -> None:
+    store.record_escalation(classification="stuck", task_ids=["t1"], now=NOW)
+    assert store.load()["events"][-1]["task_ids"] == ["t1"]
+
+
+# ---------------------------------------------------------------------------
+# cost / spend
+# ---------------------------------------------------------------------------
+def test_record_cost_and_spend_report(store: UsageStore) -> None:
+    store.record_execution_cost(task_id="t1", repo_key="r1", estimated_usd=1.5, now=NOW)
+    store.record_execution_cost(task_id="t2", repo_key="r1", estimated_usd=0.5, now=NOW)
+    rep = store.get_spend_report(now=NOW)
+    assert rep["total_executions"] == 2
+    assert rep["total_estimated_usd"] == 2.0
+    assert rep["per_repo"]["r1"]["executions"] == 2
+
+
+def test_spend_report_filters(store: UsageStore) -> None:
+    evs = [
+        {
+            "kind": "execution_cost",
+            "repo_key": None,
+            "estimated_usd": None,
+            "timestamp": _ts(NOW, hours=-1),
+        },
+        {"kind": "execution_cost", "repo_key": "r", "estimated_usd": 1.0, "timestamp": "bad"},
+        {
+            "kind": "execution_cost",
+            "repo_key": "r",
+            "estimated_usd": 1.0,
+            "timestamp": _ts(NOW, hours=-30),
+        },
+        {"kind": "other", "timestamp": _ts(NOW, hours=-1)},
+    ]
+    store.path.write_text(json.dumps({"events": evs}), encoding="utf-8")
+    rep = store.get_spend_report(window_days=1, now=NOW)
+    assert rep["total_executions"] == 1
+    assert rep["per_repo"]["unknown"]["estimated_usd"] == 0.0
+
+
+def test_spend_report_default_now(store: UsageStore) -> None:
+    rep = store.get_spend_report()
+    assert rep["total_executions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# proposal budget suppression / artifacts
+# ---------------------------------------------------------------------------
+def test_record_proposal_budget_suppression(store: UsageStore) -> None:
+    store.record_proposal_budget_suppression(reason="cap", now=NOW, evidence={"k": 1})
+    assert store.load()["events"][-1]["kind"] == "proposal_budget_suppressed"
+
+
+def test_record_and_get_task_artifact(store: UsageStore) -> None:
+    store.record_task_artifact(task_id="t1", artifact={"outcome_status": "ok"}, now=NOW)
+    art = store.get_task_artifact("t1")
+    assert art["outcome_status"] == "ok" and "recorded_at" in art
+
+
+def test_get_task_artifact_missing(store: UsageStore) -> None:
+    assert store.get_task_artifact("nope") is None
+
+
+def test_get_task_artifact_non_dict(store: UsageStore) -> None:
+    store.path.write_text(json.dumps({"task_artifacts": {"t1": "notadict"}}), encoding="utf-8")
+    assert store.get_task_artifact("t1") is None
+
+
+# ---------------------------------------------------------------------------
+# static helpers
+# ---------------------------------------------------------------------------
+def test_issue_signature_dict_state(store: UsageStore) -> None:
+    issue = {
+        "id": "i1",
+        "state": {"name": "Open"},
+        "updated_at": "2026-01-01",
+        "description_html": "<p>hi</p>",
+    }
+    sig = UsageStore.issue_signature(issue)
+    assert sig == "i1|Open|2026-01-01|<p>hi</p>"
+
+
+def test_issue_signature_str_state_fallbacks(store: UsageStore) -> None:
+    issue = {"id": "i2", "state": "Closed", "updated": "u", "description": "desc"}
+    assert UsageStore.issue_signature(issue) == "i2|Closed|u|desc"
+
+
+def test_issue_signature_description_stripped(store: UsageStore) -> None:
+    issue = {"id": "i3", "state": None, "description_stripped": "stripped"}
+    assert UsageStore.issue_signature(issue) == "i3|||stripped"
+
+
+def test_exec_count_bad_timestamp(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "timestamp": "bad"},
+        {"kind": "execution", "timestamp": NOW.isoformat()},
+        {"kind": "skip_budget", "timestamp": NOW.isoformat()},
+    ]
+    assert UsageStore._exec_count(evs, since=NOW - timedelta(hours=1)) == 1
+
+
+def test_prune_events_caps_and_drops(store: UsageStore) -> None:
+    evs = [{"kind": "execution", "timestamp": "bad"}]
+    evs += [{"kind": "execution", "timestamp": _ts(NOW, minutes=-i)} for i in range(1100)]
+    out = UsageStore._prune_events(evs, now=NOW)
+    assert len(out) == 1000  # capped, bad dropped
+
+
+def test_prune_events_drops_old(store: UsageStore) -> None:
+    evs = [
+        {"kind": "execution", "timestamp": _ts(NOW, days=-10)},
+        {"kind": "execution", "timestamp": NOW.isoformat()},
+    ]
+    out = UsageStore._prune_events(evs, now=NOW)
+    assert len(out) == 1

--- a/tests/unit/execution/test_validation_cov.py
+++ b/tests/unit/execution/test_validation_cov.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from operations_center.execution.validation import (
+    EnvironmentCheck,
+    ImproveTriageResult,
+    _check_execution_environment,
+    _collect_open_pr_files,
+    _has_conflict_with_active_task,
+    build_improve_triage_result,
+)
+
+
+# ── _check_execution_environment ─────────────────────────────────────────────
+
+
+def test_check_env_missing_workspace(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    res = _check_execution_environment(missing)
+    assert isinstance(res, EnvironmentCheck)
+    assert res.ok is False
+    assert res.missing == ("workspace_path",)
+    assert res.notes == ()
+
+
+def test_check_env_no_git_and_empty(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = _check_execution_environment(ws)
+    assert res.ok is False
+    assert ".git" in res.missing
+    assert "workspace_is_empty" in res.notes
+
+
+def test_check_env_happy_path(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    (ws / "README.md").write_text("hi")
+    res = _check_execution_environment(ws, required_files=("README.md",))
+    assert res.ok is True
+    assert res.missing == ()
+    assert res.notes == ()
+
+
+def test_check_env_missing_required_file(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    res = _check_execution_environment(ws, required_files=("pyproject.toml",))
+    assert res.ok is False
+    assert "pyproject.toml" in res.missing
+    # .git exists so not flagged; workspace not empty so no note
+    assert ".git" not in res.missing
+    assert res.notes == ()
+
+
+def test_check_env_accepts_string_path(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".git").mkdir()
+    res = _check_execution_environment(str(ws))
+    assert res.ok is True
+
+
+def test_check_env_git_present_but_empty_dir_note(tmp_path):
+    # .git present means not empty, so the empty-note branch needs a dir with
+    # no .git. Verify empty-note appears alongside missing .git.
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = _check_execution_environment(ws)
+    assert res.ok is False
+    assert res.missing == (".git",)
+    assert res.notes == ("workspace_is_empty",)
+
+
+# ── _collect_open_pr_files ───────────────────────────────────────────────────
+
+
+def test_collect_pr_files_happy():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"number": 1}, {"number": 2}]
+    gh.list_pr_files.side_effect = lambda o, r, n: [f"file{n}.py"]
+    out = _collect_open_pr_files(gh, "owner", "repo")
+    assert out == {1: ["file1.py"], 2: ["file2.py"]}
+
+
+def test_collect_pr_files_list_open_prs_fails():
+    gh = MagicMock()
+    gh.list_open_prs.side_effect = RuntimeError("boom")
+    out = _collect_open_pr_files(gh, "o", "r")
+    assert out == {}
+
+
+def test_collect_pr_files_skips_excluded_pr():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"number": 1}, {"number": 2}]
+    gh.list_pr_files.return_value = ["x.py"]
+    out = _collect_open_pr_files(gh, "o", "r", exclude_pr=1)
+    assert 1 not in out
+    assert out == {2: ["x.py"]}
+
+
+def test_collect_pr_files_skips_none_number():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"title": "no number"}, {"number": 3}]
+    gh.list_pr_files.return_value = ["a.py"]
+    out = _collect_open_pr_files(gh, "o", "r")
+    assert out == {3: ["a.py"]}
+
+
+def test_collect_pr_files_per_pr_fetch_failure_dropped():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"number": 5}]
+    gh.list_pr_files.side_effect = ValueError("nope")
+    out = _collect_open_pr_files(gh, "o", "r")
+    # files = [] so PR not added
+    assert out == {}
+
+
+def test_collect_pr_files_empty_files_omitted():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"number": 7}]
+    gh.list_pr_files.return_value = []
+    out = _collect_open_pr_files(gh, "o", "r")
+    assert out == {}
+
+
+def test_collect_pr_files_coerces_number_to_int():
+    gh = MagicMock()
+    gh.list_open_prs.return_value = [{"number": "9"}]
+    gh.list_pr_files.return_value = ["z.py"]
+    out = _collect_open_pr_files(gh, "o", "r")
+    assert out == {9: ["z.py"]}
+
+
+# ── _has_conflict_with_active_task ───────────────────────────────────────────
+
+
+def test_conflict_empty_candidate():
+    has, prs = _has_conflict_with_active_task([], {1: ["a.py"]})
+    assert has is False
+    assert prs == []
+
+
+def test_conflict_candidate_all_falsy():
+    has, prs = _has_conflict_with_active_task(["", None], {1: ["a.py"]})
+    assert has is False
+    assert prs == []
+
+
+def test_conflict_detected():
+    has, prs = _has_conflict_with_active_task(
+        ["src/a.py"], {3: ["src/a.py", "src/b.py"], 4: ["src/c.py"]}
+    )
+    assert has is True
+    assert prs == [3]
+
+
+def test_conflict_multiple_sorted():
+    has, prs = _has_conflict_with_active_task(["a.py"], {9: ["a.py"], 2: ["a.py"], 5: ["other.py"]})
+    assert has is True
+    assert prs == [2, 9]
+
+
+def test_conflict_no_overlap():
+    has, prs = _has_conflict_with_active_task(["a.py"], {1: ["b.py"]})
+    assert has is False
+    assert prs == []
+
+
+def test_conflict_excludes_in_review_pr():
+    has, prs = _has_conflict_with_active_task(["a.py"], {1: ["a.py"]}, in_review_pr=1)
+    assert has is False
+    assert prs == []
+
+
+def test_conflict_path_normalization():
+    # './src/a.py' normalizes to 'src/a.py'
+    has, prs = _has_conflict_with_active_task(["./src/a.py"], {1: ["src/a.py"]})
+    assert has is True
+    assert prs == [1]
+
+
+def test_conflict_skips_falsy_files_in_pr():
+    has, prs = _has_conflict_with_active_task(["a.py"], {1: ["", None, "a.py"]})
+    assert has is True
+    assert prs == [1]
+
+
+# ── build_improve_triage_result ──────────────────────────────────────────────
+
+
+def test_build_triage_happy(tmp_path):
+    res = build_improve_triage_result(
+        success=True,
+        summary="all good",
+        suggestions=[{"title": "do x"}, {"title": "do y"}],
+        workspace_path=tmp_path / "ws",
+        executor_exit_code=0,
+    )
+    assert isinstance(res, ImproveTriageResult)
+    assert res.success is True
+    assert res.summary == "all good"
+    assert res.suggestions == ({"title": "do x"}, {"title": "do y"})
+    assert res.workspace_path == str(tmp_path / "ws")
+    assert res.executor_exit_code == 0
+
+
+def test_build_triage_none_suggestions():
+    res = build_improve_triage_result(
+        success=False,
+        summary="",
+        suggestions=None,
+        workspace_path="/tmp/x",
+        executor_exit_code=1,
+    )
+    assert res.suggestions == ()
+    assert res.success is False
+    assert res.summary == ""
+
+
+def test_build_triage_filters_invalid_suggestions():
+    res = build_improve_triage_result(
+        success=True,
+        summary="s",
+        suggestions=[
+            {"title": "keep"},
+            {"no_title": 1},  # missing title
+            {"title": ""},  # falsy title
+            "not a dict",  # wrong type
+            None,
+        ],
+        workspace_path="ws",
+        executor_exit_code=0,
+    )
+    assert res.suggestions == ({"title": "keep"},)
+
+
+def test_build_triage_summary_truncated():
+    long = "x" * 1000
+    res = build_improve_triage_result(
+        success=True,
+        summary=long,
+        suggestions=[],
+        workspace_path="ws",
+        executor_exit_code=0,
+    )
+    assert len(res.summary) == 500
+
+
+def test_build_triage_summary_none_coerced():
+    res = build_improve_triage_result(
+        success=True,
+        summary=None,  # type: ignore[arg-type]
+        suggestions=[],
+        workspace_path="ws",
+        executor_exit_code=0,
+    )
+    assert res.summary == ""
+
+
+def test_build_triage_coerces_types():
+    res = build_improve_triage_result(
+        success=1,  # type: ignore[arg-type]
+        summary=123,  # type: ignore[arg-type]
+        suggestions=[],
+        workspace_path=Path("/a/b"),
+        executor_exit_code="5",  # type: ignore[arg-type]
+    )
+    assert res.success is True
+    assert res.summary == "123"
+    assert res.executor_exit_code == 5
+    assert res.workspace_path == str(Path("/a/b"))
+
+
+def test_dataclasses_are_frozen():
+    res = build_improve_triage_result(
+        success=True,
+        summary="s",
+        suggestions=[],
+        workspace_path="ws",
+        executor_exit_code=0,
+    )
+    import pytest
+
+    with pytest.raises(Exception):
+        res.success = False  # type: ignore[misc]
+    env = EnvironmentCheck(ok=True, missing=(), notes=())
+    with pytest.raises(Exception):
+        env.ok = False  # type: ignore[misc]

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -1,0 +1,887 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from operations_center.contracts.enums import ExecutionStatus, ValidationStatus
+from operations_center.contracts.execution import ExecutionRequest, ExecutionResult
+from operations_center.execution import workspace as ws_mod
+from operations_center.execution.workspace import WorkspaceManager
+
+
+# ── builders ──────────────────────────────────────────────────────────────
+
+
+def _make_request(workspace_path: Path, **overrides) -> ExecutionRequest:
+    data = dict(
+        proposal_id="prop-1",
+        decision_id="dec-1",
+        goal_text="Fix the widget",
+        repo_key="acme/widget",
+        clone_url="https://github.com/acme/widget.git",
+        base_branch="main",
+        task_branch="goal/fix-widget",
+        workspace_path=workspace_path,
+    )
+    data.update(overrides)
+    return ExecutionRequest(**data)
+
+
+def _make_result(success: bool = True, **overrides) -> ExecutionResult:
+    data = dict(
+        run_id="run-12345678-abcd",
+        proposal_id="prop-1",
+        decision_id="dec-1",
+        status=ExecutionStatus.SUCCEEDED if success else ExecutionStatus.FAILED,
+        success=success,
+    )
+    data.update(overrides)
+    return ExecutionResult(**data)
+
+
+def _fake_completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ── __init__ defaults ───────────────────────────────────────────────────────
+
+
+def test_init_defaults_and_overrides():
+    mgr = WorkspaceManager()
+    assert mgr._max_files == ws_mod._DEFAULT_MAX_FILES
+    assert mgr._max_lines == ws_mod._DEFAULT_MAX_LINES
+    assert mgr._bot_name == "Operations Center"
+    assert mgr._await_review == set()
+    # default lookup returns None for anything
+    assert mgr._repo_lookup("anything") is None
+
+    custom = WorkspaceManager(
+        github_token="tok",
+        await_review_repos={"acme/widget"},
+        bot_identity=("Bot", "bot@x"),
+        max_files=5,
+        max_lines=10,
+        repo_settings_lookup=lambda k: "cfg" if k == "acme/widget" else None,
+    )
+    assert custom._max_files == 5
+    assert custom._max_lines == 10
+    assert custom._token == "tok"
+    assert custom._await_review == {"acme/widget"}
+    assert custom._bot_name == "Bot"
+    assert custom._bot_email == "bot@x"
+    assert custom._repo_lookup("acme/widget") == "cfg"
+
+
+# ── prepare() ────────────────────────────────────────────────────────────────
+
+
+def _git_for_prepare():
+    git = mock.Mock()
+    git.verify_remote_branch_exists.return_value = None
+    return git
+
+
+def test_prepare_non_empty_workspace_raises(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "preexisting.txt").write_text("x", encoding="utf-8")
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws)
+    with pytest.raises(RuntimeError, match="not empty"):
+        mgr.prepare(req)
+
+
+def test_prepare_clone_failure_raises(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws)
+    with mock.patch.object(
+        ws_mod.subprocess, "run", return_value=_fake_completed(1, stderr="boom")
+    ):
+        with pytest.raises(RuntimeError, match="git clone failed: boom"):
+            mgr.prepare(req)
+
+
+def test_prepare_clone_failure_falls_back_to_stdout(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws)
+    with mock.patch.object(
+        ws_mod.subprocess, "run", return_value=_fake_completed(1, stdout="stdout-err", stderr="")
+    ):
+        with pytest.raises(RuntimeError, match="git clone failed: stdout-err"):
+            mgr.prepare(req)
+
+
+def test_prepare_happy_path(tmp_path):
+    ws = tmp_path / "ws"
+    git = _git_for_prepare()
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)):
+        mgr.prepare(req)
+    git.set_identity.assert_called_once()
+    # one add_local_exclude per pattern
+    assert git.add_local_exclude.call_count == len(ws_mod._LOCAL_EXCLUDE_PATTERNS)
+    git.checkout_base.assert_called_once_with(ws, "main")
+    git.restore_to_head.assert_called_once_with(ws, ".baseline-validation.json")
+    git.create_task_branch.assert_called_once_with(ws, "goal/fix-widget")
+    # not self-healing since verify succeeded first time
+    git.create_remote_branch_from.assert_not_called()
+
+
+def test_prepare_pre_created_empty_workspace_ok(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir(parents=True)
+    git = _git_for_prepare()
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)):
+        mgr.prepare(req)
+    git.create_task_branch.assert_called_once()
+
+
+def test_prepare_self_heals_missing_base_branch(tmp_path):
+    ws = tmp_path / "ws"
+    git = mock.Mock()
+    # first verify raises, after heal it returns None
+    git.verify_remote_branch_exists.side_effect = [ValueError("missing"), None]
+    git.remote_default_branch.return_value = "main"
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws, base_branch="autonomy-staging")
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)):
+        mgr.prepare(req)
+    git.create_remote_branch_from.assert_called_once_with(ws, "autonomy-staging", "origin/main")
+    assert git.verify_remote_branch_exists.call_count == 2
+    git.create_task_branch.assert_called_once()
+
+
+def test_prepare_self_heal_failure_raises(tmp_path):
+    ws = tmp_path / "ws"
+    git = mock.Mock()
+    git.verify_remote_branch_exists.side_effect = ValueError("missing")
+    git.remote_default_branch.side_effect = RuntimeError("no default")
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws, base_branch="autonomy-staging")
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)):
+        with pytest.raises(RuntimeError, match="does not exist on origin"):
+            mgr.prepare(req)
+
+
+def test_prepare_runs_bootstrap_and_baseline(tmp_path):
+    ws = tmp_path / "ws"
+    git = _git_for_prepare()
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    with (
+        mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)),
+        mock.patch.object(mgr, "_maybe_bootstrap") as boot,
+        mock.patch.object(mgr, "_run_baseline_validation") as base,
+    ):
+        mgr.prepare(req)
+    boot.assert_called_once_with(ws, req)
+    base.assert_called_once_with(ws, req)
+
+
+# ── finalize() — early returns ───────────────────────────────────────────────
+
+
+def test_finalize_returns_unchanged_when_not_success(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws")
+    result = _make_result(success=False)
+    assert mgr.finalize(req, result) is result
+
+
+@pytest.mark.parametrize("prefix", ["improve/", "review/"])
+def test_finalize_skips_no_push_prefixes(tmp_path, prefix):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws", task_branch=f"{prefix}thing")
+    result = _make_result(success=True)
+    assert mgr.finalize(req, result) is result
+
+
+def test_finalize_returns_when_not_git_repo(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager()
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    # no .git dir
+    assert mgr.finalize(req, result) is result
+
+
+def _git_repo(tmp_path) -> Path:
+    ws = tmp_path / "ws"
+    (ws / ".git").mkdir(parents=True)
+    return ws
+
+
+# ── finalize() — oversized diff ──────────────────────────────────────────────
+
+
+def test_finalize_oversized_diff_writes_marker_and_fails(tmp_path):
+    ws = _git_repo(tmp_path)
+    mgr = WorkspaceManager(max_files=2, max_lines=5)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    file_list = [f"f{i}.py" for i in range(20)]
+    with mock.patch.object(mgr, "_diff_oversized", return_value=(20, 999, file_list)):
+        out = mgr.finalize(req, result)
+    assert out.branch_pushed is False
+    assert out.failure_category == "scope_too_wide"
+    assert "diff exceeded soft cap" in out.failure_reason
+    assert "(+5 more)" in out.failure_reason  # 20 files, top 15 shown
+    marker = ws / "scope-too-wide.json"
+    assert marker.exists()
+    import json
+
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["files"] == file_list
+    assert data["n_lines"] == 999
+
+
+def test_finalize_oversized_diff_marker_write_failure_is_nonfatal(tmp_path):
+    ws = _git_repo(tmp_path)
+    mgr = WorkspaceManager()
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=(3, 4, ["a.py", "b.py"])),
+        mock.patch.object(Path, "write_text", side_effect=OSError("disk full")),
+    ):
+        out = mgr.finalize(req, result)
+    assert out.failure_category == "scope_too_wide"
+    # few files -> no "(+N more)"
+    assert "more)" not in out.failure_reason
+
+
+# ── finalize() — push paths ──────────────────────────────────────────────────
+
+
+def _finalize_git_ok():
+    git = mock.Mock()
+    git.changed_files.return_value = ["a.py"]
+    git.commit_all.return_value = True
+    git.squash_commits.return_value = False
+    return git
+
+
+def test_finalize_no_new_commits_returns_early(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=False),
+    ):
+        out = mgr.finalize(req, result)
+    assert out is result
+    git.commit_all.assert_called_once()
+    git.push_branch.assert_not_called()
+
+
+def test_finalize_no_changed_files_skips_commit(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.changed_files.return_value = []
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=False),
+    ):
+        mgr.finalize(req, result)
+    git.commit_all.assert_not_called()
+
+
+def test_finalize_push_regular_no_squash(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = False
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact") as warn,
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/1"),
+    ):
+        out = mgr.finalize(req, result)
+    git.push_branch.assert_called_once_with(ws, "goal/fix-widget")
+    git.push_branch_force.assert_not_called()
+    warn.assert_called_once_with(ws, req)
+    assert out.branch_pushed is True
+    assert out.branch_name == "goal/fix-widget"
+    assert out.pull_request_url == "http://pr/1"
+
+
+def test_finalize_push_force_when_squashed(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = True
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value=None),
+    ):
+        out = mgr.finalize(req, result)
+    git.push_branch_force.assert_called_once_with(ws, "goal/fix-widget")
+    git.push_branch.assert_not_called()
+    assert out.branch_pushed is True
+    assert out.pull_request_url is None
+
+
+def test_finalize_push_failure_is_nonfatal(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = False
+    git.push_branch.side_effect = RuntimeError("network down")
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+    ):
+        out = mgr.finalize(req, result)
+    assert out is result
+    assert out.branch_pushed is False
+
+
+# ── _diff_oversized ──────────────────────────────────────────────────────────
+
+
+def test_diff_oversized_within_bounds(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager(max_files=50, max_lines=2000)
+
+    def fake_run(args, **kwargs):
+        if args[:3] == ["git", "diff", "--cached"] and "--shortstat" in args:
+            return _fake_completed(0, stdout="1 file changed, 3 insertions(+), 1 deletion(-)")
+        if args[:3] == ["git", "diff", "--cached"] and "--name-only" in args:
+            return _fake_completed(0, stdout="a.py\nb.py\n")
+        return _fake_completed(0)
+
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
+        assert mgr._diff_oversized(ws) is None
+
+
+def test_diff_oversized_exceeds_files(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager(max_files=1, max_lines=10000)
+
+    def fake_run(args, **kwargs):
+        if "--shortstat" in args:
+            return _fake_completed(0, stdout="3 files changed, 2 insertions(+)")
+        if "--name-only" in args:
+            return _fake_completed(0, stdout="z.py\n a.py \nb.py\n")
+        return _fake_completed(0)
+
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
+        out = mgr._diff_oversized(ws)
+    assert out is not None
+    n_files, n_lines, file_list = out
+    assert n_files == 3
+    assert n_lines == 2
+    # sorted + stripped
+    assert file_list == ["a.py", "b.py", "z.py"]
+
+
+def test_diff_oversized_exceeds_lines(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager(max_files=100, max_lines=5)
+
+    def fake_run(args, **kwargs):
+        if "--shortstat" in args:
+            return _fake_completed(0, stdout="1 file changed, 10 insertions(+), 4 deletions(-)")
+        if "--name-only" in args:
+            return _fake_completed(0, stdout="a.py\n")
+        return _fake_completed(0)
+
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
+        out = mgr._diff_oversized(ws)
+    assert out is not None
+    assert out[1] == 14  # 10 + 4
+
+
+def test_diff_oversized_calledprocesserror_returns_none(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager()
+
+    def fake_run(args, **kwargs):
+        if kwargs.get("check"):
+            raise subprocess.CalledProcessError(1, args)
+        return _fake_completed(0)
+
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
+        assert mgr._diff_oversized(ws) is None
+
+
+# ── _has_new_commits ─────────────────────────────────────────────────────────
+
+
+def test_has_new_commits_true(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager()
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0, stdout="3\n")):
+        assert mgr._has_new_commits(ws, "main") is True
+
+
+def test_has_new_commits_zero(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager()
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0, stdout="0\n")):
+        assert mgr._has_new_commits(ws, "main") is False
+
+
+def test_has_new_commits_nonzero_returncode(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager()
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(1)):
+        assert mgr._has_new_commits(ws, "main") is False
+
+
+def test_has_new_commits_unparseable(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager()
+    with mock.patch.object(
+        ws_mod.subprocess, "run", return_value=_fake_completed(0, stdout="not-a-number")
+    ):
+        assert mgr._has_new_commits(ws, "main") is False
+
+
+# ── _commit_message ──────────────────────────────────────────────────────────
+
+
+def test_commit_message_strips_noise(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(
+        tmp_path / "ws", goal_text="[Impl] Add **bold** and `code` to the parser.\nmore"
+    )
+    assert mgr._commit_message(req) == "Add bold and code to the parser"
+
+
+def test_commit_message_fallback_to_run_id(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws", goal_text="", run_id="abcdef1234567890")
+    assert mgr._commit_message(req) == "Operations Center run abcdef12"
+
+
+def test_commit_message_fallback_when_only_noise(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws", goal_text="[Tag]   ", run_id="zzzzzzzz1234")
+    msg = mgr._commit_message(req)
+    assert msg == "Operations Center run zzzzzzzz"
+
+
+def test_commit_message_truncates_to_72(tmp_path):
+    mgr = WorkspaceManager()
+    long = "x" * 100
+    req = _make_request(tmp_path / "ws", goal_text=long)
+    assert mgr._commit_message(req) == "x" * 72
+
+
+# ── _maybe_create_pr ─────────────────────────────────────────────────────────
+
+
+def test_maybe_create_pr_no_token(tmp_path):
+    mgr = WorkspaceManager()
+    assert mgr._maybe_create_pr(_make_request(tmp_path / "ws")) is None
+
+
+def test_maybe_create_pr_repo_not_in_await_review(tmp_path):
+    mgr = WorkspaceManager(github_token="tok", await_review_repos={"other/repo"})
+    assert mgr._maybe_create_pr(_make_request(tmp_path / "ws")) is None
+
+
+def test_maybe_create_pr_open_pr_default_false(tmp_path):
+    cfg = SimpleNamespace(open_pr_default=False)
+    mgr = WorkspaceManager(
+        github_token="tok",
+        await_review_repos={"acme/widget"},
+        repo_settings_lookup=lambda k: cfg,
+    )
+    assert mgr._maybe_create_pr(_make_request(tmp_path / "ws")) is None
+
+
+def test_maybe_create_pr_success(tmp_path):
+    mgr = WorkspaceManager(
+        github_token="tok",
+        await_review_repos={"acme/widget"},
+        repo_settings_lookup=lambda k: SimpleNamespace(open_pr_default=True),
+    )
+    req = _make_request(tmp_path / "ws")
+
+    fake_gh = mock.Mock()
+    fake_gh.create_pr.return_value = {"html_url": "http://pr/99"}
+    fake_cls = mock.Mock(return_value=fake_gh)
+    fake_cls.owner_repo_from_clone_url.return_value = ("acme", "widget")
+    fake_module = SimpleNamespace(GitHubPRClient=fake_cls)
+
+    with mock.patch.dict("sys.modules", {"operations_center.adapters.github_pr": fake_module}):
+        url = mgr._maybe_create_pr(req)
+    assert url == "http://pr/99"
+    fake_gh.create_pr.assert_called_once()
+    _, kwargs = fake_gh.create_pr.call_args
+    assert kwargs["head"] == "goal/fix-widget"
+    assert kwargs["base"] == "main"
+
+
+def test_maybe_create_pr_exception_returns_none(tmp_path):
+    mgr = WorkspaceManager(
+        github_token="tok",
+        await_review_repos={"acme/widget"},
+    )
+    req = _make_request(tmp_path / "ws")
+
+    fake_cls = mock.Mock()
+    fake_cls.owner_repo_from_clone_url.side_effect = RuntimeError("bad url")
+    fake_module = SimpleNamespace(GitHubPRClient=fake_cls)
+    with mock.patch.dict("sys.modules", {"operations_center.adapters.github_pr": fake_module}):
+        assert mgr._maybe_create_pr(req) is None
+
+
+# ── _run_baseline_validation ─────────────────────────────────────────────────
+
+
+def test_baseline_validation_no_repo_cfg_is_noop(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: None)
+    mgr._run_baseline_validation(ws, _make_request(ws))
+    assert not (ws / ".baseline-validation.json").exists()
+
+
+def test_baseline_validation_writes_marker(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    cfg = SimpleNamespace()
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    req = _make_request(ws)
+
+    summary = mock.Mock()
+    summary.model_dump_json.return_value = '{"status": "passed"}'
+    fake_module = SimpleNamespace(run_baseline_validation=mock.Mock(return_value=summary))
+    with mock.patch.dict(
+        "sys.modules",
+        {"operations_center.execution.baseline_validation": fake_module},
+    ):
+        mgr._run_baseline_validation(ws, req)
+    assert (ws / ".baseline-validation.json").read_text(encoding="utf-8") == '{"status": "passed"}'
+
+
+def test_baseline_validation_crash_is_nonfatal(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    cfg = SimpleNamespace()
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    fake_module = SimpleNamespace(
+        run_baseline_validation=mock.Mock(side_effect=RuntimeError("boom"))
+    )
+    with mock.patch.dict(
+        "sys.modules",
+        {"operations_center.execution.baseline_validation": fake_module},
+    ):
+        mgr._run_baseline_validation(ws, _make_request(ws))
+    assert not (ws / ".baseline-validation.json").exists()
+
+
+def test_baseline_validation_marker_write_oserror_is_nonfatal(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: SimpleNamespace())
+    summary = mock.Mock()
+    summary.model_dump_json.return_value = "{}"
+    fake_module = SimpleNamespace(run_baseline_validation=mock.Mock(return_value=summary))
+    with (
+        mock.patch.dict(
+            "sys.modules",
+            {"operations_center.execution.baseline_validation": fake_module},
+        ),
+        mock.patch.object(Path, "write_text", side_effect=OSError("nope")) as write_text,
+    ):
+        mgr._run_baseline_validation(ws, _make_request(ws))  # no raise
+    # the write was attempted but failed; marker must not exist
+    write_text.assert_called_once()
+    assert not (ws / ".baseline-validation.json").exists()
+
+
+# ── _maybe_bootstrap ─────────────────────────────────────────────────────────
+
+
+def test_bootstrap_no_repo_cfg_noop(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: None)
+    with mock.patch.object(ws_mod.subprocess, "run") as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    run.assert_not_called()
+
+
+def test_bootstrap_disabled_noop(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(bootstrap_enabled=False)
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run") as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    run.assert_not_called()
+
+
+def test_bootstrap_nothing_configured_noop(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(bootstrap_commands=None, install_dev_command=None)
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run") as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    run.assert_not_called()
+
+
+def test_bootstrap_custom_commands_success(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=["echo hi", "  ", "", 123, "make setup"],
+        install_dev_command="pip install -e .",
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    # only the two valid string commands run; install path NOT reached
+    ran = [c.args[0] for c in run.call_args_list]
+    assert ran == ["echo hi", "make setup"]
+
+
+def test_bootstrap_custom_command_failure_aborts(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(bootstrap_commands=["bad", "second"], install_dev_command=None)
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(
+        ws_mod.subprocess, "run", return_value=_fake_completed(1, stderr="failed")
+    ) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    # stops after first failing command
+    assert run.call_count == 1
+
+
+def test_bootstrap_standard_install_success(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=".venv",
+        python_binary="python3",
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    # venv creation + install
+    assert run.call_count == 2
+    venv_call = run.call_args_list[0]
+    assert venv_call.args[0] == ["python3", "-m", "venv", ".venv"]
+    install_call = run.call_args_list[1]
+    assert install_call.args[0] == "pip install -e ."
+
+
+def test_bootstrap_defaults_venv_and_python(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=None,
+        python_binary=None,
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    assert run.call_args_list[0].args[0] == ["python3", "-m", "venv", ".venv"]
+
+
+def test_bootstrap_venv_creation_failure_aborts(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=".venv",
+        python_binary="python3",
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(
+        ws_mod.subprocess,
+        "run",
+        side_effect=subprocess.CalledProcessError(1, "venv"),
+    ) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    assert run.call_count == 1  # only venv attempt
+
+
+def test_bootstrap_install_command_failure_logged(tmp_path):
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=".venv",
+        python_binary="python3",
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if kwargs.get("check"):
+            return _fake_completed(0)  # venv ok
+        return _fake_completed(1, stderr="install failed")  # install fails
+
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    assert len(calls) == 2
+
+
+# ── _warn_cross_repo_impact ──────────────────────────────────────────────────
+
+
+def test_warn_cross_repo_impact_helper_missing(tmp_path):
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager()
+    with (
+        mock.patch.dict("sys.modules", {"operations_center.cross_repo_impact": None}),
+        mock.patch.object(ws_mod.subprocess, "run") as run,
+    ):
+        # importing a None module raises ImportError -> caught before any git work
+        mgr._warn_cross_repo_impact(ws, _make_request(ws))  # no raise
+    run.assert_not_called()
+
+
+def test_warn_cross_repo_impact_no_settings_obj(tmp_path):
+    ws = tmp_path / "ws"
+    # plain lambda has no __self__ -> all_repos stays empty -> early return
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: None)
+    fake_module = SimpleNamespace(_check_cross_repo_impact=mock.Mock())
+    with mock.patch.dict("sys.modules", {"operations_center.cross_repo_impact": fake_module}):
+        mgr._warn_cross_repo_impact(ws, _make_request(ws))
+    fake_module._check_cross_repo_impact.assert_not_called()
+
+
+def test_warn_cross_repo_impact_logs_impacts(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    # bound method whose __self__ exposes .repos
+    settings_obj = SimpleNamespace(repos={"acme/widget": object(), "other/repo": object()})
+
+    class Lookup:
+        def __init__(self, s):
+            self.__self__ = s
+
+        def __call__(self, k):
+            return None
+
+    # Build a real bound method so hasattr(__self__) is true
+    def lookup(k):
+        return None
+
+    lookup.__self__ = settings_obj  # type: ignore[attr-defined]
+
+    mgr = WorkspaceManager(repo_settings_lookup=lookup)
+    req = _make_request(ws)
+
+    impact = SimpleNamespace(repo_key="other/repo", matched_paths=["api/x.py"])
+    check = mock.Mock(return_value=[impact])
+    fake_module = SimpleNamespace(_check_cross_repo_impact=check)
+
+    with (
+        mock.patch.dict("sys.modules", {"operations_center.cross_repo_impact": fake_module}),
+        mock.patch.object(
+            ws_mod.subprocess,
+            "run",
+            return_value=_fake_completed(0, stdout="api/x.py\n\n"),
+        ),
+    ):
+        mgr._warn_cross_repo_impact(ws, req)
+    check.assert_called_once()
+    _, kwargs = check.call_args
+    assert kwargs["source_repo_key"] == "acme/widget"
+
+
+def test_warn_cross_repo_impact_diff_fails(tmp_path):
+    ws = tmp_path / "ws"
+    settings_obj = SimpleNamespace(repos={"acme/widget": object()})
+
+    def lookup(k):
+        return None
+
+    lookup.__self__ = settings_obj  # type: ignore[attr-defined]
+    mgr = WorkspaceManager(repo_settings_lookup=lookup)
+    check = mock.Mock()
+    fake_module = SimpleNamespace(_check_cross_repo_impact=check)
+    with (
+        mock.patch.dict("sys.modules", {"operations_center.cross_repo_impact": fake_module}),
+        mock.patch.object(
+            ws_mod.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, "diff"),
+        ),
+    ):
+        mgr._warn_cross_repo_impact(ws, _make_request(ws))
+    check.assert_not_called()
+
+
+def test_warn_cross_repo_impact_no_files(tmp_path):
+    ws = tmp_path / "ws"
+    settings_obj = SimpleNamespace(repos={"acme/widget": object()})
+
+    def lookup(k):
+        return None
+
+    lookup.__self__ = settings_obj  # type: ignore[attr-defined]
+    mgr = WorkspaceManager(repo_settings_lookup=lookup)
+    check = mock.Mock()
+    fake_module = SimpleNamespace(_check_cross_repo_impact=check)
+    with (
+        mock.patch.dict("sys.modules", {"operations_center.cross_repo_impact": fake_module}),
+        mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0, stdout="\n\n")),
+    ):
+        mgr._warn_cross_repo_impact(ws, _make_request(ws))
+    check.assert_not_called()
+
+
+# ── finalize() wires _warn before _maybe_create_pr (integration-ish) ─────────
+
+
+def test_finalize_full_chain_with_validation_summary(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = True
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    from operations_center.contracts.common import ValidationSummary
+
+    result = _make_result(
+        success=True, validation=ValidationSummary(status=ValidationStatus.PASSED)
+    )
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/7"),
+    ):
+        out = mgr.finalize(req, result)
+    assert out.pull_request_url == "http://pr/7"
+    assert out.validation.status == ValidationStatus.PASSED

--- a/tests/unit/executors/test_artifacts_cov.py
+++ b/tests/unit/executors/test_artifacts_cov.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Complementary coverage tests for the per-backend artifact loaders.
+
+These exercise branches not covered by ``test_artifacts.py``: empty/missing
+files, type-shape rejections, optional-field defaults and full happy-path
+construction for each loader.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from operations_center.executors._artifacts import (
+    AuditArtifactError,
+    AuditOutcome,
+    AuditVerdict,
+    CapabilityCard,
+    ContractGap,
+    GapStatus,
+    PhaseClassification,
+    RuntimeSupportCard,
+    load_audit_verdict,
+    load_capability_card,
+    load_contract_gaps,
+    load_runtime_support,
+)
+
+_FULL_PHASES = (
+    "per_phase:\n"
+    "  runtime_control: PASS\n"
+    "  capability_control: PARTIAL\n"
+    "  drift_detection: FAIL\n"
+    "  failure_observability: PASS\n"
+    "  internal_routing: 'N/A'\n"
+)
+
+
+# ── load_contract_gaps ──────────────────────────────────────────────────
+
+
+class TestLoadContractGaps:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_contract_gaps(tmp_path / "nope.yaml") == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        p = tmp_path / "g.yaml"
+        p.write_text("")
+        assert load_contract_gaps(p) == []
+
+    def test_top_level_not_a_list(self, tmp_path):
+        p = tmp_path / "g.yaml"
+        p.write_text("id: g\n")
+        with pytest.raises(AuditArtifactError, match="top-level must be a list"):
+            load_contract_gaps(p)
+
+    def test_entry_not_a_dict(self, tmp_path):
+        p = tmp_path / "g.yaml"
+        p.write_text("- just_a_string\n")
+        with pytest.raises(AuditArtifactError, match="each gap must be a dict"):
+            load_contract_gaps(p)
+
+    def test_missing_required_fields(self, tmp_path):
+        p = tmp_path / "g.yaml"
+        p.write_text("- id: g\n  gap: x\n")
+        with pytest.raises(AuditArtifactError, match="missing fields"):
+            load_contract_gaps(p)
+
+    def test_full_gap_with_patch_deadline(self, tmp_path):
+        p = tmp_path / "g.yaml"
+        p.write_text(
+            "- id: g1\n"
+            "  gap: missing thing\n"
+            "  discovered_at: 2026-01-01\n"
+            "  backend_version: 1.2.3\n"
+            "  impact: high\n"
+            "  workaround: none\n"
+            "  fork_threshold: never\n"
+            "  status: patched_upstream\n"
+            "  patch_deadline: 2026-12-31\n"
+        )
+        gaps = load_contract_gaps(p)
+        assert len(gaps) == 1
+        g = gaps[0]
+        assert isinstance(g, ContractGap)
+        assert g.id == "g1"
+        assert g.backend_version == "1.2.3"
+        assert g.status is GapStatus.PATCHED_UPSTREAM
+        assert g.patch_deadline == "2026-12-31"
+
+    def test_defaults_backend_version_and_no_deadline(self, tmp_path):
+        # backend_version omitted -> "unknown"; patch_deadline absent -> None;
+        # also covers the falsy patch_deadline branch (empty string).
+        p = tmp_path / "g.yaml"
+        p.write_text(
+            "- id: g2\n"
+            "  gap: x\n"
+            "  discovered_at: t\n"
+            "  impact: i\n"
+            "  workaround: w\n"
+            "  fork_threshold: f\n"
+            "  status: open\n"
+            "  patch_deadline: ''\n"
+        )
+        (g,) = load_contract_gaps(p)
+        assert g.backend_version == "unknown"
+        assert g.patch_deadline is None
+        assert g.status is GapStatus.OPEN
+
+
+# ── load_capability_card ────────────────────────────────────────────────
+
+
+class TestLoadCapabilityCard:
+    def test_empty_file_yields_defaults(self, tmp_path):
+        p = tmp_path / "c.yaml"
+        p.write_text("")
+        card = load_capability_card(p)
+        assert isinstance(card, CapabilityCard)
+        assert card.backend_id == ""
+        assert card.backend_version == "unknown"
+        assert card.advertised_capabilities == []
+        assert card.measured_constraints == {}
+        assert card.known_capability_gaps == []
+
+    def test_not_a_dict(self, tmp_path):
+        p = tmp_path / "c.yaml"
+        p.write_text("- a\n- b\n")
+        with pytest.raises(AuditArtifactError, match="must be a dict"):
+            load_capability_card(p)
+
+    def test_full_valid_card(self, tmp_path):
+        p = tmp_path / "c.yaml"
+        p.write_text(
+            "backend_id: my_backend\n"
+            "backend_version: 9.9\n"
+            "advertised_capabilities: [repo_patch, network_access]\n"
+            "measured_constraints:\n  max_tokens: 100\n"
+            "known_capability_gaps: [some_gap]\n"
+        )
+        card = load_capability_card(p)
+        assert card.backend_id == "my_backend"
+        assert card.backend_version == "9.9"
+        assert "repo_patch" in card.advertised_capabilities
+        assert card.measured_constraints == {"max_tokens": 100}
+        assert card.known_capability_gaps == ["some_gap"]
+
+
+# ── load_runtime_support ────────────────────────────────────────────────
+
+
+class TestLoadRuntimeSupport:
+    def test_empty_file_yields_defaults(self, tmp_path):
+        p = tmp_path / "r.yaml"
+        p.write_text("")
+        rs = load_runtime_support(p)
+        assert isinstance(rs, RuntimeSupportCard)
+        assert rs.backend_id == ""
+        assert rs.backend_version == "unknown"
+        assert rs.supported_runtime_kinds == []
+        assert rs.supported_selection_modes == []
+        assert rs.known_runtime_gaps == []
+
+    def test_not_a_dict(self, tmp_path):
+        p = tmp_path / "r.yaml"
+        p.write_text("- a\n")
+        with pytest.raises(AuditArtifactError, match="must be a dict"):
+            load_runtime_support(p)
+
+    def test_full_valid_card(self, tmp_path):
+        p = tmp_path / "r.yaml"
+        p.write_text(
+            "backend_id: rb\n"
+            "backend_version: 2.0\n"
+            "supported_runtime_kinds: [cli_subscription, backend_default]\n"
+            "supported_selection_modes: [explicit_request, backend_default]\n"
+            "known_runtime_gaps: [g]\n"
+        )
+        rs = load_runtime_support(p)
+        assert rs.backend_id == "rb"
+        assert rs.backend_version == "2.0"
+        assert "cli_subscription" in rs.supported_runtime_kinds
+        assert "explicit_request" in rs.supported_selection_modes
+        assert rs.known_runtime_gaps == ["g"]
+
+
+# ── load_audit_verdict ──────────────────────────────────────────────────
+
+
+class TestLoadAuditVerdict:
+    def test_empty_file_missing_phase(self, tmp_path):
+        # Empty -> per_phase {} -> first required phase missing.
+        p = tmp_path / "v.yaml"
+        p.write_text("")
+        with pytest.raises(AuditArtifactError, match="missing required phase"):
+            load_audit_verdict(p)
+
+    def test_not_a_dict(self, tmp_path):
+        p = tmp_path / "v.yaml"
+        p.write_text("- a\n")
+        with pytest.raises(AuditArtifactError, match="must be a dict"):
+            load_audit_verdict(p)
+
+    def test_per_phase_not_a_dict(self, tmp_path):
+        p = tmp_path / "v.yaml"
+        p.write_text("outcome: adapter_only\nper_phase:\n  - a\n  - b\n")
+        with pytest.raises(AuditArtifactError, match="per_phase must be a dict"):
+            load_audit_verdict(p)
+
+    def test_missing_outcome_key(self, tmp_path):
+        p = tmp_path / "v.yaml"
+        p.write_text(_FULL_PHASES)
+        with pytest.raises(AuditArtifactError, match="invalid or missing outcome"):
+            load_audit_verdict(p)
+
+    def test_invalid_outcome_value(self, tmp_path):
+        p = tmp_path / "v.yaml"
+        p.write_text("outcome: teleport\n" + _FULL_PHASES)
+        with pytest.raises(AuditArtifactError, match="invalid or missing outcome"):
+            load_audit_verdict(p)
+
+    def test_full_valid_verdict_with_review(self, tmp_path):
+        p = tmp_path / "v.yaml"
+        p.write_text(
+            "backend_id: vb\n"
+            "audited_at: 2026-01-02\n"
+            "audited_against_cxrp_version: '0.5'\n"
+            "backend_version: 3.1\n"
+            "outcome: fork_required\n"
+            "gap_refs: [g1, g2]\n"
+            "next_review_by: 2026-06-01\n" + _FULL_PHASES
+        )
+        v = load_audit_verdict(p)
+        assert isinstance(v, AuditVerdict)
+        assert v.backend_id == "vb"
+        assert v.audited_at == "2026-01-02"
+        assert v.audited_against_cxrp_version == "0.5"
+        assert v.backend_version == "3.1"
+        assert v.outcome is AuditOutcome.FORK_REQUIRED
+        assert v.gap_refs == ["g1", "g2"]
+        assert v.next_review_by == "2026-06-01"
+        assert v.per_phase["runtime_control"] is PhaseClassification.PASS
+        assert v.per_phase["drift_detection"] is PhaseClassification.FAIL
+        assert v.per_phase["internal_routing"] is PhaseClassification.NA
+
+    def test_defaults_and_no_next_review(self, tmp_path):
+        # Minimal: omit metadata to hit default branches; next_review_by absent -> None.
+        p = tmp_path / "v.yaml"
+        p.write_text("outcome: adapter_only\n" + _FULL_PHASES)
+        v = load_audit_verdict(p)
+        assert v.backend_id == ""
+        assert v.audited_at == ""
+        assert v.audited_against_cxrp_version == ""
+        assert v.backend_version == "unknown"
+        assert v.gap_refs == []
+        assert v.next_review_by is None
+        assert v.outcome is AuditOutcome.ADAPTER_ONLY

--- a/tests/unit/maintenance/__init__.py
+++ b/tests/unit/maintenance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/maintenance/test_registry_cov.py
+++ b/tests/unit/maintenance/test_registry_cov.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from operations_center.maintenance.contracts import (
+    MaintenanceContext,
+    MaintenanceResult,
+)
+from operations_center.maintenance.registry import (
+    _DEFAULT_STATE_PATH,
+    MaintenanceRegistry,
+)
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class FakeTask:
+    """Minimal MaintenanceTask implementation for tests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        interval_seconds: int = 60,
+        enabled: bool = True,
+        status: str = "ok",
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self.interval_seconds = interval_seconds
+        self.enabled = enabled
+        self._status = status
+        self._raise_exc = raise_exc
+        self.run_calls = 0
+
+    def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
+        self.run_calls += 1
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return MaintenanceResult(
+            name=self.name,
+            status=self._status,  # type: ignore[arg-type]
+            duration_seconds=0.0,
+            details={"cycle": ctx.cycle_id},
+        )
+
+
+def _ctx(now: datetime | None = None, cycle_id: str = "c1") -> MaintenanceContext:
+    return MaintenanceContext(
+        cycle_id=cycle_id,
+        now=now or datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+# --------------------------------------------------------------------------
+# Construction / state path
+# --------------------------------------------------------------------------
+
+
+def test_default_state_path_used_when_none(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    reg = MaintenanceRegistry()
+    assert reg.state_path == _DEFAULT_STATE_PATH
+
+
+def test_explicit_state_path(tmp_path):
+    p = tmp_path / "state.json"
+    reg = MaintenanceRegistry(state_path=p)
+    assert reg.state_path == p
+
+
+def test_init_loads_existing_state(tmp_path):
+    p = tmp_path / "state.json"
+    p.write_text(
+        json.dumps({"last_run": {"alpha": 100.0, "beta": "200"}}),
+        encoding="utf-8",
+    )
+    reg = MaintenanceRegistry(state_path=p)
+    # beta coerced from string -> float
+    assert reg._last_run == {"alpha": 100.0, "beta": 200.0}
+
+
+# --------------------------------------------------------------------------
+# registration
+# --------------------------------------------------------------------------
+
+
+def test_register_and_list(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a")
+    reg.register(t)
+    tasks = reg.list_tasks()
+    assert tasks == [t]
+    # list_tasks returns a copy
+    tasks.append(FakeTask("x"))
+    assert len(reg.list_tasks()) == 1
+
+
+def test_register_duplicate_name_raises(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    reg.register(FakeTask("dup"))
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(FakeTask("dup"))
+
+
+def test_register_many(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    reg.register_many([FakeTask("a"), FakeTask("b")])
+    assert [t.name for t in reg.list_tasks()] == ["a", "b"]
+
+
+# --------------------------------------------------------------------------
+# _is_due
+# --------------------------------------------------------------------------
+
+
+def test_is_due_disabled_task(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", enabled=False)
+    assert reg._is_due(t, 1000.0) is False
+
+
+def test_is_due_never_run(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a")
+    assert reg._is_due(t, 1000.0) is True
+
+
+def test_is_due_interval_elapsed(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", interval_seconds=60)
+    reg._last_run["a"] = 1000.0
+    assert reg._is_due(t, 1061.0) is True
+
+
+def test_is_due_interval_not_elapsed(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", interval_seconds=60)
+    reg._last_run["a"] = 1000.0
+    assert reg._is_due(t, 1030.0) is False
+
+
+def test_is_due_interval_exactly_elapsed(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", interval_seconds=60)
+    reg._last_run["a"] = 1000.0
+    assert reg._is_due(t, 1060.0) is True
+
+
+# --------------------------------------------------------------------------
+# run_due
+# --------------------------------------------------------------------------
+
+
+def test_run_due_happy_path_runs_and_persists(tmp_path):
+    p = tmp_path / "s.json"
+    reg = MaintenanceRegistry(state_path=p)
+    t = FakeTask("a")
+    reg.register(t)
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    results = reg.run_due(_ctx(now=now))
+    assert len(results) == 1
+    assert results[0].status == "ok"
+    assert results[0].details == {"cycle": "c1"}
+    assert t.run_calls == 1
+    # last_run recorded with the cycle's epoch
+    assert reg._last_run["a"] == now.timestamp()
+    # persisted to disk
+    saved = json.loads(p.read_text(encoding="utf-8"))
+    assert saved["last_run"]["a"] == now.timestamp()
+    assert "written_at" in saved
+
+
+def test_run_due_skips_not_due(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", interval_seconds=3600)
+    reg.register(t)
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    reg._last_run["a"] = now.timestamp() - 10.0  # ran 10s ago, interval 3600
+    results = reg.run_due(_ctx(now=now))
+    assert results == []
+    assert t.run_calls == 0
+
+
+def test_run_due_skips_disabled(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    t = FakeTask("a", enabled=False)
+    reg.register(t)
+    results = reg.run_due(_ctx())
+    assert results == []
+    assert t.run_calls == 0
+
+
+def test_run_due_failing_task_recorded_and_continues(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "s.json")
+    bad = FakeTask("bad", raise_exc=RuntimeError("boom"))
+    good = FakeTask("good")
+    reg.register(bad)
+    reg.register(good)
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    results = reg.run_due(_ctx(now=now))
+    assert len(results) == 2
+    by_name = {r.name: r for r in results}
+    assert by_name["bad"].status == "failed"
+    assert by_name["bad"].error == "boom"
+    assert by_name["bad"].details == {}
+    assert by_name["bad"].duration_seconds >= 0.0
+    assert by_name["good"].status == "ok"
+    # both marked as run even though one failed
+    assert reg._last_run["bad"] == now.timestamp()
+    assert reg._last_run["good"] == now.timestamp()
+
+
+def test_run_due_empty_registry_saves_state(tmp_path):
+    p = tmp_path / "s.json"
+    reg = MaintenanceRegistry(state_path=p)
+    results = reg.run_due(_ctx())
+    assert results == []
+    assert p.exists()
+
+
+# --------------------------------------------------------------------------
+# _load_state edge cases
+# --------------------------------------------------------------------------
+
+
+def test_load_state_missing_file(tmp_path):
+    reg = MaintenanceRegistry(state_path=tmp_path / "nope.json")
+    assert reg._last_run == {}
+
+
+def test_load_state_non_dict_top_level(tmp_path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    reg = MaintenanceRegistry(state_path=p)
+    assert reg._last_run == {}
+
+
+def test_load_state_malformed_values_dropped(tmp_path):
+    p = tmp_path / "s.json"
+    p.write_text(
+        json.dumps({"last_run": {"a": "notafloat", "b": None, "c": 5}}),
+        encoding="utf-8",
+    )
+    reg = MaintenanceRegistry(state_path=p)
+    assert reg._last_run == {"c": 5.0}
+
+
+def test_load_state_invalid_json(tmp_path, caplog):
+    p = tmp_path / "s.json"
+    p.write_text("{ not valid json", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        reg = MaintenanceRegistry(state_path=p)
+    assert reg._last_run == {}
+    assert any("load failed" in m for m in caplog.messages)
+
+
+def test_load_state_oserror(tmp_path, monkeypatch, caplog):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"last_run": {}}), encoding="utf-8")
+
+    def boom(*_a, **_k):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    with caplog.at_level("WARNING"):
+        reg = MaintenanceRegistry(state_path=p)
+    assert reg._last_run == {}
+    assert any("load failed" in m for m in caplog.messages)
+
+
+def test_load_state_no_last_run_key(tmp_path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"written_at": "x"}), encoding="utf-8")
+    reg = MaintenanceRegistry(state_path=p)
+    assert reg._last_run == {}
+
+
+# --------------------------------------------------------------------------
+# _save_state edge cases
+# --------------------------------------------------------------------------
+
+
+def test_save_state_creates_parent_dirs(tmp_path):
+    p = tmp_path / "deep" / "nested" / "s.json"
+    reg = MaintenanceRegistry(state_path=p)
+    reg._last_run["a"] = 1.0
+    reg._save_state()
+    assert p.exists()
+    saved = json.loads(p.read_text(encoding="utf-8"))
+    assert saved["last_run"] == {"a": 1.0}
+
+
+def test_save_state_oserror_swallowed(tmp_path, monkeypatch, caplog):
+    p = tmp_path / "s.json"
+    reg = MaintenanceRegistry(state_path=p)
+
+    def boom(*_a, **_k):
+        raise OSError("readonly fs")
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    with caplog.at_level("WARNING"):
+        reg._save_state()  # should not raise
+    assert any("save failed" in m for m in caplog.messages)
+
+
+# --------------------------------------------------------------------------
+# round trip persistence across instances
+# --------------------------------------------------------------------------
+
+
+def test_state_survives_new_instance(tmp_path):
+    p = tmp_path / "s.json"
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+    reg1 = MaintenanceRegistry(state_path=p)
+    reg1.register(FakeTask("a"))
+    reg1.run_due(_ctx(now=now))
+
+    reg2 = MaintenanceRegistry(state_path=p)
+    assert reg2._last_run["a"] == now.timestamp()
+    # Newly loaded registry treats the task as not-due within interval
+    t = FakeTask("a", interval_seconds=3600)
+    assert reg2._is_due(t, now.timestamp() + 10.0) is False

--- a/tests/unit/observer/__init__.py
+++ b/tests/unit/observer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/observer/test_validation_cov.py
+++ b/tests/unit/observer/test_validation_cov.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Complementary coverage tests for observer.validation.
+
+Focuses on branches not exercised by the existing helper tests:
+metrics_exporter wiring, export-exception swallowing, dataclass
+behaviour, and the full LintItemValidator branch matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.observer.validation import (
+    ArtifactValidator,
+    DependencyReportValidator,
+    ExecutionOutcomeValidator,
+    LintItemValidator,
+    ParseError,
+    ParseErrorMetadata,
+    RequestValidator,
+    ValidationHistoryValidator,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Dataclasses
+# --------------------------------------------------------------------------- #
+class TestParseError:
+    def test_str_with_types(self) -> None:
+        pe = ParseError(field="x", error="bad", expected_type="int", actual_type="str")
+        assert str(pe) == "x: expected int, got str"
+
+    def test_str_without_types(self) -> None:
+        pe = ParseError(field="x", error="bad")
+        assert str(pe) == "x: bad"
+
+    def test_str_partial_types_falls_back_to_error(self) -> None:
+        # Only expected_type set -> the and-condition is False -> error branch.
+        pe = ParseError(field="x", error="bad", expected_type="int")
+        assert str(pe) == "x: bad"
+
+
+class TestParseErrorMetadata:
+    def test_defaults(self) -> None:
+        meta = ParseErrorMetadata()
+        assert meta.total_errors == 0
+        assert meta.last_error_type is None
+        assert meta.last_error_msg is None
+        assert meta.error_categories == {}
+
+    def test_independent_dict_instances(self) -> None:
+        a = ParseErrorMetadata()
+        b = ParseErrorMetadata()
+        a.error_categories["json"] = 1
+        assert b.error_categories == {}
+
+
+# --------------------------------------------------------------------------- #
+# Static helper edge branches
+# --------------------------------------------------------------------------- #
+class TestSafeGet:
+    def test_returns_value_at_path(self) -> None:
+        obj = {"a": {"b": {"c": 5}}}
+        assert ArtifactValidator.safe_get(obj, ["a", "b", "c"]) == 5
+
+    def test_non_dict_midway_returns_default(self) -> None:
+        obj = {"a": 7}
+        assert ArtifactValidator.safe_get(obj, ["a", "b"], default="d") == "d"
+
+    def test_missing_key_returns_default(self) -> None:
+        assert ArtifactValidator.safe_get({"a": {}}, ["a", "z"], default=None) is None
+
+    def test_empty_path_returns_obj(self) -> None:
+        obj = {"a": 1}
+        assert ArtifactValidator.safe_get(obj, []) is obj
+
+
+class TestTypeAndRangeChecks:
+    def test_type_check_ok_and_fail(self) -> None:
+        assert ArtifactValidator.type_check(1, int, "n") == (True, "")
+        ok, msg = ArtifactValidator.type_check("x", int, "n")
+        assert ok is False
+        assert "expected int" in msg and "got str" in msg
+
+    def test_enum_check(self) -> None:
+        assert ArtifactValidator.enum_check("a", {"a", "b"}, "f") == (True, "")
+        ok, msg = ArtifactValidator.enum_check("z", {"a", "b"}, "f")
+        assert ok is False
+        assert "not in allowed values" in msg
+
+    def test_range_check(self) -> None:
+        assert ArtifactValidator.range_check(5, 1, 10, "f") == (True, "")
+        ok, _ = ArtifactValidator.range_check(0, 1, 10, "f")
+        assert ok is False
+
+    def test_required_field_no_type(self) -> None:
+        assert ArtifactValidator.required_field({"f": 1}, "f") == (True, "")
+
+    def test_is_nonempty_string_whitespace(self) -> None:
+        assert ArtifactValidator.is_nonempty_string("   ") is False
+        assert ArtifactValidator.is_nonempty_string("x") is True
+        assert ArtifactValidator.is_nonempty_string(5) is False
+
+
+# --------------------------------------------------------------------------- #
+# Logging helpers + metrics_exporter wiring
+# --------------------------------------------------------------------------- #
+class TestLogParseError:
+    def test_jsondecodeerror_high_severity_and_export(self) -> None:
+        exporter = MagicMock()
+        try:
+            json.loads("{bad")
+        except json.JSONDecodeError as exc:
+            err = exc
+        ArtifactValidator.log_parse_error(
+            Path("/tmp/a.json"),
+            err,
+            context={"collector": "depdrift", "extra": "k"},
+            metrics_exporter=exporter,
+        )
+        exporter.export_failure.assert_called_once()
+        kw = exporter.export_failure.call_args.kwargs
+        assert kw["collector_name"] == "depdrift"
+        assert kw["severity"] == "HIGH"
+        assert kw["failure_type"] == "parse_error"
+        # collector key stripped from nested context, error_class added.
+        assert "collector" not in kw["context"]
+        assert kw["context"]["error_class"] == "JSONDecodeError"
+        assert kw["context"]["extra"] == "k"
+
+    def test_non_json_error_medium_no_context(self) -> None:
+        exporter = MagicMock()
+        ArtifactValidator.log_parse_error("x.json", ValueError("boom"), metrics_exporter=exporter)
+        kw = exporter.export_failure.call_args.kwargs
+        assert kw["severity"] == "MEDIUM"
+        assert kw["collector_name"] == "unknown"
+
+    def test_no_exporter_does_not_crash(self) -> None:
+        result = ArtifactValidator.log_parse_error("x.json", ValueError("boom"))
+        assert result is None
+
+    def test_export_exception_swallowed(self, caplog: pytest.LogCaptureFixture) -> None:
+        exporter = MagicMock()
+        exporter.export_failure.side_effect = RuntimeError("nope")
+        with caplog.at_level(logging.DEBUG):
+            ArtifactValidator.log_parse_error(
+                "x.json", ValueError("boom"), metrics_exporter=exporter
+            )
+        assert any("Failed to export parse error" in r.message for r in caplog.records)
+
+
+class TestLogStructureError:
+    def test_export_with_schema(self) -> None:
+        exporter = MagicMock()
+        ArtifactValidator.log_structure_error(
+            "x.json",
+            "bad shape",
+            expected_schema="request",
+            context={"collector": "c1"},
+            metrics_exporter=exporter,
+        )
+        kw = exporter.export_failure.call_args.kwargs
+        assert kw["artifact_type"] == "request"
+        assert kw["severity"] == "HIGH"
+        assert kw["context"]["expected_schema"] == "request"
+        assert "collector" not in kw["context"]
+
+    def test_export_schema_none_defaults_unknown(self) -> None:
+        exporter = MagicMock()
+        ArtifactValidator.log_structure_error("x.json", "bad", metrics_exporter=exporter)
+        assert exporter.export_failure.call_args.kwargs["artifact_type"] == "unknown"
+
+    def test_export_exception_swallowed(self, caplog: pytest.LogCaptureFixture) -> None:
+        exporter = MagicMock()
+        exporter.export_failure.side_effect = RuntimeError("nope")
+        with caplog.at_level(logging.DEBUG):
+            ArtifactValidator.log_structure_error("x.json", "bad", metrics_exporter=exporter)
+        assert any("Failed to export structure error" in r.message for r in caplog.records)
+
+    def test_no_exporter(self) -> None:
+        result = ArtifactValidator.log_structure_error("x.json", "bad")
+        assert result is None
+
+
+class TestLogIoError:
+    def test_permission_error_warning_medium(self, caplog: pytest.LogCaptureFixture) -> None:
+        exporter = MagicMock()
+        with caplog.at_level(logging.WARNING):
+            ArtifactValidator.log_io_error(
+                "x.json", PermissionError("denied"), metrics_exporter=exporter
+            )
+        kw = exporter.export_failure.call_args.kwargs
+        assert kw["severity"] == "MEDIUM"
+        assert kw["artifact_type"] == "file"
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_generic_error_debug_low(self) -> None:
+        exporter = MagicMock()
+        ArtifactValidator.log_io_error(
+            "x.json", OSError("oops"), context={"collector": "c"}, metrics_exporter=exporter
+        )
+        kw = exporter.export_failure.call_args.kwargs
+        assert kw["severity"] == "LOW"
+        assert kw["context"]["error_class"] == "OSError"
+        assert "collector" not in kw["context"]
+
+    def test_export_exception_swallowed(self, caplog: pytest.LogCaptureFixture) -> None:
+        exporter = MagicMock()
+        exporter.export_failure.side_effect = RuntimeError("nope")
+        with caplog.at_level(logging.DEBUG):
+            ArtifactValidator.log_io_error("x.json", OSError("oops"), metrics_exporter=exporter)
+        assert any("Failed to export IO error" in r.message for r in caplog.records)
+
+    def test_no_exporter(self) -> None:
+        result = ArtifactValidator.log_io_error("x.json", OSError("oops"))
+        assert result is None
+
+
+# --------------------------------------------------------------------------- #
+# ExecutionOutcomeValidator branches
+# --------------------------------------------------------------------------- #
+class TestExecutionOutcomeValidator:
+    def test_valid_with_attempt(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate(
+            {"task_id": "t1", "status": "executed", "attempt": 3}
+        )
+        assert ok is True and msg == ""
+
+    def test_root_not_dict(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate([])  # type: ignore[arg-type]
+        assert ok is False and "Root must be dict" in msg
+
+    def test_task_id_wrong_type(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate({"task_id": 5, "status": "executed"})
+        assert ok is False and "task_id" in msg
+
+    def test_task_id_empty(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate({"task_id": "  ", "status": "executed"})
+        assert ok is False and "non-empty" in msg
+
+    def test_missing_status(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate({"task_id": "t"})
+        assert ok is False and "status" in msg
+
+    def test_bad_status_value(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate({"task_id": "t", "status": "weird"})
+        assert ok is False and "not in allowed values" in msg
+
+    def test_attempt_wrong_type(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate(
+            {"task_id": "t", "status": "executed", "attempt": "1"}
+        )
+        assert ok is False and "attempt: expected int" in msg
+
+    def test_attempt_out_of_range(self) -> None:
+        ok, msg = ExecutionOutcomeValidator.validate(
+            {"task_id": "t", "status": "executed", "attempt": 0}
+        )
+        assert ok is False and "out of range" in msg
+
+    def test_attempt_bool_is_int_subclass_in_range(self) -> None:
+        # bool is an int subclass; True == 1 is within [1, 1000].
+        ok, _ = ExecutionOutcomeValidator.validate(
+            {"task_id": "t", "status": "executed", "attempt": True}
+        )
+        assert ok is True
+
+
+# --------------------------------------------------------------------------- #
+# RequestValidator branches
+# --------------------------------------------------------------------------- #
+class TestRequestValidator:
+    def test_valid(self) -> None:
+        assert RequestValidator.validate({"task": {}}) == (True, "")
+
+    def test_root_not_dict(self) -> None:
+        ok, msg = RequestValidator.validate("nope")  # type: ignore[arg-type]
+        assert ok is False and "Root must be dict" in msg
+
+    def test_missing_task(self) -> None:
+        ok, msg = RequestValidator.validate({})
+        assert ok is False and "task" in msg
+
+    def test_task_wrong_type(self) -> None:
+        ok, msg = RequestValidator.validate({"task": 1})
+        assert ok is False and "expected dict" in msg
+
+
+# --------------------------------------------------------------------------- #
+# ValidationHistoryValidator branches
+# --------------------------------------------------------------------------- #
+class TestValidationHistoryValidator:
+    def test_valid_minimal(self) -> None:
+        assert ValidationHistoryValidator.validate({"passed": True}) == (True, "")
+
+    def test_valid_with_errors_and_warnings(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate(
+            {
+                "passed": False,
+                "errors": [{"code": "E1"}, {}],
+                "warnings": ["w"],
+            }
+        )
+        assert ok is True and msg == ""
+
+    def test_root_not_dict(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate(3)  # type: ignore[arg-type]
+        assert ok is False and "Root must be dict" in msg
+
+    def test_missing_passed(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate({})
+        assert ok is False and "passed" in msg
+
+    def test_errors_not_list(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate({"passed": True, "errors": {}})
+        assert ok is False and "errors: expected list" in msg
+
+    def test_error_item_not_dict(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate({"passed": True, "errors": ["x"]})
+        assert ok is False and "errors[0]: expected dict" in msg
+
+    def test_error_code_empty(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate({"passed": True, "errors": [{"code": ""}]})
+        assert ok is False and "errors[0].code" in msg
+
+    def test_warnings_not_list(self) -> None:
+        ok, msg = ValidationHistoryValidator.validate({"passed": True, "warnings": "x"})
+        assert ok is False and "warnings: expected list" in msg
+
+
+# --------------------------------------------------------------------------- #
+# DependencyReportValidator branches
+# --------------------------------------------------------------------------- #
+class TestDependencyReportValidator:
+    def test_valid(self) -> None:
+        ok, msg = DependencyReportValidator.validate({"statuses": [{"severity": "info"}, {}]})
+        assert ok is True and msg == ""
+
+    def test_root_not_dict(self) -> None:
+        ok, msg = DependencyReportValidator.validate(0)  # type: ignore[arg-type]
+        assert ok is False and "Root must be dict" in msg
+
+    def test_missing_statuses(self) -> None:
+        ok, msg = DependencyReportValidator.validate({})
+        assert ok is False and "statuses" in msg
+
+    def test_status_item_not_dict(self) -> None:
+        ok, msg = DependencyReportValidator.validate({"statuses": ["x"]})
+        assert ok is False and "statuses[0]: expected dict" in msg
+
+    def test_severity_wrong_type(self) -> None:
+        ok, msg = DependencyReportValidator.validate({"statuses": [{"severity": 1}]})
+        assert ok is False and "severity: expected str" in msg
+
+    def test_severity_bad_value(self) -> None:
+        ok, msg = DependencyReportValidator.validate({"statuses": [{"severity": "critical"}]})
+        assert ok is False and "not in" in msg
+
+
+# --------------------------------------------------------------------------- #
+# LintItemValidator branches
+# --------------------------------------------------------------------------- #
+class TestLintItemValidator:
+    def test_valid_full(self) -> None:
+        ok, msg = LintItemValidator.validate(
+            {"filename": "f.py", "location": {"row": 5, "column": 2}}, 0
+        )
+        assert ok is True and msg == ""
+
+    def test_valid_no_column(self) -> None:
+        ok, _ = LintItemValidator.validate({"filename": "f.py", "location": {"row": 1}}, 0)
+        assert ok is True
+
+    def test_item_not_dict(self) -> None:
+        ok, msg = LintItemValidator.validate("x", 2)  # type: ignore[arg-type]
+        assert ok is False and "[2]: expected dict" in msg
+
+    def test_missing_filename(self) -> None:
+        ok, msg = LintItemValidator.validate({"location": {"row": 1}}, 0)
+        assert ok is False and "'filename'" in msg
+
+    def test_empty_filename(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "  ", "location": {"row": 1}}, 0)
+        assert ok is False and "filename: must be non-empty" in msg
+
+    def test_missing_location(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "f.py"}, 0)
+        assert ok is False and "'location'" in msg
+
+    def test_location_not_dict(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "f.py", "location": 5}, 0)
+        assert ok is False and "location: expected dict" in msg
+
+    def test_missing_row(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "f.py", "location": {}}, 0)
+        assert ok is False and "missing required field 'row'" in msg
+
+    def test_row_wrong_type(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "f.py", "location": {"row": "1"}}, 0)
+        assert ok is False and "row: expected int" in msg
+
+    def test_row_out_of_range(self) -> None:
+        ok, msg = LintItemValidator.validate({"filename": "f.py", "location": {"row": 0}}, 0)
+        assert ok is False and "out of range" in msg
+
+    def test_column_wrong_type(self) -> None:
+        ok, msg = LintItemValidator.validate(
+            {"filename": "f.py", "location": {"row": 1, "column": "0"}}, 0
+        )
+        assert ok is False and "column: expected int" in msg
+
+    def test_column_out_of_range(self) -> None:
+        ok, msg = LintItemValidator.validate(
+            {"filename": "f.py", "location": {"row": 1, "column": 1000001}}, 0
+        )
+        assert ok is False and "out of range" in msg

--- a/tests/unit/operations_center/__init__.py
+++ b/tests/unit/operations_center/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/audit_governance/__init__.py
+++ b/tests/unit/operations_center/audit_governance/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/audit_governance/test_models_cov.py
+++ b/tests/unit/operations_center/audit_governance/test_models_cov.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Coverage tests for operations_center.audit_governance.models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from operations_center.audit_dispatch.models import (
+    DispatchStatus,
+    ManagedAuditDispatchResult,
+)
+from operations_center.audit_governance import models as m
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_result(
+    status: DispatchStatus = DispatchStatus.COMPLETED,
+) -> ManagedAuditDispatchResult:
+    now = datetime.now(UTC)
+    return ManagedAuditDispatchResult(
+        repo_id="r",
+        audit_type="a",
+        run_id="run-1",
+        status=status,
+        started_at=now,
+        ended_at=now,
+        duration_seconds=1.0,
+    )
+
+
+def _request(**overrides) -> m.AuditGovernanceRequest:
+    base = dict(
+        repo_id="repo",
+        audit_type="lint",
+        requested_by="alice",
+        requested_reason="because",
+    )
+    base.update(overrides)
+    return m.AuditGovernanceRequest(**base)
+
+
+def _decision(decision: str = "approved", policy_results=None) -> m.AuditGovernanceDecision:
+    return m.AuditGovernanceDecision(
+        request_id="req-1",
+        repo_id="repo",
+        audit_type="lint",
+        decision=decision,
+        reasons=["ok"],
+        policy_results=policy_results or [],
+        requires_manual_approval=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level id helpers
+# ---------------------------------------------------------------------------
+
+
+def test_safe_id_replaces_unsafe_chars():
+    assert m._safe_id("a/b c.d") == "a_b_c_d"
+    assert m._safe_id("Keep-09_x") == "Keep-09_x"
+
+
+def test_make_request_id_format(monkeypatch):
+    fixed = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+    class _DT:
+        @staticmethod
+        def now(tz=None):
+            return fixed
+
+    monkeypatch.setattr(m, "datetime", _DT)
+    rid = m.make_request_id("my/repo", "type:x")
+    assert rid == "my_repo__type_x__20260102_030405"
+
+
+def test_make_request_id_public_wraps_private():
+    rid = m.make_request_id("repo", "lint")
+    assert rid.startswith("repo__lint__")
+    assert "/" not in rid
+
+
+# ---------------------------------------------------------------------------
+# PolicyResult
+# ---------------------------------------------------------------------------
+
+
+def test_policy_result_defaults_and_frozen():
+    pr = m.PolicyResult(policy_name="p", status="passed", reason="ok")
+    assert pr.details == ""
+    with pytest.raises(ValidationError):
+        pr.reason = "x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AuditGovernanceRequest validators + defaults
+# ---------------------------------------------------------------------------
+
+
+def test_request_defaults():
+    r = _request()
+    assert r.urgency == "normal"
+    assert r.metadata == {}
+    assert r.related_recommendation_ids == []
+    assert r.allow_if_recent_success is False
+    assert r.run_coverage_audit is False
+    assert "-" not in r.request_id  # uuid hyphens replaced with underscores
+    assert isinstance(r.created_at, datetime)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["repo_id", "audit_type", "requested_reason", "requested_by"],
+)
+def test_request_empty_field_rejected(field):
+    with pytest.raises(ValidationError):
+        _request(**{field: "   "})
+
+
+def test_request_frozen():
+    r = _request()
+    with pytest.raises(ValidationError):
+        r.repo_id = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# AuditGovernanceDecision properties
+# ---------------------------------------------------------------------------
+
+
+def test_decision_is_approved_and_denied():
+    assert _decision("approved").is_approved is True
+    assert _decision("approved").is_denied is False
+    assert _decision("denied").is_denied is True
+    assert _decision("denied").is_approved is False
+
+
+def test_decision_failed_and_warning_policies():
+    pr_pass = m.PolicyResult(policy_name="a", status="passed", reason="r")
+    pr_fail = m.PolicyResult(policy_name="b", status="failed", reason="r")
+    pr_warn = m.PolicyResult(policy_name="c", status="warning", reason="r")
+    d = _decision(policy_results=[pr_pass, pr_fail, pr_warn])
+    assert d.failed_policies == [pr_fail]
+    assert d.warning_policies == [pr_warn]
+
+
+def test_decision_default_id_present():
+    d = _decision()
+    assert isinstance(d.decision_id, str) and d.decision_id
+
+
+# ---------------------------------------------------------------------------
+# AuditManualApproval
+# ---------------------------------------------------------------------------
+
+
+def test_manual_approval_defaults():
+    ap = m.AuditManualApproval(decision_id="d", request_id="r", approved_by="bob")
+    assert ap.approval_notes == ""
+    assert isinstance(ap.approved_at, datetime)
+
+
+def test_manual_approval_empty_approver_rejected():
+    with pytest.raises(ValidationError):
+        m.AuditManualApproval(decision_id="d", request_id="r", approved_by="  ")
+
+
+# ---------------------------------------------------------------------------
+# AuditBudgetState
+# ---------------------------------------------------------------------------
+
+
+def _budget(max_runs=5, runs_used=0) -> m.AuditBudgetState:
+    now = datetime.now(UTC)
+    return m.AuditBudgetState(
+        repo_id="r",
+        audit_type="a",
+        period_start=now,
+        period_end=now + timedelta(days=7),
+        max_runs=max_runs,
+        runs_used=runs_used,
+    )
+
+
+def test_budget_runs_remaining_and_exhausted():
+    b = _budget(max_runs=3, runs_used=1)
+    assert b.runs_remaining == 2
+    assert b.is_exhausted is False
+
+    b2 = _budget(max_runs=3, runs_used=3)
+    assert b2.runs_remaining == 0
+    assert b2.is_exhausted is True
+
+    b3 = _budget(max_runs=3, runs_used=5)
+    assert b3.runs_remaining == 0  # clamped at 0
+    assert b3.is_exhausted is True
+
+
+# ---------------------------------------------------------------------------
+# AuditCooldownState
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_no_last_run():
+    c = m.AuditCooldownState(repo_id="r", audit_type="a", cooldown_seconds=100.0)
+    assert c.is_in_cooldown() is False
+    assert c.seconds_remaining() == 0.0
+
+
+def test_cooldown_active_and_expired():
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    c = m.AuditCooldownState(
+        repo_id="r",
+        audit_type="a",
+        cooldown_seconds=100.0,
+        last_run_at=now,
+    )
+    # 40s elapsed -> still in cooldown, 60s remaining
+    t_active = now + timedelta(seconds=40)
+    assert c.is_in_cooldown(now=t_active) is True
+    assert c.seconds_remaining(now=t_active) == pytest.approx(60.0)
+
+    # 150s elapsed -> expired, 0 remaining
+    t_expired = now + timedelta(seconds=150)
+    assert c.is_in_cooldown(now=t_expired) is False
+    assert c.seconds_remaining(now=t_expired) == 0.0
+
+
+def test_cooldown_defaults_now(monkeypatch):
+    # last_run far in the past relative to real now -> not in cooldown
+    past = datetime.now(UTC) - timedelta(seconds=10_000)
+    c = m.AuditCooldownState(repo_id="r", audit_type="a", cooldown_seconds=1.0, last_run_at=past)
+    assert c.is_in_cooldown() is False
+    assert c.seconds_remaining() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Config dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_budget_and_cooldown_config_defaults():
+    assert m.BudgetConfig().max_runs == 10
+    assert m.BudgetConfig().period_days == 7
+    assert m.CooldownConfig().cooldown_seconds == 3600.0
+
+
+def test_governance_config_defaults():
+    g = m.GovernanceConfig()
+    assert g.known_repos == []
+    assert g.known_audit_types == {}
+    assert isinstance(g.state_dir, Path)
+    assert g.require_mini_regression_for_urgency == ["low", "normal"]
+
+
+def test_governance_config_get_budget_default_and_specific():
+    custom = m.BudgetConfig(max_runs=99, period_days=1)
+    g = m.GovernanceConfig(budget_config={"repo": {"lint": custom}})
+    assert g.get_budget_config("repo", "lint") is custom
+    # missing repo -> default
+    assert g.get_budget_config("other", "lint") == m.BudgetConfig()
+    # missing audit_type within known repo -> default
+    assert g.get_budget_config("repo", "other") == m.BudgetConfig()
+
+
+def test_governance_config_get_cooldown_default_and_specific():
+    custom = m.CooldownConfig(cooldown_seconds=42.0)
+    g = m.GovernanceConfig(cooldown_config={"repo": {"lint": custom}})
+    assert g.get_cooldown_config("repo", "lint") is custom
+    assert g.get_cooldown_config("other", "lint") == m.CooldownConfig()
+    assert g.get_cooldown_config("repo", "other") == m.CooldownConfig()
+
+
+# ---------------------------------------------------------------------------
+# AuditGovernedRunResult
+# ---------------------------------------------------------------------------
+
+
+def test_governed_run_result_not_dispatched():
+    res = m.AuditGovernedRunResult(
+        request=_request(),
+        decision=_decision("denied"),
+        governance_status="denied",
+    )
+    assert res.was_dispatched is False
+    assert res.succeeded is False
+
+
+def test_governed_run_result_dispatched_success():
+    res = m.AuditGovernedRunResult(
+        request=_request(),
+        decision=_decision("approved"),
+        governance_status="approved_and_dispatched",
+        dispatch_result=_dispatch_result(DispatchStatus.COMPLETED),
+    )
+    assert res.was_dispatched is True
+    assert res.succeeded is True
+
+
+def test_governed_run_result_dispatched_but_failed_dispatch():
+    res = m.AuditGovernedRunResult(
+        request=_request(),
+        decision=_decision("approved"),
+        governance_status="approved_and_dispatched",
+        dispatch_result=_dispatch_result(DispatchStatus.FAILED),
+    )
+    assert res.was_dispatched is True
+    assert res.succeeded is False  # dispatch did not succeed
+
+
+def test_governed_run_result_status_mismatch():
+    # dispatch succeeded but governance_status not approved_and_dispatched
+    res = m.AuditGovernedRunResult(
+        request=_request(),
+        decision=_decision("approved"),
+        governance_status="dispatch_failed",
+        dispatch_result=_dispatch_result(DispatchStatus.COMPLETED),
+    )
+    assert res.succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# Report summaries
+# ---------------------------------------------------------------------------
+
+
+def test_summary_models_construct():
+    ds = m.DispatchResultSummary(run_id="r1", status="completed")
+    assert ds.failure_kind is None
+    bs = m.BudgetStateSummary(runs_used=1, max_runs=5, runs_remaining=4)
+    assert bs.period_start is None
+    cs = m.CooldownStateSummary(in_cooldown=False, cooldown_seconds=10.0, seconds_remaining=0.0)
+    assert cs.last_run_at is None
+    cv = m.CoverageAuditSummary()
+    assert cv.findings_total == 0
+    assert cv.sample_findings == []
+
+
+# ---------------------------------------------------------------------------
+# AuditGovernanceReport
+# ---------------------------------------------------------------------------
+
+
+def test_report_defaults_and_dispatched_run_id_none():
+    rep = m.AuditGovernanceReport(
+        request=_request(),
+        decision=_decision("denied"),
+        policy_results=[],
+    )
+    assert rep.schema_version == "1.2"
+    assert rep.governance_status == "denied"
+    assert rep.approval is None
+    assert rep.dispatched_run_id is None
+
+
+def test_report_dispatched_run_id_present():
+    rep = m.AuditGovernanceReport(
+        request=_request(),
+        decision=_decision("approved"),
+        policy_results=[],
+        dispatch_result_summary=m.DispatchResultSummary(run_id="abc", status="completed"),
+    )
+    assert rep.dispatched_run_id == "abc"
+
+
+def test_report_serializes_roundtrip():
+    rep = m.AuditGovernanceReport(
+        request=_request(),
+        decision=_decision("approved"),
+        policy_results=[m.PolicyResult(policy_name="p", status="passed", reason="r")],
+    )
+    dumped = rep.model_dump()
+    rebuilt = m.AuditGovernanceReport.model_validate(dumped)
+    assert rebuilt.request.repo_id == "repo"
+    assert rebuilt.policy_results[0].policy_name == "p"

--- a/tests/unit/operations_center/decision/__init__.py
+++ b/tests/unit/operations_center/decision/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/decision/test_service_cov.py
+++ b/tests/unit/operations_center/decision/test_service_cov.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from operations_center.decision import service as service_mod
+from operations_center.decision.artifact_writer import DecisionArtifactWriter
+from operations_center.decision.candidate_builder import CandidateSpec
+from operations_center.decision.models import (
+    CandidateRationale,
+    ProposalCandidate,
+    ProposalCandidatesArtifact,
+    ProposalOutline,
+)
+from operations_center.decision.service import (
+    _DEFAULT_ALLOWED_FAMILIES,
+    DecisionContext,
+    DecisionEngineService,
+    _build_rules,
+    new_decision_context,
+)
+from operations_center.tuning.models import TuningConfig
+
+NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRepo:
+    def __init__(self, name: str = "repo", path: str = "/tmp/repo") -> None:
+        self.name = name
+        self.path = Path(path)
+
+
+class _FakeInsightArtifact:
+    def __init__(self, run_id: str = "ins_1") -> None:
+        self.insights = ["insight-a", "insight-b"]
+        self.repo = _FakeRepo()
+        self.run_id = run_id
+
+
+class _FakeLoader:
+    """Loader stub returning a fixed insight artifact and prior decisions."""
+
+    def __init__(self, prior_decisions: list | None = None) -> None:
+        self.prior_decisions = prior_decisions or []
+        self.calls: list[dict] = []
+
+    def load(self, *, repo, insight_run_id, history_limit):
+        self.calls.append(
+            {"repo": repo, "insight_run_id": insight_run_id, "history_limit": history_limit}
+        )
+        return _FakeInsightArtifact(), self.prior_decisions
+
+
+class _Rule:
+    """Rule stub yielding pre-built CandidateSpecs regardless of insights."""
+
+    def __init__(self, specs: list[CandidateSpec]) -> None:
+        self._specs = specs
+
+    def evaluate(self, insights):
+        return list(self._specs)
+
+
+class _FakeSettings:
+    def __init__(self, min_remaining: int = 0) -> None:
+        self.min_remaining_exec_for_proposals = min_remaining
+
+
+class _FakeUsageStore:
+    def __init__(self, *, remaining: int = 100, min_remaining: int = 0) -> None:
+        self._remaining = remaining
+        self.settings = _FakeSettings(min_remaining)
+        self.suppression_calls: list[dict] = []
+
+    def remaining_exec_capacity(self, *, now):
+        return self._remaining
+
+    def record_proposal_budget_suppression(self, *, reason, now, evidence):
+        self.suppression_calls.append({"reason": reason, "now": now, "evidence": evidence})
+
+
+def _spec(family: str = "lint_fix", subject: str = "pkg/mod.py") -> CandidateSpec:
+    return CandidateSpec(
+        family=family,
+        subject=subject,
+        pattern_key="key",
+        evidence={"violation_count": 7},
+        matched_rules=[f"{family}_rule"],
+        proposal_outline=ProposalOutline(title_hint="t", summary_hint="s"),
+        confidence="medium",
+    )
+
+
+def _make_service(
+    *,
+    loader: _FakeLoader,
+    usage_store: _FakeUsageStore | None = None,
+    rules_specs: list[CandidateSpec] | None = None,
+    writer_root: Path | None = None,
+) -> DecisionEngineService:
+    svc = DecisionEngineService(
+        loader=loader,
+        usage_store=usage_store or _FakeUsageStore(),
+        artifact_writer=DecisionArtifactWriter(root=writer_root),
+    )
+    if rules_specs is not None:
+        svc.rules = [_Rule(rules_specs)]
+    return svc
+
+
+def _ctx(tmp_path: Path, **overrides) -> DecisionContext:
+    base = {
+        "repo_filter": "repo",
+        "insight_run_id": "ins_1",
+        "history_limit": 5,
+        "max_candidates": 5,
+        "cooldown_minutes": 120,
+        "run_id": "dec_test",
+        "generated_at": NOW,
+        "source_command": "oc decide",
+        "proposer_root": tmp_path / "proposer",
+        "feedback_root": tmp_path / "feedback",
+    }
+    base.update(overrides)
+    return DecisionContext(**base)
+
+
+# --------------------------------------------------------------------------- #
+# _build_rules
+# --------------------------------------------------------------------------- #
+
+
+def test_build_rules_without_tuning_returns_full_set():
+    rules = _build_rules(None)
+    assert len(rules) == 14
+
+
+def test_build_rules_with_tuning_overrides_applied():
+    tuning = TuningConfig(
+        updated_at=NOW,
+        overrides={
+            "observation_coverage": {"min_consecutive_runs": 9},
+            "test_visibility": {"min_consecutive_runs": 8},
+            "dependency_drift": {"min_consecutive_runs": 7},
+            "lint_fix": {"min_violations": 11},
+            "type_fix": {"min_errors": 12},
+        },
+    )
+    rules = _build_rules(tuning)
+    assert len(rules) == 14
+    # ObservationCoverageRule is first; confirm override threaded through.
+    assert rules[0].min_consecutive_runs == 9
+
+
+# --------------------------------------------------------------------------- #
+# new_decision_context
+# --------------------------------------------------------------------------- #
+
+
+def test_new_decision_context_defaults_allowed_families(monkeypatch):
+    monkeypatch.setattr(service_mod, "datetime", _frozen_datetime(NOW), raising=True)
+    ctx = new_decision_context(
+        repo_filter=None,
+        insight_run_id=None,
+        history_limit=3,
+        max_candidates=2,
+        cooldown_minutes=60,
+        source_command="cmd",
+    )
+    assert ctx.allowed_families == _DEFAULT_ALLOWED_FAMILIES
+    assert ctx.dry_run is False
+    assert ctx.run_id.startswith("dec_")
+    assert len(ctx.run_id) <= 31
+
+
+def test_new_decision_context_explicit_allowed_families(monkeypatch):
+    monkeypatch.setattr(service_mod, "datetime", _frozen_datetime(NOW), raising=True)
+    custom = frozenset({"lint_fix"})
+    ctx = new_decision_context(
+        repo_filter="r",
+        insight_run_id="i",
+        history_limit=1,
+        max_candidates=1,
+        cooldown_minutes=1,
+        source_command="cmd",
+        dry_run=True,
+        allowed_families=custom,
+    )
+    assert ctx.allowed_families == custom
+    assert ctx.dry_run is True
+
+
+def _frozen_datetime(value: datetime):
+    class _DT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return value
+
+    return _DT
+
+
+# --------------------------------------------------------------------------- #
+# decide() happy path + branches
+# --------------------------------------------------------------------------- #
+
+
+def test_decide_emits_allowed_family_candidate(tmp_path):
+    loader = _FakeLoader()
+    svc = _make_service(
+        loader=loader,
+        rules_specs=[_spec(family="lint_fix")],
+        writer_root=tmp_path / "out",
+    )
+    artifact, paths = svc.decide(_ctx(tmp_path))
+
+    assert isinstance(artifact, ProposalCandidatesArtifact)
+    assert len(artifact.candidates) == 1
+    assert artifact.candidates[0].family == "lint_fix"
+    assert artifact.suppressed == []
+    # Loader received context-derived params.
+    assert loader.calls[0]["repo"] == "repo"
+    # Writer produced json + md files that actually exist.
+    assert len(paths) == 2
+    for p in paths:
+        assert Path(p).exists()
+
+
+def test_decide_suppresses_family_not_allowed(tmp_path):
+    loader = _FakeLoader()
+    # ci_pattern is in ALL_FAMILIES but not in the default allowed set.
+    svc = _make_service(
+        loader=loader,
+        rules_specs=[_spec(family="ci_pattern", subject="x")],
+        writer_root=tmp_path / "out",
+    )
+    artifact, _ = svc.decide(_ctx(tmp_path))
+    assert artifact.candidates == []
+    reasons = {s.reason for s in artifact.suppressed}
+    assert "family_deferred_initial_gating" in reasons
+
+
+def test_decide_budget_too_low_suppresses_all(tmp_path):
+    loader = _FakeLoader()
+    usage = _FakeUsageStore(remaining=1, min_remaining=10)
+    svc = _make_service(
+        loader=loader,
+        usage_store=usage,
+        rules_specs=[_spec(family="lint_fix")],
+        writer_root=tmp_path / "out",
+    )
+    artifact, _ = svc.decide(_ctx(tmp_path))
+    assert artifact.candidates == []
+    assert any(s.reason == "proposal_budget_too_low" for s in artifact.suppressed)
+    assert usage.suppression_calls and usage.suppression_calls[0]["reason"] == (
+        "proposal_budget_too_low"
+    )
+
+
+def test_decide_defaults_to_real_usage_store(monkeypatch, tmp_path):
+    """When no usage_store is injected, decide() instantiates UsageStore()."""
+    loader = _FakeLoader()
+    instances = []
+
+    class _Stub:
+        def __init__(self):
+            instances.append(self)
+            self.settings = _FakeSettings(min_remaining=0)
+
+        def remaining_exec_capacity(self, *, now):
+            return 50
+
+    monkeypatch.setattr(service_mod, "UsageStore", _Stub)
+    svc = DecisionEngineService(
+        loader=loader, artifact_writer=DecisionArtifactWriter(root=tmp_path)
+    )
+    svc.rules = [_Rule([_spec(family="lint_fix")])]
+    svc.decide(_ctx(tmp_path))
+    assert len(instances) == 1
+
+
+def test_decide_velocity_cap_suppresses_all(tmp_path):
+    loader = _FakeLoader()
+    proposer = tmp_path / "proposer"
+    run_dir = proposer / "p1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "proposal_results.json").write_text(
+        json.dumps(
+            {
+                "dry_run": False,
+                "generated_at": NOW.isoformat(),
+                "created": [{"dedup_key": "a"}, {"dedup_key": "b"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    svc = _make_service(
+        loader=loader,
+        rules_specs=[_spec(family="lint_fix")],
+        writer_root=tmp_path / "out",
+    )
+    ctx = _ctx(tmp_path, proposer_root=proposer, max_proposals_per_24h=2)
+    artifact, _ = svc.decide(ctx)
+    assert artifact.candidates == []
+    assert any(s.reason == "velocity_cap_reached" for s in artifact.suppressed)
+
+
+def test_decide_stale_open_suppression(tmp_path):
+    # Prior decision artifact with a candidate that will expire.
+    proposed_at = NOW - timedelta(days=100)
+    candidate = _emit_candidate(dedup_key="candidate|lint_fix|pkg/mod.py|key")
+    prior = _prior_artifact(generated_at=proposed_at, candidates=[candidate])
+    loader = _FakeLoader(prior_decisions=[prior])
+
+    # proposer artifact maps the dedup_key to a plane issue id (so it was created).
+    proposer = tmp_path / "proposer"
+    rd = proposer / "p1"
+    rd.mkdir(parents=True)
+    (rd / "proposal_results.json").write_text(
+        json.dumps(
+            {
+                "created": [
+                    {"dedup_key": "candidate|lint_fix|pkg/mod.py|key", "plane_issue_id": "ISS-1"}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    # feedback root has no resolution => still open => stale.
+    feedback = tmp_path / "feedback"
+    feedback.mkdir()
+
+    svc = _make_service(
+        loader=loader,
+        rules_specs=[_spec(family="lint_fix")],
+        writer_root=tmp_path / "out",
+    )
+    ctx = _ctx(tmp_path, proposer_root=proposer, feedback_root=feedback)
+    artifact, _ = svc.decide(ctx)
+    assert any(s.reason == "proposal_stale_open" for s in artifact.suppressed)
+    assert artifact.candidates == []
+
+
+def test_decide_stale_keys_present_but_spec_not_stale(tmp_path):
+    """stale_keys non-empty, but the live spec's dedup_key differs -> survives."""
+    proposed_at = NOW - timedelta(days=100)
+    stale_cand = _emit_candidate(dedup_key="candidate|type_fix|other.py|key")
+    prior = _prior_artifact(generated_at=proposed_at, candidates=[stale_cand])
+    loader = _FakeLoader(prior_decisions=[prior])
+
+    proposer = tmp_path / "proposer"
+    rd = proposer / "p1"
+    rd.mkdir(parents=True)
+    (rd / "proposal_results.json").write_text(
+        json.dumps(
+            {"created": [{"dedup_key": "candidate|type_fix|other.py|key", "plane_issue_id": "X"}]}
+        ),
+        encoding="utf-8",
+    )
+    feedback = tmp_path / "feedback"
+    feedback.mkdir()
+
+    svc = _make_service(
+        loader=loader,
+        rules_specs=[_spec(family="lint_fix", subject="pkg/mod.py")],
+        writer_root=tmp_path / "out",
+    )
+    ctx = _ctx(tmp_path, proposer_root=proposer, feedback_root=feedback)
+    artifact, _ = svc.decide(ctx)
+    # The lint_fix candidate survives staleness gate and is emitted.
+    assert any(c.family == "lint_fix" for c in artifact.candidates)
+
+
+# --------------------------------------------------------------------------- #
+# _count_proposals_last_24h
+# --------------------------------------------------------------------------- #
+
+
+def test_count_proposals_no_root(tmp_path):
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=tmp_path / "missing")
+    assert svc._count_proposals_last_24h(ctx) == 0
+
+
+def test_count_proposals_skips_bad_and_dry_and_old(tmp_path):
+    proposer = tmp_path / "proposer"
+    proposer.mkdir()
+
+    def _wr(name, payload):
+        d = proposer / name
+        d.mkdir()
+        (d / "proposal_results.json").write_text(
+            payload if isinstance(payload, str) else json.dumps(payload),
+            encoding="utf-8",
+        )
+
+    _wr("bad", "{ not json")  # ValueError -> skipped
+    _wr("dry", {"dry_run": True, "generated_at": NOW.isoformat(), "created": [{}]})
+    _wr("badts", {"generated_at": "not-a-date", "created": [{}]})
+    _wr(
+        "old",
+        {"generated_at": (NOW - timedelta(hours=48)).isoformat(), "created": [{}, {}]},
+    )
+    _wr(
+        "good",
+        {"generated_at": NOW.isoformat(), "created": [{}, {}, {}]},
+    )
+    _wr("non_list_created", {"generated_at": NOW.isoformat(), "created": "nope"})
+
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=proposer)
+    assert svc._count_proposals_last_24h(ctx) == 3
+
+
+# --------------------------------------------------------------------------- #
+# _stale_open_dedup_keys
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_keys_empty_when_no_prior(tmp_path):
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path)
+    assert svc._stale_open_dedup_keys(ctx, []) == set()
+
+
+def test_stale_keys_not_expired_returns_empty(tmp_path):
+    cand = _emit_candidate(dedup_key="dk", expires_after_runs=5)
+    prior = _prior_artifact(generated_at=NOW, candidates=[cand])
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path)
+    # generated_at == proposed_at => expiry in future => not stale.
+    assert svc._stale_open_dedup_keys(ctx, [prior]) == set()
+
+
+def test_stale_keys_expired_but_no_issue_id(tmp_path):
+    cand = _emit_candidate(dedup_key="dk", expires_after_runs=1)
+    prior = _prior_artifact(generated_at=NOW - timedelta(days=100), candidates=[cand])
+    # proposer root absent => no issue mapping => skipped (never created in Plane).
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=tmp_path / "missing", feedback_root=tmp_path / "fbmissing")
+    assert svc._stale_open_dedup_keys(ctx, [prior]) == set()
+
+
+def test_stale_keys_resolved_issue_excluded(tmp_path):
+    cand = _emit_candidate(dedup_key="dk", expires_after_runs=1)
+    prior = _prior_artifact(generated_at=NOW - timedelta(days=100), candidates=[cand])
+
+    proposer = tmp_path / "proposer"
+    rd = proposer / "p1"
+    rd.mkdir(parents=True)
+    (rd / "proposal_results.json").write_text(
+        json.dumps({"created": [{"dedup_key": "dk", "plane_issue_id": "ISS-9"}]}),
+        encoding="utf-8",
+    )
+    feedback = tmp_path / "feedback"
+    feedback.mkdir()
+    (feedback / "fb.json").write_text(
+        json.dumps({"task_id": "ISS-9", "outcome": "merged"}), encoding="utf-8"
+    )
+
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=proposer, feedback_root=feedback)
+    # Resolved => excluded from stale.
+    assert svc._stale_open_dedup_keys(ctx, [prior]) == set()
+
+
+def test_stale_keys_handles_corrupt_files(tmp_path):
+    cand = _emit_candidate(dedup_key="dk", expires_after_runs=1)
+    prior = _prior_artifact(generated_at=NOW - timedelta(days=100), candidates=[cand])
+
+    proposer = tmp_path / "proposer"
+    rd = proposer / "p1"
+    rd.mkdir(parents=True)
+    # bad json in proposer
+    (rd / "proposal_results.json").write_text("{bad", encoding="utf-8")
+    rd2 = proposer / "p2"
+    rd2.mkdir()
+    # created not a list -> skipped
+    (rd2 / "proposal_results.json").write_text(json.dumps({"created": "no"}), encoding="utf-8")
+    rd3 = proposer / "p3"
+    rd3.mkdir()
+    # created item not a dict, plus missing fields
+    (rd3 / "proposal_results.json").write_text(
+        json.dumps({"created": ["str", {"dedup_key": "", "plane_issue_id": ""}]}),
+        encoding="utf-8",
+    )
+
+    feedback = tmp_path / "feedback"
+    feedback.mkdir()
+    (feedback / "bad.json").write_text("{bad", encoding="utf-8")  # corrupt -> skipped
+    (feedback / "incomplete.json").write_text(
+        json.dumps({"task_id": "", "outcome": "merged"}), encoding="utf-8"
+    )
+
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=proposer, feedback_root=feedback)
+    # No usable issue mapping => not stale despite expiry.
+    assert svc._stale_open_dedup_keys(ctx, [prior]) == set()
+
+
+def test_stale_keys_actually_stale(tmp_path):
+    cand = _emit_candidate(dedup_key="dk", expires_after_runs=1)
+    prior = _prior_artifact(generated_at=NOW - timedelta(days=100), candidates=[cand])
+
+    proposer = tmp_path / "proposer"
+    rd = proposer / "p1"
+    rd.mkdir(parents=True)
+    (rd / "proposal_results.json").write_text(
+        json.dumps({"created": [{"dedup_key": "dk", "plane_issue_id": "ISS-9"}]}),
+        encoding="utf-8",
+    )
+    feedback = tmp_path / "feedback"
+    feedback.mkdir()
+    # unresolved outcome
+    (feedback / "fb.json").write_text(
+        json.dumps({"task_id": "ISS-9", "outcome": "in_review"}), encoding="utf-8"
+    )
+
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=proposer, feedback_root=feedback)
+    assert svc._stale_open_dedup_keys(ctx, [prior]) == {"dk"}
+
+
+def test_stale_keys_dedup_first_artifact_wins(tmp_path):
+    """A dedup_key seen twice across artifacts keeps the first artifact's data."""
+    c1 = _emit_candidate(dedup_key="dk", expires_after_runs=1)
+    c2 = _emit_candidate(dedup_key="dk", expires_after_runs=99)
+    a1 = _prior_artifact(generated_at=NOW - timedelta(days=100), candidates=[c1])
+    a2 = _prior_artifact(generated_at=NOW, candidates=[c2])
+    svc = _make_service(loader=_FakeLoader(), rules_specs=[])
+    ctx = _ctx(tmp_path, proposer_root=tmp_path / "missing")
+    # First artifact (expired, no issue mapping) -> not stale (no issue), but the
+    # key is only registered once; assert no crash and empty result.
+    assert svc._stale_open_dedup_keys(ctx, [a1, a2]) == set()
+
+
+# --------------------------------------------------------------------------- #
+# helpers building real pydantic models
+# --------------------------------------------------------------------------- #
+
+
+def _emit_candidate(*, dedup_key: str, expires_after_runs: int = 5) -> ProposalCandidate:
+    return ProposalCandidate(
+        candidate_id="c1",
+        dedup_key=dedup_key,
+        family="lint_fix",
+        subject="pkg/mod.py",
+        status="emit",
+        expires_after_runs=expires_after_runs,
+        rationale=CandidateRationale(),
+        proposal_outline=ProposalOutline(title_hint="t", summary_hint="s"),
+    )
+
+
+def _prior_artifact(*, generated_at: datetime, candidates: list) -> ProposalCandidatesArtifact:
+    return ProposalCandidatesArtifact(
+        run_id="prev",
+        generated_at=generated_at,
+        source_command="oc decide",
+        repo={"name": "repo", "path": "/tmp/repo"},
+        source_insight_run_id="ins_0",
+        candidates=candidates,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/operations_center/execution/__init__.py
+++ b/tests/unit/operations_center/execution/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/execution/test_ci_coordinator_cov.py
+++ b/tests/unit/operations_center/execution/test_ci_coordinator_cov.py
@@ -1,0 +1,620 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.contracts.ci import (
+    ContinuousImprovementSpec,
+    EvaluationScore,
+    EvaluationSpec,
+    ImprovementLineage,
+    ImprovementStrategy,
+    RefinementPolicy,
+    ScoringMetric,
+)
+from operations_center.contracts.enums import (
+    EnforcedGuardrail,
+    EvaluationCommandSource,
+    EvaluationOutcome,
+    LineageBranchReason,
+    RefinementDecision,
+    RefinementStatus,
+)
+from operations_center.execution import ci_coordinator
+from operations_center.execution.ci_coordinator import (
+    CiCoordinator,
+    CiRunContext,
+    ExecutionCallable,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(
+    *,
+    max_attempts: int = 3,
+    accept_on_neutral: bool = False,
+    vary_strategy_on_retry: bool = False,
+    failure_penalty: int = 0,
+    evaluation_command: str | None = None,
+    evaluation_command_hint: str | None = None,
+    variation_hint: str | None = None,
+    guardrails=None,
+) -> ContinuousImprovementSpec:
+    strategy = ImprovementStrategy(
+        principle="reduce false retries",
+        constraints=["fail_closed"],
+        variation_hint=variation_hint,
+    )
+    evaluation = EvaluationSpec(
+        baseline_description="baseline",
+        primary_scoring=ScoringMetric(metric="false_retry_rate"),
+        guardrails=guardrails if guardrails is not None else [],
+        evaluation_command=evaluation_command,
+        evaluation_command_hint=evaluation_command_hint,
+    )
+    refinement = RefinementPolicy(
+        max_attempts=max_attempts,
+        accept_on_neutral=accept_on_neutral,
+        vary_strategy_on_retry=vary_strategy_on_retry,
+        failure_penalty=failure_penalty,
+    )
+    return ContinuousImprovementSpec(
+        strategy=strategy,
+        evaluation=evaluation,
+        refinement=refinement,
+    )
+
+
+def _make_ctx(spec: ContinuousImprovementSpec, repo_path: Path, **kw) -> CiRunContext:
+    return CiRunContext(
+        proposal_id=kw.get("proposal_id", "prop-1"),
+        repo_path=repo_path,
+        lineage_id=kw.get("lineage_id", "lin-1"),
+        spec=spec,
+        validation_commands=kw.get("validation_commands", ["pytest"]),
+        base_commit_sha=kw.get("base_commit_sha", "abc123"),
+        eval_output_dir=kw.get("eval_output_dir", None),
+        timeout_seconds=kw.get("timeout_seconds", 120),
+    )
+
+
+def _score(
+    outcome: EvaluationOutcome,
+    *,
+    guardrails_failed=None,
+    delta: float | None = -1.0,
+) -> EvaluationScore:
+    return EvaluationScore(
+        primary_metric_delta=delta,
+        guardrails_failed=guardrails_failed or [],
+        outcome=outcome,
+    )
+
+
+def _make_coordinator(eval_scores):
+    """Build a coordinator with mocked evaluator (returns scores in order) and store."""
+    evaluator = MagicMock()
+    if isinstance(eval_scores, list):
+        evaluator.evaluate.side_effect = eval_scores
+    else:
+        evaluator.evaluate.return_value = eval_scores
+
+    store = MagicMock()
+    store.get_state.return_value = None  # force init path
+    coord = CiCoordinator(evaluator=evaluator, store=store)
+    return coord, evaluator, store
+
+
+def _execute_stub(success: bool = True):
+    calls = []
+
+    def _execute(*, attempt_number, strategy, proposal_id):
+        calls.append((attempt_number, strategy, proposal_id))
+        return (f"run-{attempt_number}", [f"file-{attempt_number}.py"], success)
+
+    _execute.calls = calls
+    return _execute
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+def test_execution_callable_runtime_checkable():
+    assert isinstance(_execute_stub(), ExecutionCallable)
+
+
+# ---------------------------------------------------------------------------
+# run() — happy path: ACCEPT on first attempt
+# ---------------------------------------------------------------------------
+
+
+def test_run_accept_first_attempt(repo):
+    spec = _make_spec(max_attempts=3)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.IMPROVED))
+    ctx = _make_ctx(spec, repo)
+    execute = _execute_stub()
+
+    result = coord.run(ctx, execute)
+
+    assert result.final_status == RefinementStatus.ACCEPTED
+    assert result.accepted_attempt_number == 1
+    assert result.total_attempts == 1
+    assert result.last_decision == RefinementDecision.ACCEPT
+    assert result.last_score.outcome == EvaluationOutcome.IMPROVED
+    # only one attempt dispatched
+    assert len(execute.calls) == 1
+    # persistence happened
+    store.save_lineage = store.save_lineage  # noqa
+    store.upsert_index_entry.assert_called_once()
+    store.upsert_state.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# run() — ABANDON on hard guardrail failure
+# ---------------------------------------------------------------------------
+
+
+def test_run_abandon_on_guardrails_failed(repo):
+    spec = _make_spec(max_attempts=3)
+    score = _score(
+        EvaluationOutcome.REGRESSED,
+        guardrails_failed=[EnforcedGuardrail.CUSTODIAN_CLEAN],
+    )
+    coord, evaluator, store = _make_coordinator(score)
+    ctx = _make_ctx(spec, repo)
+    execute = _execute_stub()
+
+    result = coord.run(ctx, execute)
+
+    assert result.final_status == RefinementStatus.ABANDONED
+    assert result.last_decision == RefinementDecision.ABANDON
+    assert result.accepted_attempt_number is None
+    assert len(execute.calls) == 1
+
+
+def test_run_abandon_on_guardrail_violated_outcome(repo):
+    spec = _make_spec(max_attempts=3)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.GUARDRAIL_VIOLATED))
+    ctx = _make_ctx(spec, repo)
+    result = coord.run(ctx, _execute_stub())
+    assert result.last_decision == RefinementDecision.ABANDON
+    assert result.final_status == RefinementStatus.ABANDONED
+
+
+# ---------------------------------------------------------------------------
+# run() — NEUTRAL accept-on-neutral policy
+# ---------------------------------------------------------------------------
+
+
+def test_run_neutral_accepted_per_policy(repo):
+    spec = _make_spec(max_attempts=3, accept_on_neutral=True)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.NEUTRAL))
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+    assert result.last_decision == RefinementDecision.ACCEPT
+    assert result.final_status == RefinementStatus.ACCEPTED
+
+
+# ---------------------------------------------------------------------------
+# run() — INCONCLUSIVE escalation
+# ---------------------------------------------------------------------------
+
+
+def test_run_inconclusive_escalates_with_budget(repo):
+    spec = _make_spec(max_attempts=3)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.INCONCLUSIVE))
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+    assert result.last_decision == RefinementDecision.ESCALATE
+    assert result.final_status == RefinementStatus.ESCALATED
+    # only one attempt — escalate breaks the loop
+    assert result.total_attempts == 1
+
+
+def test_run_inconclusive_escalates_at_budget_exhausted(repo):
+    # max_attempts=1: remaining = 1 - 1 = 0 → "Inconclusive after budget exhausted"
+    spec = _make_spec(max_attempts=1)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.INCONCLUSIVE))
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+    assert result.last_decision == RefinementDecision.ESCALATE
+
+
+# ---------------------------------------------------------------------------
+# run() — RETRY then ACCEPT (multi-attempt loop)
+# ---------------------------------------------------------------------------
+
+
+def test_run_retry_then_accept(repo):
+    spec = _make_spec(max_attempts=3)
+    scores = [
+        _score(EvaluationOutcome.REGRESSED),  # retry (remaining=3-1-0=2)
+        _score(EvaluationOutcome.IMPROVED),  # accept
+    ]
+    coord, evaluator, store = _make_coordinator(scores)
+    execute = _execute_stub()
+    result = coord.run(_make_ctx(spec, repo), execute)
+
+    assert result.total_attempts == 2
+    assert result.accepted_attempt_number == 2
+    assert result.final_status == RefinementStatus.ACCEPTED
+    assert len(execute.calls) == 2
+    # second attempt is a retry branch
+    assert evaluator.evaluate.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# run() — budget exhausted via repeated regression
+# ---------------------------------------------------------------------------
+
+
+def test_run_budget_exhausted_via_regression(repo):
+    spec = _make_spec(max_attempts=2)
+    # attempt1: regressed → remaining = 2-1-0=1 → retry
+    # attempt2: regressed → remaining = 2-2-0=0 → abandon (budget exhausted)
+    scores = [
+        _score(EvaluationOutcome.REGRESSED),
+        _score(EvaluationOutcome.REGRESSED),
+    ]
+    coord, evaluator, store = _make_coordinator(scores)
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+
+    assert result.total_attempts == 2
+    assert result.last_decision == RefinementDecision.ABANDON
+    assert result.final_status == RefinementStatus.ABANDONED
+
+
+def test_run_loop_terminates_on_max_attempts_without_break(repo):
+    # failure_penalty large enough that decision is RETRY but loop ends on max_attempts.
+    # max_attempts=2, failure_penalty=0 → attempt1 retry, attempt2 abandon.
+    # Use neutral (not accepted) to keep retrying. attempt1: NEUTRAL not accept →
+    # remaining = 2-1-0 = 1 → retry; attempt2: remaining = 2-2-0 = 0 → abandon.
+    spec = _make_spec(max_attempts=2, accept_on_neutral=False)
+    scores = [
+        _score(EvaluationOutcome.NEUTRAL),
+        _score(EvaluationOutcome.NEUTRAL),
+    ]
+    coord, evaluator, store = _make_coordinator(scores)
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+    assert result.total_attempts == 2
+    assert result.final_status == RefinementStatus.ABANDONED
+
+
+# ---------------------------------------------------------------------------
+# eval_output_dir wiring
+# ---------------------------------------------------------------------------
+
+
+def test_run_passes_eval_output_path(repo):
+    spec = _make_spec(max_attempts=1)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.IMPROVED))
+    out_dir = repo / "evals"
+    ctx = _make_ctx(spec, repo, eval_output_dir=out_dir)
+    coord.run(ctx, _execute_stub())
+
+    eval_ctx = evaluator.evaluate.call_args.args[1]
+    assert eval_ctx.eval_output_path == out_dir / "attempt-1" / "eval.json"
+
+
+def test_run_no_eval_output_dir_yields_none(repo):
+    spec = _make_spec(max_attempts=1)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.IMPROVED))
+    coord.run(_make_ctx(spec, repo), _execute_stub())
+    eval_ctx = evaluator.evaluate.call_args.args[1]
+    assert eval_ctx.eval_output_path is None
+
+
+# ---------------------------------------------------------------------------
+# Resume from existing state / lineage
+# ---------------------------------------------------------------------------
+
+
+def test_run_resumes_existing_lineage_at_budget(repo, monkeypatch):
+    spec = _make_spec(max_attempts=1)
+    # Existing lineage already at current_attempt_number == max_attempts → loop skipped.
+    existing_lineage = ImprovementLineage(
+        lineage_id="lin-1",
+        status=RefinementStatus.IN_PROGRESS,
+        current_attempt_number=1,
+    )
+    monkeypatch.setattr(
+        ci_coordinator.CiStore,
+        "load_lineage",
+        staticmethod(lambda p: existing_lineage),
+    )
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.IMPROVED))
+    # existing state present too
+    store.get_state.return_value = MagicMock(resolved_evaluation_command="cmd")
+    result = coord.run(_make_ctx(spec, repo), _execute_stub())
+
+    # No attempt dispatched, no evaluation
+    evaluator.evaluate.assert_not_called()
+    assert result.total_attempts == 1
+    assert result.last_decision is None
+    assert result.last_score is None
+    assert result.final_status == RefinementStatus.IN_PROGRESS
+
+
+def test_load_or_init_lineage_initialises_when_absent(repo, monkeypatch):
+    monkeypatch.setattr(ci_coordinator.CiStore, "load_lineage", staticmethod(lambda p: None))
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    ctx = _make_ctx(_make_spec(), repo)
+    lineage = coord._load_or_init_lineage(ctx)
+    assert lineage.lineage_id == "lin-1"
+    assert lineage.status == RefinementStatus.NOT_STARTED
+
+
+def test_load_or_init_state_returns_existing(repo):
+    sentinel = object()
+    store = MagicMock()
+    store.get_state.return_value = sentinel
+    coord = CiCoordinator(evaluator=MagicMock(), store=store)
+    ctx = _make_ctx(_make_spec(), repo)
+    lineage = ImprovementLineage(lineage_id="lin-1")
+    assert coord._load_or_init_state(ctx, lineage) is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Strategy selection
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_for_attempt_first_attempt_uses_spec_strategy():
+    spec = _make_spec()
+    lineage = ImprovementLineage(lineage_id="x")
+    s = CiCoordinator._strategy_for_attempt(spec, lineage, 1)
+    assert s is spec.strategy
+
+
+def test_strategy_for_attempt_no_vary_returns_spec_strategy():
+    spec = _make_spec(vary_strategy_on_retry=False)
+    lineage = ImprovementLineage(lineage_id="x")
+    s = CiCoordinator._strategy_for_attempt(spec, lineage, 2)
+    assert s is spec.strategy
+
+
+def test_strategy_for_attempt_vary_builds_new_strategy():
+    spec = _make_spec(vary_strategy_on_retry=True, variation_hint="try harder")
+    lineage = ImprovementLineage(lineage_id="x")
+    s = CiCoordinator._strategy_for_attempt(spec, lineage, 2)
+    assert s is not spec.strategy
+    assert s.principle == spec.strategy.principle
+    assert s.variation_hint == "try harder"
+    assert "fail_closed" in s.constraints
+
+
+def test_run_uses_retry_branch_reason_with_vary(repo):
+    spec = _make_spec(max_attempts=2, vary_strategy_on_retry=True)
+    scores = [
+        _score(EvaluationOutcome.REGRESSED),
+        _score(EvaluationOutcome.IMPROVED),
+    ]
+    coord, evaluator, store = _make_coordinator(scores)
+    execute = _execute_stub()
+    coord.run(_make_ctx(spec, repo), execute)
+    # attempt 1 used spec.strategy, attempt 2 a varied copy
+    assert execute.calls[0][1] is spec.strategy
+    assert execute.calls[1][1] is not spec.strategy
+
+
+# ---------------------------------------------------------------------------
+# _decide unit coverage
+# ---------------------------------------------------------------------------
+
+
+def _policy(**kw):
+    return RefinementPolicy(**kw)
+
+
+def test_decide_guardrails_failed():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    score = _score(
+        EvaluationOutcome.IMPROVED,
+        guardrails_failed=[EnforcedGuardrail.REGRESSION_FIXTURES_PASS],
+    )
+    decision, reason = coord._decide(score=score, policy=_policy(), attempts_used=1)
+    assert decision == RefinementDecision.ABANDON
+    assert "regression_fixtures_pass" in reason
+
+
+def test_decide_improved():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    score = _score(EvaluationOutcome.IMPROVED, delta=-2.5)
+    decision, reason = coord._decide(score=score, policy=_policy(), attempts_used=1)
+    assert decision == RefinementDecision.ACCEPT
+    assert "-2.5" in reason
+
+
+def test_decide_neutral_no_accept_retry():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    score = _score(EvaluationOutcome.NEUTRAL)
+    decision, reason = coord._decide(
+        score=score, policy=_policy(max_attempts=3, accept_on_neutral=False), attempts_used=1
+    )
+    assert decision == RefinementDecision.RETRY
+    assert "remaining" in reason
+
+
+def test_decide_regressed_retry_and_abandon():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    score = _score(EvaluationOutcome.REGRESSED)
+    # remaining = 3 - 1 - 0 = 2 → retry
+    d1, _ = coord._decide(score=score, policy=_policy(max_attempts=3), attempts_used=1)
+    assert d1 == RefinementDecision.RETRY
+    # remaining = 1 - 1 - 0 = 0 → abandon
+    d2, r2 = coord._decide(score=score, policy=_policy(max_attempts=1), attempts_used=1)
+    assert d2 == RefinementDecision.ABANDON
+    assert "Budget exhausted" in r2
+
+
+def test_decide_failure_penalty_forces_abandon():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    score = _score(EvaluationOutcome.REGRESSED)
+    # remaining = 5 - 1 - 5 = -1 → abandon
+    d, r = coord._decide(
+        score=score, policy=_policy(max_attempts=5, failure_penalty=5), attempts_used=1
+    )
+    assert d == RefinementDecision.ABANDON
+
+
+# ---------------------------------------------------------------------------
+# Status mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "decision,status",
+    [
+        (RefinementDecision.ACCEPT, RefinementStatus.ACCEPTED),
+        (RefinementDecision.ABANDON, RefinementStatus.ABANDONED),
+        (RefinementDecision.ESCALATE, RefinementStatus.ESCALATED),
+        (RefinementDecision.RETRY, RefinementStatus.IN_PROGRESS),
+    ],
+)
+def test_status_for_decision(decision, status):
+    assert CiCoordinator._status_for_decision(decision, 1) == status
+
+
+# ---------------------------------------------------------------------------
+# _append_attempt
+# ---------------------------------------------------------------------------
+
+
+def _make_attempt(n, decision):
+    from datetime import UTC, datetime
+
+    return ci_coordinator.LineageAttempt(
+        attempt_number=n,
+        run_id=f"run-{n}",
+        branch_reason=LineageBranchReason.INITIAL,
+        strategy_used=ImprovementStrategy(principle="p", constraints=["fail_closed"]),
+        started_at=datetime.now(UTC),
+        decision=decision,
+    )
+
+
+def test_append_attempt_accept_sets_accepted_number():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    lineage = ImprovementLineage(lineage_id="x", current_attempt_number=0)
+    attempt = _make_attempt(1, RefinementDecision.ACCEPT)
+    new = coord._append_attempt(lineage, attempt, RefinementDecision.ACCEPT)
+    assert new.accepted_attempt_number == 1
+    assert new.status == RefinementStatus.ACCEPTED
+    assert new.current_attempt_number == 1
+    assert len(new.attempts) == 1
+
+
+def test_append_attempt_retry_keeps_prior_accepted():
+    coord = CiCoordinator(evaluator=MagicMock(), store=MagicMock())
+    lineage = ImprovementLineage(
+        lineage_id="x", current_attempt_number=1, accepted_attempt_number=None
+    )
+    attempt = _make_attempt(2, RefinementDecision.RETRY)
+    new = coord._append_attempt(lineage, attempt, RefinementDecision.RETRY)
+    assert new.accepted_attempt_number is None
+    assert new.status == RefinementStatus.IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# _resolve_evaluation_command
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_evaluation_command_explicit():
+    spec = _make_spec(evaluation_command="make eval")
+    cmd, source = CiCoordinator._resolve_evaluation_command(spec)
+    assert cmd == "make eval"
+    assert source == EvaluationCommandSource.OC_DERIVED
+
+
+def test_resolve_evaluation_command_hint():
+    spec = _make_spec(evaluation_command_hint="pytest -q")
+    cmd, source = CiCoordinator._resolve_evaluation_command(spec)
+    assert cmd == "pytest -q"
+    assert source == EvaluationCommandSource.PROPOSER_SUGGESTED
+
+
+def test_resolve_evaluation_command_none():
+    spec = _make_spec()
+    cmd, source = CiCoordinator._resolve_evaluation_command(spec)
+    assert cmd is None
+    assert source is None
+
+
+# ---------------------------------------------------------------------------
+# _lineage_path / _build_replay_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_path(repo):
+    ctx = _make_ctx(_make_spec(), repo, lineage_id="LID")
+    p = CiCoordinator._lineage_path(ctx)
+    assert p == repo / ".context" / "capsules" / "LID" / "lineage.json"
+
+
+def test_build_replay_metadata(repo):
+    spec = _make_spec()
+    ctx = _make_ctx(spec, repo, base_commit_sha="deadbeef")
+    meta = CiCoordinator._build_replay_metadata(ctx, spec, 2)
+    assert meta["base_commit_sha"] == "deadbeef"
+    assert meta["goal_text_hash"].startswith("sha256:")
+    assert meta["strategy_principle_hash"].startswith("sha256:")
+    assert meta["clp_schema_version"] == "0.1"
+    assert meta["oc_schema_version"] == "0.3"
+
+
+# ---------------------------------------------------------------------------
+# default construction
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_default_construction(monkeypatch):
+    made = {}
+
+    class _FakeEvaluator:
+        def __init__(self):
+            made["eval"] = True
+
+    class _FakeStore:
+        def __init__(self):
+            made["store"] = True
+
+    monkeypatch.setattr(ci_coordinator, "CiEvaluator", _FakeEvaluator)
+    monkeypatch.setattr(ci_coordinator, "CiStore", _FakeStore)
+    coord = CiCoordinator()
+    assert made == {"eval": True, "store": True}
+    assert isinstance(coord._evaluator, _FakeEvaluator)
+    assert isinstance(coord._store, _FakeStore)
+
+
+# ---------------------------------------------------------------------------
+# _persist wiring (via run, with save_lineage patched)
+# ---------------------------------------------------------------------------
+
+
+def test_persist_calls_store(repo, monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        ci_coordinator.CiStore,
+        "save_lineage",
+        staticmethod(lambda lineage, path: saved.append((lineage, path))),
+    )
+    monkeypatch.setattr(ci_coordinator.CiStore, "load_lineage", staticmethod(lambda p: None))
+    spec = _make_spec(max_attempts=1)
+    coord, evaluator, store = _make_coordinator(_score(EvaluationOutcome.IMPROVED))
+    coord.run(_make_ctx(spec, repo), _execute_stub())
+    assert len(saved) == 1
+    store.upsert_index_entry.assert_called_once()
+    store.upsert_state.assert_called_once()

--- a/tests/unit/operations_center/execution/test_ci_evaluator_cov.py
+++ b/tests/unit/operations_center/execution/test_ci_evaluator_cov.py
@@ -1,0 +1,582 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from operations_center.contracts.ci import EvaluationSpec, ScoringMetric
+from operations_center.contracts.enums import (
+    EnforcedGuardrail,
+    EvaluationOutcome,
+)
+from operations_center.execution import ci_evaluator
+from operations_center.execution.ci_evaluator import CiEvaluator, EvaluationContext
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(
+    *,
+    metric: str = "false_retry_rate",
+    direction: str = "lower_is_better",
+    baseline_value=None,
+    target_delta=None,
+    secondary=None,
+    guardrails=None,
+):
+    return EvaluationSpec(
+        baseline_description="baseline",
+        primary_scoring=ScoringMetric(
+            metric=metric,
+            direction=direction,
+            baseline_value=baseline_value,
+            target_delta=target_delta,
+        ),
+        secondary_scoring=secondary or [],
+        guardrails=guardrails if guardrails is not None else [],
+    )
+
+
+def _make_ctx(tmp_path: Path, **kwargs) -> EvaluationContext:
+    defaults = dict(
+        repo_path=tmp_path,
+        attempt_number=1,
+        evaluation_command="echo hi",
+        validation_commands=[],
+        changed_file_paths=[],
+    )
+    defaults.update(kwargs)
+    return EvaluationContext(**defaults)
+
+
+def _proc(returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _run_evaluation_command
+# ---------------------------------------------------------------------------
+
+
+def test_run_eval_empty_command_returns_empty(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, evaluation_command="   ")
+    assert ev._run_evaluation_command(ctx) == {}
+
+
+def test_run_eval_reads_output_file_and_substitutes_n(tmp_path):
+    ev = CiEvaluator()
+    out_file = tmp_path / "eval.json"
+    out_file.write_text(json.dumps({"false_retry_rate": 0.2}), encoding="utf-8")
+    ctx = _make_ctx(
+        tmp_path,
+        evaluation_command="run --attempt {n}",
+        attempt_number=7,
+        eval_output_path=out_file,
+    )
+    with patch.object(ci_evaluator.subprocess, "run", return_value=_proc()) as m:
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"false_retry_rate": 0.2}
+    # placeholder substituted
+    assert m.call_args.args[0] == "run --attempt 7"
+
+
+def test_run_eval_output_file_bad_json_logs_and_falls_through(tmp_path):
+    ev = CiEvaluator()
+    out_file = tmp_path / "eval.json"
+    out_file.write_text("not json", encoding="utf-8")
+    ctx = _make_ctx(tmp_path, eval_output_path=out_file)
+    proc = _proc(returncode=3, stdout="also not json")
+    with patch.object(ci_evaluator.subprocess, "run", return_value=proc):
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"exit_code": 3, "stdout": "also not json"}
+
+
+def test_run_eval_parses_stdout_json_when_no_file(tmp_path):
+    ev = CiEvaluator()
+    proc = _proc(stdout='{"metric": 1.0}\n')
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=proc):
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"metric": 1.0}
+
+
+def test_run_eval_stdout_not_json_returns_exit_envelope(tmp_path):
+    ev = CiEvaluator()
+    proc = _proc(returncode=5, stdout="plain text")
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=proc):
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"exit_code": 5, "stdout": "plain text"}
+
+
+def test_run_eval_empty_stdout_returns_exit_envelope(tmp_path):
+    ev = CiEvaluator()
+    proc = _proc(returncode=0, stdout="")
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=proc):
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"exit_code": 0, "stdout": ""}
+
+
+def test_run_eval_output_path_set_but_missing_falls_to_stdout(tmp_path):
+    ev = CiEvaluator()
+    missing = tmp_path / "nope.json"
+    proc = _proc(stdout='{"x": 2}')
+    ctx = _make_ctx(tmp_path, eval_output_path=missing)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=proc):
+        result = ev._run_evaluation_command(ctx)
+    assert result == {"x": 2}
+
+
+# ---------------------------------------------------------------------------
+# _parse_eval_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_eval_primary_with_baseline_delta(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(metric="m", baseline_value=10.0)
+    val, delta, sec = ev._parse_eval_output(spec, {"m": 4}, _make_ctx(tmp_path))
+    assert val == 4.0
+    assert delta == -6.0
+    assert sec == {}
+
+
+def test_parse_eval_primary_without_baseline_no_delta(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(metric="m", baseline_value=None)
+    val, delta, _ = ev._parse_eval_output(spec, {"m": 4}, _make_ctx(tmp_path))
+    assert val == 4.0
+    assert delta is None
+
+
+def test_parse_eval_primary_not_in_output(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(metric="m", baseline_value=1.0)
+    val, delta, _ = ev._parse_eval_output(spec, {"other": 1}, _make_ctx(tmp_path))
+    assert val is None
+    assert delta is None
+
+
+def test_parse_eval_primary_unconvertible(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(metric="m", baseline_value=1.0)
+    val, delta, _ = ev._parse_eval_output(spec, {"m": "abc"}, _make_ctx(tmp_path))
+    assert val is None
+    assert delta is None
+
+
+def test_parse_eval_secondary_metrics_mixed(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(
+        metric="m",
+        secondary=[
+            ScoringMetric(metric="good"),
+            ScoringMetric(metric="bad"),
+            ScoringMetric(metric="absent"),
+        ],
+    )
+    output = {"m": 1, "good": 2.5, "bad": "nan-ish-string"}
+    _, _, sec = ev._parse_eval_output(spec, output, _make_ctx(tmp_path))
+    assert sec == {"good": 2.5}
+
+
+# ---------------------------------------------------------------------------
+# _check_guardrail dispatch + error handling
+# ---------------------------------------------------------------------------
+
+
+def test_check_guardrail_unknown_returns_false(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec()
+    fake = MagicMock()
+    fake.__eq__ = lambda self, other: False  # never matches any branch
+    result = ev._check_guardrail(fake, spec, _make_ctx(tmp_path), {})
+    assert result is False
+
+
+def test_check_guardrail_catches_exception(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec()
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ev, "_check_regression_fixtures", side_effect=RuntimeError("boom")):
+        result = ev._check_guardrail(EnforcedGuardrail.REGRESSION_FIXTURES_PASS, spec, ctx, {})
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "guardrail,method",
+    [
+        (EnforcedGuardrail.REGRESSION_FIXTURES_PASS, "_check_regression_fixtures"),
+        (EnforcedGuardrail.CUSTODIAN_CLEAN, "_check_custodian_clean"),
+        (EnforcedGuardrail.NO_ARCHITECTURE_VIOLATIONS, "_check_no_architecture_violations"),
+        (EnforcedGuardrail.NO_RUNTIME_POLICY_WIDENING, "_check_no_policy_widening"),
+    ],
+)
+def test_check_guardrail_dispatch(tmp_path, guardrail, method):
+    ev = CiEvaluator()
+    spec = _make_spec()
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ev, method, return_value=True) as m:
+        assert ev._check_guardrail(guardrail, spec, ctx, {}) is True
+    m.assert_called_once()
+
+
+def test_check_guardrail_dispatch_lost_escalations(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec()
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ev, "_check_no_lost_escalations", return_value=True) as m:
+        assert (
+            ev._check_guardrail(EnforcedGuardrail.NO_LOST_ESCALATIONS, spec, ctx, {"a": 1}) is True
+        )
+    m.assert_called_once_with(spec, {"a": 1})
+
+
+# ---------------------------------------------------------------------------
+# _check_regression_fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_regression_fixtures_all_pass(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, validation_commands=["a", "b"])
+    with patch.object(ci_evaluator.subprocess, "run", return_value=_proc(returncode=0)):
+        assert ev._check_regression_fixtures(ctx) is True
+
+
+def test_regression_fixtures_one_fails(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, validation_commands=["a", "b"])
+    procs = [_proc(returncode=0), _proc(returncode=1)]
+    with patch.object(ci_evaluator.subprocess, "run", side_effect=procs):
+        assert ev._check_regression_fixtures(ctx) is False
+
+
+def test_regression_fixtures_empty_passes(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, validation_commands=[])
+    assert ev._check_regression_fixtures(ctx) is True
+
+
+# ---------------------------------------------------------------------------
+# _check_custodian_clean
+# ---------------------------------------------------------------------------
+
+
+def test_custodian_clean_not_found_fails_closed(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ci_evaluator.shutil, "which", return_value=None):
+        assert ev._check_custodian_clean(ctx) is False
+
+
+def test_custodian_clean_zero_findings(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(stdout=json.dumps({"total_findings": 0}))
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_custodian_clean(ctx) is True
+
+
+def test_custodian_clean_nonzero_findings(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(stdout=json.dumps({"total_findings": 3}))
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_custodian_clean(ctx) is False
+
+
+def test_custodian_clean_bad_json_falls_back_to_returncode(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(returncode=0, stdout="garbage")
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_custodian_clean(ctx) is True
+
+
+def test_custodian_clean_bad_json_nonzero_rc(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(returncode=1, stdout="garbage")
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_custodian_clean(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# _check_no_architecture_violations
+# ---------------------------------------------------------------------------
+
+
+def test_arch_violations_not_found_fails_closed(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    with patch.object(ci_evaluator.shutil, "which", return_value=None):
+        assert ev._check_no_architecture_violations(ctx) is False
+
+
+def test_arch_violations_zero_findings_with_policy_flag(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(stdout=json.dumps({"total_findings": 0}))
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc) as m,
+    ):
+        assert ev._check_no_architecture_violations(ctx) is True
+    assert "architecture" in m.call_args.args[0]
+    assert "--policy" in m.call_args.args[0]
+
+
+def test_arch_violations_nonzero(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(stdout=json.dumps({"total_findings": 2}))
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_no_architecture_violations(ctx) is False
+
+
+def test_arch_violations_bad_json_falls_back(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path)
+    proc = _proc(returncode=0, stdout="no json here")
+    with (
+        patch.object(ci_evaluator.shutil, "which", return_value="/bin/custodian-audit"),
+        patch.object(ci_evaluator.subprocess, "run", return_value=proc),
+    ):
+        assert ev._check_no_architecture_violations(ctx) is True
+
+
+# ---------------------------------------------------------------------------
+# _check_no_policy_widening
+# ---------------------------------------------------------------------------
+
+
+def test_policy_widening_clean(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, changed_file_paths=["src/foo.py", "README.md"])
+    assert ev._check_no_policy_widening(ctx) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/.custodian.yaml",
+        "CUSTODIAN.md",
+        "config/forbidden_paths.txt",
+        "policy/rules.yaml",
+        "allowed_paths.json",
+        ".console/workers.yaml",
+    ],
+)
+def test_policy_widening_detects(tmp_path, path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, changed_file_paths=["safe.py", path])
+    assert ev._check_no_policy_widening(ctx) is False
+
+
+def test_policy_widening_empty_changes(tmp_path):
+    ev = CiEvaluator()
+    ctx = _make_ctx(tmp_path, changed_file_paths=[])
+    assert ev._check_no_policy_widening(ctx) is True
+
+
+# ---------------------------------------------------------------------------
+# _check_no_lost_escalations
+# ---------------------------------------------------------------------------
+
+
+def test_lost_escalations_missing_keys_passes():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    assert ev._check_no_lost_escalations(spec, {}) is True
+    assert ev._check_no_lost_escalations(spec, {"escalations_before": 1}) is True
+    assert ev._check_no_lost_escalations(spec, {"escalations_after": 1}) is True
+
+
+def test_lost_escalations_preserved():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    out = {"escalations_before": 2, "escalations_after": 2}
+    assert ev._check_no_lost_escalations(spec, out) is True
+
+
+def test_lost_escalations_increased():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    out = {"escalations_before": 2, "escalations_after": 3}
+    assert ev._check_no_lost_escalations(spec, out) is True
+
+
+def test_lost_escalations_dropped_fails():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    out = {"escalations_before": 3, "escalations_after": 1}
+    assert ev._check_no_lost_escalations(spec, out) is False
+
+
+# ---------------------------------------------------------------------------
+# _determine_outcome
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_guardrail_violated():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    out = ev._determine_outcome(
+        spec=spec,
+        primary_delta=-5.0,
+        guardrails_failed=[EnforcedGuardrail.CUSTODIAN_CLEAN],
+    )
+    assert out == EvaluationOutcome.GUARDRAIL_VIOLATED
+
+
+def test_outcome_inconclusive_when_delta_none():
+    ev = CiEvaluator()
+    spec = _make_spec()
+    out = ev._determine_outcome(spec=spec, primary_delta=None, guardrails_failed=[])
+    assert out == EvaluationOutcome.INCONCLUSIVE
+
+
+def test_outcome_improved_lower_is_better_meets_target():
+    ev = CiEvaluator()
+    spec = _make_spec(direction="lower_is_better", target_delta=-2.0)
+    out = ev._determine_outcome(spec=spec, primary_delta=-5.0, guardrails_failed=[])
+    assert out == EvaluationOutcome.IMPROVED
+
+
+def test_outcome_improved_lower_is_better_no_target():
+    ev = CiEvaluator()
+    spec = _make_spec(direction="lower_is_better", target_delta=None)
+    out = ev._determine_outcome(spec=spec, primary_delta=-0.1, guardrails_failed=[])
+    assert out == EvaluationOutcome.IMPROVED
+
+
+def test_outcome_improved_higher_is_better_meets_target():
+    ev = CiEvaluator()
+    spec = _make_spec(direction="higher_is_better", target_delta=2.0)
+    out = ev._determine_outcome(spec=spec, primary_delta=5.0, guardrails_failed=[])
+    assert out == EvaluationOutcome.IMPROVED
+
+
+def test_outcome_neutral_zero_delta():
+    ev = CiEvaluator()
+    spec = _make_spec(direction="lower_is_better")
+    out = ev._determine_outcome(spec=spec, primary_delta=0.0, guardrails_failed=[])
+    assert out == EvaluationOutcome.NEUTRAL
+
+
+def test_outcome_neutral_not_improved():
+    ev = CiEvaluator()
+    # lower_is_better but delta is positive (worse) → not improved → NEUTRAL branch
+    spec = _make_spec(direction="lower_is_better")
+    out = ev._determine_outcome(spec=spec, primary_delta=3.0, guardrails_failed=[])
+    assert out == EvaluationOutcome.NEUTRAL
+
+
+def test_outcome_regressed_improved_but_below_target():
+    ev = CiEvaluator()
+    # lower_is_better: delta negative = improved, but does not meet target (-10)
+    spec = _make_spec(direction="lower_is_better", target_delta=-10.0)
+    out = ev._determine_outcome(spec=spec, primary_delta=-1.0, guardrails_failed=[])
+    # improved True but meets_target False -> falls past IMPROVED;
+    # delta != 0 and improved is True so NEUTRAL branch is False -> REGRESSED
+    assert out == EvaluationOutcome.REGRESSED
+
+
+def test_outcome_higher_is_better_improved_below_target_regressed():
+    ev = CiEvaluator()
+    spec = _make_spec(direction="higher_is_better", target_delta=10.0)
+    out = ev._determine_outcome(spec=spec, primary_delta=1.0, guardrails_failed=[])
+    assert out == EvaluationOutcome.REGRESSED
+
+
+# ---------------------------------------------------------------------------
+# evaluate() integration
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_full_improved_no_guardrails(tmp_path):
+    ev = CiEvaluator()
+    out_file = tmp_path / "eval.json"
+    out_file.write_text(json.dumps({"m": 5.0, "lat": 2.0}), encoding="utf-8")
+    spec = _make_spec(
+        metric="m",
+        direction="higher_is_better",
+        baseline_value=1.0,
+        target_delta=1.0,
+        secondary=[ScoringMetric(metric="lat")],
+        guardrails=[],
+    )
+    ctx = _make_ctx(tmp_path, eval_output_path=out_file)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=_proc()):
+        score = ev.evaluate(spec, ctx)
+    assert score.primary_metric_value == 5.0
+    assert score.primary_metric_delta == 4.0
+    assert score.secondary_metrics == {"lat": 2.0}
+    assert score.outcome == EvaluationOutcome.IMPROVED
+    assert score.evidence_paths == [str(out_file)]
+    assert score.evaluation_command_used == ctx.evaluation_command
+
+
+def test_evaluate_with_passing_and_failing_guardrails(tmp_path):
+    ev = CiEvaluator()
+    out_file = tmp_path / "eval.json"
+    out_file.write_text(json.dumps({"m": 5.0}), encoding="utf-8")
+    spec = _make_spec(
+        metric="m",
+        direction="higher_is_better",
+        baseline_value=1.0,
+        guardrails=[
+            EnforcedGuardrail.NO_RUNTIME_POLICY_WIDENING,
+            EnforcedGuardrail.REGRESSION_FIXTURES_PASS,
+        ],
+    )
+    # policy widening fails (policy file changed), regression passes (no cmds)
+    ctx = _make_ctx(
+        tmp_path,
+        eval_output_path=out_file,
+        changed_file_paths=["policy/x.yaml"],
+        validation_commands=[],
+    )
+    with patch.object(ci_evaluator.subprocess, "run", return_value=_proc()):
+        score = ev.evaluate(spec, ctx)
+    assert EnforcedGuardrail.NO_RUNTIME_POLICY_WIDENING in score.guardrails_failed
+    assert EnforcedGuardrail.REGRESSION_FIXTURES_PASS in score.guardrails_passed
+    assert score.outcome == EvaluationOutcome.GUARDRAIL_VIOLATED
+
+
+def test_evaluate_no_eval_output_path_empty_evidence(tmp_path):
+    ev = CiEvaluator()
+    spec = _make_spec(metric="m", baseline_value=None, guardrails=[])
+    ctx = _make_ctx(tmp_path, eval_output_path=None)
+    with patch.object(ci_evaluator.subprocess, "run", return_value=_proc(stdout='{"m": 2}')):
+        score = ev.evaluate(spec, ctx)
+    assert score.evidence_paths == []
+    assert score.primary_metric_value == 2.0
+    # no baseline -> delta None -> INCONCLUSIVE
+    assert score.outcome == EvaluationOutcome.INCONCLUSIVE

--- a/tests/unit/operations_center/observer/__init__.py
+++ b/tests/unit/operations_center/observer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/observer/test_exporters_cov.py
+++ b/tests/unit/operations_center/observer/test_exporters_cov.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Complementary coverage tests for observer.exporters.
+
+Targets edge branches not exercised by the sibling suite:
+- no-export-dir early returns and the ValueError guard
+- IOError handling on write/read
+- malformed JSONL lines and bad filename skipping
+- auto_rotate disabled and outer rotation exception handler
+- aggregate defaults and error-rate computation
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from operations_center.observer.exporters import (
+    ValidationFailureMetric,
+    ValidationMetricsExporter,
+)
+
+
+def _metric(**overrides: Any) -> ValidationFailureMetric:
+    base: dict[str, Any] = {
+        "timestamp": datetime(2026, 1, 1, tzinfo=UTC),
+        "collector_name": "c1",
+        "artifact_type": "control_outcome.json",
+        "failure_type": "parse_error",
+        "severity": "HIGH",
+        "error_message": "boom",
+        "artifact_path": "/x/y.json",
+        "context": {"k": "v"},
+        "metrics_snapshot": {"n": 1},
+    }
+    base.update(overrides)
+    return ValidationFailureMetric(**base)
+
+
+class TestToDict:
+    def test_to_dict_envelope_and_fields(self) -> None:
+        d = _metric().to_dict()
+        env = d["validation_failure_metric"]
+        assert env["version"] == "1.0"
+        assert env["timestamp"] == "2026-01-01T00:00:00+00:00"
+        assert env["collector_name"] == "c1"
+        assert env["metrics"] == {"n": 1}
+        assert env["context"] == {"k": "v"}
+
+
+class TestNoExportDir:
+    def test_export_failure_noop(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        # Should silently return without raising.
+        exp.export_failure(_metric())
+        assert exp.export_dir is None
+
+    def test_export_to_file_noop(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        # No export_dir -> early return, returns None and writes nothing.
+        assert exp._export_to_file(_metric()) is None
+
+    def test_get_metrics_file_path_raises(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        with pytest.raises(ValueError, match="export_dir is not set"):
+            exp._get_metrics_file_path()
+
+    def test_rotate_if_needed_noop(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        # No export_dir -> early return, returns None.
+        assert exp._rotate_if_needed() is None
+
+    def test_read_metrics_returns_empty(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        assert exp.read_metrics() == []
+
+    def test_aggregate_empty_when_no_dir(self) -> None:
+        exp = ValidationMetricsExporter(export_dir=None)
+        agg = exp.aggregate_metrics()
+        assert agg["total_errors"] == 0
+        assert agg["by_collector"] == {}
+        assert "error_rate_per_minute" not in agg
+
+
+class TestExportErrorHandling:
+    def test_export_failure_swallows_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+
+        calls: list[ValidationFailureMetric] = []
+
+        def boom(metric: ValidationFailureMetric) -> None:
+            calls.append(metric)
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(exp, "_export_to_file", boom)
+        # The outer try/except in export_failure must swallow it.
+        result = exp.export_failure(_metric())
+        assert result is None
+        # The failing writer was invoked, yet the exception did not propagate.
+        assert len(calls) == 1
+        assert list(tmp_path.glob("metrics-*.jsonl")) == []
+
+    def test_export_to_file_handles_ioerror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+
+        import builtins
+
+        real_open = builtins.open
+
+        def fake_open(*args: Any, **kwargs: Any):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        try:
+            # IOError caught inside _export_to_file; no propagation.
+            exp._export_to_file(_metric())
+        finally:
+            monkeypatch.setattr(builtins, "open", real_open)
+        # Nothing should have been written.
+        assert list(tmp_path.glob("metrics-*.jsonl")) == []
+
+
+class TestRotate:
+    def test_auto_rotate_disabled_keeps_old(self, tmp_path: Path) -> None:
+        old = tmp_path / "metrics-2000-01-01.jsonl"
+        old.write_text("{}\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path, retention_days=1, auto_rotate=False)
+        exp._rotate_if_needed()
+        assert old.exists()
+
+    def test_rotate_removes_old_keeps_new(self, tmp_path: Path) -> None:
+        old = tmp_path / "metrics-2000-01-01.jsonl"
+        recent = tmp_path / f"metrics-{datetime.now(UTC):%Y-%m-%d}.jsonl"
+        old.write_text("{}\n", encoding="utf-8")
+        recent.write_text("{}\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path, retention_days=30)
+        exp._rotate_if_needed()
+        assert not old.exists()
+        assert recent.exists()
+
+    def test_rotate_skips_malformed_filename(self, tmp_path: Path) -> None:
+        bad = tmp_path / "metrics-not-a-date.jsonl"
+        bad.write_text("{}\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path, retention_days=1)
+        exp._rotate_if_needed()
+        # ValueError on strptime is caught; file survives.
+        assert bad.exists()
+
+    def test_rotate_outer_exception_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exp = ValidationMetricsExporter(export_dir=tmp_path, retention_days=1)
+
+        glob_calls: list[str] = []
+
+        class BoomDir:
+            def glob(self, pattern: str):
+                glob_calls.append(pattern)
+                raise RuntimeError("glob exploded")
+
+        monkeypatch.setattr(exp, "export_dir", BoomDir())
+        # Outer try/except in _rotate_if_needed must swallow.
+        result = exp._rotate_if_needed()
+        assert result is None
+        # The exploding glob was reached, yet the exception was swallowed.
+        assert glob_calls == ["metrics-*.jsonl"]
+
+
+class TestReadMetrics:
+    def test_skips_empty_and_bad_lines(self, tmp_path: Path) -> None:
+        f = tmp_path / f"metrics-{datetime.now(UTC):%Y-%m-%d}.jsonl"
+        good = json.dumps(_metric().to_dict())
+        f.write_text(f"\n{good}\n   \nnot-json\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        out = exp.read_metrics()
+        assert len(out) == 1
+        assert out[0]["validation_failure_metric"]["collector_name"] == "c1"
+
+    def test_skips_bad_filename(self, tmp_path: Path) -> None:
+        bad = tmp_path / "metrics-zzzz.jsonl"
+        bad.write_text(json.dumps(_metric().to_dict()) + "\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        # ValueError on filename date -> continue -> nothing read.
+        assert exp.read_metrics() == []
+
+    def test_date_filter_excludes_out_of_range(self, tmp_path: Path) -> None:
+        early = tmp_path / "metrics-2020-01-01.jsonl"
+        late = tmp_path / "metrics-2030-01-01.jsonl"
+        early.write_text(json.dumps(_metric().to_dict()) + "\n", encoding="utf-8")
+        late.write_text(json.dumps(_metric().to_dict()) + "\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        out = exp.read_metrics(
+            from_date=datetime(2025, 1, 1),
+            to_date=datetime(2026, 1, 1),
+        )
+        # Both files fall outside the window.
+        assert out == []
+
+    def test_read_handles_ioerror(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        f = tmp_path / f"metrics-{datetime.now(UTC):%Y-%m-%d}.jsonl"
+        f.write_text(json.dumps(_metric().to_dict()) + "\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+
+        import builtins
+
+        real_open = builtins.open
+
+        def fake_open(*args: Any, **kwargs: Any):
+            raise OSError("cannot read")
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        try:
+            out = exp.read_metrics()
+        finally:
+            monkeypatch.setattr(builtins, "open", real_open)
+        assert out == []
+
+    def test_read_outer_exception_swallowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+
+        class BoomDir:
+            def glob(self, _pattern: str):
+                raise RuntimeError("glob exploded")
+
+        monkeypatch.setattr(exp, "export_dir", BoomDir())
+        assert exp.read_metrics() == []
+
+
+class TestAggregate:
+    def test_defaults_for_missing_fields(self, tmp_path: Path) -> None:
+        f = tmp_path / f"metrics-{datetime.now(UTC):%Y-%m-%d}.jsonl"
+        # Envelope present but inner fields missing -> "unknown" defaults.
+        line = json.dumps({"validation_failure_metric": {}})
+        f.write_text(line + "\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        agg = exp.aggregate_metrics()
+        assert agg["total_errors"] == 0  # unknown failure_type counts nowhere
+        assert agg["by_collector"] == {"unknown": 1}
+        assert agg["by_artifact_type"] == {"unknown": 1}
+        assert agg["by_severity"] == {"unknown": 1}
+        assert agg["error_rate_per_minute"] == 0.0
+
+    def test_counts_all_failure_types_and_rate(self, tmp_path: Path) -> None:
+        f = tmp_path / f"metrics-{datetime.now(UTC):%Y-%m-%d}.jsonl"
+        rows = [
+            _metric(failure_type="parse_error").to_dict(),
+            _metric(failure_type="structure_error", collector_name="c2").to_dict(),
+            _metric(failure_type="io_error", severity="LOW").to_dict(),
+        ]
+        f.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        agg = exp.aggregate_metrics()
+        assert agg["total_errors"] == 3
+        assert agg["parse_errors"] == 1
+        assert agg["structure_errors"] == 1
+        assert agg["io_errors"] == 1
+        assert agg["by_collector"] == {"c1": 2, "c2": 1}
+        assert agg["by_severity"] == {"HIGH": 2, "LOW": 1}
+        assert agg["error_rate_per_minute"] == pytest.approx(3 / 24 / 60)
+
+
+class TestFactory:
+    def test_create_metric_defaults(self) -> None:
+        before = datetime.now(UTC)
+        m = ValidationMetricsExporter.create_metric_from_error(
+            collector_name="col",
+            artifact_type="art",
+            failure_type="io_error",
+            severity="MEDIUM",
+            error_message="msg",
+            artifact_path=Path("/tmp/a.json"),
+        )
+        assert m.context == {}
+        assert m.metrics_snapshot == {}
+        assert m.artifact_path == str(Path("/tmp/a.json"))
+        assert m.timestamp >= before
+
+    def test_create_metric_with_context_and_snapshot(self) -> None:
+        m = ValidationMetricsExporter.create_metric_from_error(
+            collector_name="col",
+            artifact_type="art",
+            failure_type="parse_error",
+            severity="HIGH",
+            error_message="msg",
+            artifact_path="/tmp/b.json",
+            context={"a": 1},
+            metrics_snapshot={"b": 2},
+        )
+        assert m.context == {"a": 1}
+        assert m.metrics_snapshot == {"b": 2}
+
+
+class TestRoundTrip:
+    def test_export_then_read(self, tmp_path: Path) -> None:
+        exp = ValidationMetricsExporter(export_dir=tmp_path)
+        exp.export_failure(_metric())
+        out = exp.read_metrics()
+        assert len(out) == 1
+        env = out[0]["validation_failure_metric"]
+        assert env["error_message"] == "boom"

--- a/tests/unit/operations_center/observer/test_metrics_cov.py
+++ b/tests/unit/operations_center/observer/test_metrics_cov.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from operations_center.observer.metrics import (
+    CollectorMetrics,
+    MetricsCollector,
+    MetricUnit,
+    PerformanceMetric,
+    SystemMetrics,
+)
+
+
+# --------------------------------------------------------------------------
+# MetricUnit
+# --------------------------------------------------------------------------
+def test_metric_unit_values():
+    assert MetricUnit.MILLISECONDS.value == "ms"
+    assert MetricUnit.SECONDS.value == "s"
+    assert MetricUnit.BYTES.value == "bytes"
+    assert MetricUnit.COUNT.value == "count"
+    assert MetricUnit.PERCENT.value == "%"
+    assert MetricUnit.ERRORS_PER_MINUTE.value == "errors/min"
+    # str-Enum behaves like a string
+    assert MetricUnit.COUNT == "count"
+
+
+# --------------------------------------------------------------------------
+# PerformanceMetric
+# --------------------------------------------------------------------------
+def test_performance_metric_to_dict_full():
+    ts = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    pm = PerformanceMetric(
+        name="latency",
+        value=12.5,
+        unit=MetricUnit.MILLISECONDS,
+        timestamp=ts,
+        collector_name="c1",
+        artifact_type="json",
+        tags={"k": "v"},
+    )
+    d = pm.to_dict()
+    assert d == {
+        "name": "latency",
+        "value": 12.5,
+        "unit": "ms",
+        "timestamp": ts.isoformat(),
+        "collector": "c1",
+        "artifact_type": "json",
+        "tags": {"k": "v"},
+    }
+
+
+def test_performance_metric_defaults():
+    ts = datetime.now(timezone.utc)
+    pm = PerformanceMetric(name="x", value=1.0, unit=MetricUnit.COUNT, timestamp=ts)
+    assert pm.collector_name is None
+    assert pm.artifact_type is None
+    assert pm.tags == {}
+    d = pm.to_dict()
+    assert d["collector"] is None
+    assert d["artifact_type"] is None
+    assert d["tags"] == {}
+
+
+# --------------------------------------------------------------------------
+# CollectorMetrics.update_from_run
+# --------------------------------------------------------------------------
+def test_update_from_run_success_no_errors_healthy():
+    cm = CollectorMetrics(collector_name="c")
+    cm.update_from_run(
+        latency_ms=100.0,
+        artifacts_processed=10,
+        artifacts_skipped=0,
+        parse_errors=0,
+        structure_errors=0,
+        io_errors=0,
+        success=True,
+    )
+    assert cm.total_runs == 1
+    assert cm.successful_runs == 1
+    assert cm.failed_runs == 0
+    assert cm.total_artifacts_processed == 10
+    assert cm.min_latency_ms == 100.0
+    assert cm.max_latency_ms == 100.0
+    assert cm.mean_latency_ms == 100.0
+    # throughput: 10 artifacts over 0.1s = 100/s
+    assert cm.throughput_artifacts_per_sec == pytest.approx(100.0)
+    assert cm.error_rate_percent == 0
+    assert cm.health_status == "HEALTHY"
+    assert cm.last_run_timestamp is not None
+    assert cm.last_error_timestamp is None
+
+
+def test_update_from_run_failure_and_errors():
+    cm = CollectorMetrics(collector_name="c")
+    cm.update_from_run(
+        latency_ms=50.0,
+        artifacts_processed=8,
+        artifacts_skipped=2,
+        parse_errors=1,
+        structure_errors=1,
+        io_errors=0,
+        success=False,
+    )
+    assert cm.failed_runs == 1
+    assert cm.successful_runs == 0
+    assert cm.total_parse_errors == 1
+    assert cm.total_structure_errors == 1
+    assert cm.total_io_errors == 0
+    # total_errors=2, total_attempted=10 -> 20%
+    assert cm.error_rate_percent == pytest.approx(20.0)
+    assert cm.health_status == "CRITICAL"
+    assert cm.last_error_timestamp is not None
+
+
+def test_update_from_run_min_max_latency_across_runs():
+    cm = CollectorMetrics(collector_name="c")
+    cm.update_from_run(200.0, 1, 0, 0, 0, 0, True)
+    cm.update_from_run(50.0, 1, 0, 0, 0, 0, True)
+    cm.update_from_run(120.0, 1, 0, 0, 0, 0, True)
+    assert cm.min_latency_ms == 50.0
+    assert cm.max_latency_ms == 200.0
+    assert cm.total_runs == 3
+    assert cm.mean_latency_ms == pytest.approx((200.0 + 50.0 + 120.0) / 3)
+
+
+def test_update_from_run_zero_latency_skips_throughput():
+    cm = CollectorMetrics(collector_name="c")
+    cm.update_from_run(0.0, 5, 0, 0, 0, 0, True)
+    # elapsed_seconds == 0 -> throughput stays default
+    assert cm.throughput_artifacts_per_sec == 0.0
+    assert cm.min_latency_ms == 0.0
+
+
+def test_update_from_run_no_attempted_skips_error_rate():
+    cm = CollectorMetrics(collector_name="c")
+    # zero processed and skipped -> total_attempted == 0 branch skipped
+    cm.update_from_run(10.0, 0, 0, 0, 0, 0, True)
+    assert cm.error_rate_percent == 0.0
+    assert cm.health_status == "HEALTHY"
+
+
+def test_update_from_run_no_processed_skips_throughput_branch():
+    cm = CollectorMetrics(collector_name="c")
+    # processed == 0 -> throughput branch skipped, but skipped triggers error_rate path
+    cm.update_from_run(10.0, 0, 4, 0, 0, 0, True)
+    assert cm.throughput_artifacts_per_sec == 0.0
+    assert cm.error_rate_percent == 0.0
+
+
+# --------------------------------------------------------------------------
+# CollectorMetrics._update_health_status (all bands)
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "rate,expected",
+    [
+        (0.0, "HEALTHY"),
+        (4.9, "NOMINAL"),
+        (5.0, "DEGRADED"),
+        (19.9, "DEGRADED"),
+        (20.0, "CRITICAL"),
+        (75.0, "CRITICAL"),
+    ],
+)
+def test_update_health_status_bands(rate, expected):
+    cm = CollectorMetrics(collector_name="c")
+    cm.total_runs = 1
+    cm.error_rate_percent = rate
+    cm._update_health_status()
+    assert cm.health_status == expected
+
+
+def test_update_health_status_unknown_when_no_runs():
+    cm = CollectorMetrics(collector_name="c")
+    assert cm.total_runs == 0
+    cm._update_health_status()
+    assert cm.health_status == "UNKNOWN"
+
+
+# --------------------------------------------------------------------------
+# CollectorMetrics.to_dict
+# --------------------------------------------------------------------------
+def test_collector_metrics_to_dict_with_none_timestamps():
+    cm = CollectorMetrics(collector_name="c")
+    d = cm.to_dict()
+    assert d["collector_name"] == "c"
+    assert d["last_run_timestamp"] is None
+    assert d["last_error_timestamp"] is None
+    assert d["health_status"] == "HEALTHY"
+
+
+def test_collector_metrics_to_dict_with_timestamps():
+    cm = CollectorMetrics(collector_name="c")
+    cm.update_from_run(10.0, 1, 0, 1, 0, 0, True)
+    d = cm.to_dict()
+    assert isinstance(d["last_run_timestamp"], str)
+    assert isinstance(d["last_error_timestamp"], str)
+    assert d["total_parse_errors"] == 1
+
+
+# --------------------------------------------------------------------------
+# SystemMetrics.update_from_collectors
+# --------------------------------------------------------------------------
+def _make_collector(name, health, processed=0, skipped=0, parse=0, struct=0, io=0):
+    cm = CollectorMetrics(collector_name=name)
+    cm.health_status = health
+    cm.total_artifacts_processed = processed
+    cm.total_artifacts_skipped = skipped
+    cm.total_parse_errors = parse
+    cm.total_structure_errors = struct
+    cm.total_io_errors = io
+    return cm
+
+
+def test_system_update_empty():
+    sm = SystemMetrics()
+    sm.update_from_collectors({})
+    assert sm.total_collectors == 0
+    assert sm.healthy_collectors == 0
+    # total_collectors == 0 and healthy == 0 -> healthy == total -> HEALTHY branch
+    assert sm.system_health_status == "HEALTHY"
+
+
+def test_system_update_all_healthy():
+    cols = {
+        "a": _make_collector("a", "HEALTHY", processed=10),
+        "b": _make_collector("b", "HEALTHY", processed=5),
+    }
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    assert sm.total_collectors == 2
+    assert sm.healthy_collectors == 2
+    assert sm.system_health_status == "HEALTHY"
+    assert sm.overall_error_rate_percent == 0.0
+
+
+def test_system_update_critical_takes_precedence():
+    cols = {
+        "a": _make_collector("a", "CRITICAL", processed=10, parse=5),
+        "b": _make_collector("b", "DEGRADED", processed=10, io=2),
+    }
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    assert sm.critical_collectors == 1
+    assert sm.degraded_collectors == 1
+    assert sm.system_health_status == "CRITICAL"
+    assert sm.total_validation_failures == 7
+    # 7 errors / 20 processed -> 35%
+    assert sm.overall_error_rate_percent == pytest.approx(35.0)
+
+
+def test_system_update_degraded():
+    cols = {"a": _make_collector("a", "DEGRADED", processed=10, struct=1)}
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    assert sm.system_health_status == "DEGRADED"
+
+
+def test_system_update_nominal_when_mixed_unknown():
+    # No critical, no degraded, not all healthy -> NOMINAL
+    cols = {
+        "a": _make_collector("a", "HEALTHY", processed=10),
+        "b": _make_collector("b", "NOMINAL", processed=10),
+    }
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    assert sm.critical_collectors == 0
+    assert sm.degraded_collectors == 0
+    assert sm.healthy_collectors == 1
+    assert sm.system_health_status == "NOMINAL"
+
+
+def test_system_update_zero_processed_skips_error_rate():
+    cols = {"a": _make_collector("a", "HEALTHY", parse=5)}
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    # total_processed == 0 -> branch skipped, stays default 0.0
+    assert sm.overall_error_rate_percent == 0.0
+    assert sm.total_validation_failures == 5
+
+
+# --------------------------------------------------------------------------
+# SystemMetrics.to_dict
+# --------------------------------------------------------------------------
+def test_system_metrics_to_dict():
+    cols = {"a": _make_collector("a", "HEALTHY", processed=2)}
+    sm = SystemMetrics()
+    sm.update_from_collectors(cols)
+    d = sm.to_dict()
+    assert isinstance(d["timestamp"], str)
+    assert d["total_collectors"] == 1
+    assert "a" in d["collector_metrics"]
+    assert d["collector_metrics"]["a"]["collector_name"] == "a"
+    assert d["time_window_minutes"] == 5
+
+
+def test_system_metrics_default_timestamp_is_set():
+    sm = SystemMetrics()
+    assert isinstance(sm.timestamp, datetime)
+
+
+# --------------------------------------------------------------------------
+# MetricsCollector
+# --------------------------------------------------------------------------
+def test_collector_init():
+    mc = MetricsCollector()
+    assert mc.collector_metrics == {}
+    assert isinstance(mc.system_metrics, SystemMetrics)
+    assert mc.performance_metrics == []
+    assert isinstance(mc._start_time, datetime)
+
+
+def test_record_collector_run_creates_and_updates():
+    mc = MetricsCollector()
+    mc.record_collector_run(
+        collector_name="c1",
+        latency_ms=10.0,
+        artifacts_processed=5,
+        artifacts_skipped=0,
+        parse_errors=0,
+        structure_errors=0,
+        io_errors=0,
+        success=True,
+    )
+    assert "c1" in mc.collector_metrics
+    assert mc.collector_metrics["c1"].total_runs == 1
+    assert mc.system_metrics.total_collectors == 1
+
+    # Second run on same collector reuses object
+    obj = mc.collector_metrics["c1"]
+    mc.record_collector_run("c1", 20.0, 5, 0, 0, 0, 0, True)
+    assert mc.collector_metrics["c1"] is obj
+    assert obj.total_runs == 2
+
+
+def test_record_performance_metric_defaults_and_appends():
+    mc = MetricsCollector()
+    mc.record_performance_metric("m", 1.0, MetricUnit.COUNT)
+    assert len(mc.performance_metrics) == 1
+    pm = mc.performance_metrics[0]
+    assert pm.tags == {}
+    assert pm.collector_name is None
+    assert isinstance(pm.timestamp, datetime)
+
+
+def test_record_performance_metric_with_tags():
+    mc = MetricsCollector()
+    mc.record_performance_metric(
+        "m", 2.0, MetricUnit.SECONDS, collector_name="c", artifact_type="t", tags={"a": "b"}
+    )
+    pm = mc.performance_metrics[0]
+    assert pm.tags == {"a": "b"}
+    assert pm.collector_name == "c"
+    assert pm.artifact_type == "t"
+
+
+def test_record_performance_metric_trims_to_1000():
+    mc = MetricsCollector()
+    for i in range(1005):
+        mc.record_performance_metric(f"m{i}", float(i), MetricUnit.COUNT)
+    assert len(mc.performance_metrics) == 1000
+    # oldest dropped: first remaining should be m5
+    assert mc.performance_metrics[0].name == "m5"
+    assert mc.performance_metrics[-1].name == "m1004"
+
+
+def test_get_system_metrics_refreshes():
+    mc = MetricsCollector()
+    mc.record_collector_run("c1", 10.0, 1, 0, 0, 0, 0, True)
+    sm = mc.get_system_metrics()
+    assert sm is mc.system_metrics
+    assert sm.total_collectors == 1
+
+
+def test_get_collector_metrics_present_and_absent():
+    mc = MetricsCollector()
+    assert mc.get_collector_metrics("nope") is None
+    mc.record_collector_run("c1", 10.0, 1, 0, 0, 0, 0, True)
+    got = mc.get_collector_metrics("c1")
+    assert got is not None
+    assert got.collector_name == "c1"
+
+
+def test_get_all_collector_metrics_returns_copy():
+    mc = MetricsCollector()
+    mc.record_collector_run("c1", 10.0, 1, 0, 0, 0, 0, True)
+    all_metrics = mc.get_all_collector_metrics()
+    assert "c1" in all_metrics
+    # mutating the copy doesn't affect internal dict
+    all_metrics["c2"] = CollectorMetrics(collector_name="c2")
+    assert "c2" not in mc.collector_metrics
+
+
+def test_get_recent_performance_metrics_empty():
+    mc = MetricsCollector()
+    assert mc.get_recent_performance_metrics() == []
+
+
+def test_get_recent_performance_metrics_limit():
+    mc = MetricsCollector()
+    for i in range(10):
+        mc.record_performance_metric(f"m{i}", float(i), MetricUnit.COUNT)
+    recent = mc.get_recent_performance_metrics(limit=3)
+    assert len(recent) == 3
+    assert [m.name for m in recent] == ["m7", "m8", "m9"]
+
+
+def test_export_snapshot():
+    mc = MetricsCollector()
+    mc.record_collector_run("c1", 10.0, 5, 0, 1, 0, 0, True)
+    mc.record_performance_metric("lat", 10.0, MetricUnit.MILLISECONDS)
+    snap = mc.export_snapshot()
+    assert set(snap.keys()) == {
+        "snapshot_time",
+        "system_metrics",
+        "collector_metrics",
+        "performance_metrics",
+    }
+    assert isinstance(snap["snapshot_time"], str)
+    assert "c1" in snap["collector_metrics"]
+    assert snap["system_metrics"]["total_collectors"] == 1
+    assert len(snap["performance_metrics"]) == 1
+    assert snap["performance_metrics"][0]["name"] == "lat"

--- a/tests/unit/operations_center/policy/__init__.py
+++ b/tests/unit/operations_center/policy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/policy/test_engine_cov.py
+++ b/tests/unit/operations_center/policy/test_engine_cov.py
@@ -1,0 +1,864 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from operations_center.contracts.common import (
+    BranchPolicy,
+    TaskTarget,
+    ValidationProfile,
+)
+from operations_center.contracts.enums import (
+    BackendName,
+    ExecutionMode,
+    LaneName,
+    RiskLevel,
+    TaskType,
+)
+from operations_center.contracts.execution import OcExecutionRequest
+from operations_center.contracts.proposal import OcPlanningProposal
+from operations_center.contracts.routing import OcRoutingDecision
+from operations_center.policy.engine import (
+    PolicyEngine,
+    _build_notes,
+    _check_branch_guardrail,
+    _check_path_restrictions,
+    _check_repo_enabled,
+    _check_review_requirements,
+    _check_routing_constraints,
+    _check_task_type,
+    _check_tool_guardrail,
+    _check_validation_requirements,
+    _determine_status,
+    _effective_review_requirement,
+    _effective_scope,
+    _effective_validation_profile,
+    _match_path_rule,
+    _validation_req_applies,
+)
+from operations_center.policy.models import (
+    BranchGuardrail,
+    PathPolicy,
+    PathScopeRule,
+    PolicyConfig,
+    PolicyDecision,
+    PolicyStatus,
+    PolicyViolation,
+    PolicyWarning,
+    RepoPolicy,
+    ReviewRequirement,
+    ToolGuardrail,
+    ValidationRequirement,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _make_proposal(
+    *,
+    repo_key: str = "repo-a",
+    base_branch: str = "main",
+    allowed_paths: list[str] | None = None,
+    task_type: TaskType = TaskType.SIMPLE_EDIT,
+    risk_level: RiskLevel = RiskLevel.LOW,
+    labels: list[str] | None = None,
+    branch_prefix: str = "auto/",
+    open_pr: bool = False,
+    validation_commands: list[str] | None = None,
+) -> OcPlanningProposal:
+    return OcPlanningProposal(
+        task_id="t-1",
+        project_id="p-1",
+        task_type=task_type,
+        execution_mode=ExecutionMode.GOAL,
+        goal_text="do the thing",
+        target=TaskTarget(
+            repo_key=repo_key,
+            clone_url="https://example.invalid/r.git",
+            base_branch=base_branch,
+            allowed_paths=allowed_paths or [],
+        ),
+        risk_level=risk_level,
+        validation_profile=ValidationProfile(
+            profile_name="default",
+            commands=validation_commands or [],
+        ),
+        branch_policy=BranchPolicy(branch_prefix=branch_prefix, open_pr=open_pr),
+        labels=labels or [],
+    )
+
+
+def _make_decision(lane: LaneName = LaneName.AIDER_LOCAL) -> OcRoutingDecision:
+    backend = BackendName.AIDER_LOCAL if lane == LaneName.AIDER_LOCAL else BackendName.OPENCLAW
+    return OcRoutingDecision(
+        proposal_id="prop-1",
+        selected_lane=lane,
+        selected_backend=backend,
+    )
+
+
+def _make_request(
+    *,
+    allowed_paths: list[str] | None = None,
+    validation_commands: list[str] | None = None,
+    tmp_path: Path | None = None,
+) -> OcExecutionRequest:
+    return OcExecutionRequest(
+        proposal_id="prop-1",
+        decision_id="dec-1",
+        goal_text="do the thing",
+        repo_key="repo-a",
+        clone_url="https://example.invalid/r.git",
+        base_branch="main",
+        task_branch="auto/x",
+        workspace_path=(tmp_path or Path("/tmp")) / "ws",
+        allowed_paths=allowed_paths or [],
+        validation_commands=validation_commands or [],
+    )
+
+
+def _simple_policy(**kwargs) -> RepoPolicy:
+    """A maximally-permissive policy unless overridden."""
+    defaults: dict = dict(
+        repo_key="repo-a",
+        enabled=True,
+        path_policy=PathPolicy(rules=[], default_mode="allow"),
+        branch_guardrail=BranchGuardrail(allow_direct_commit=True),
+        tool_guardrail=ToolGuardrail(network_mode="allowed", allow_destructive_actions=True),
+        validation_requirements=[],
+        review_requirement=ReviewRequirement(autonomous_allowed=True),
+    )
+    defaults.update(kwargs)
+    return RepoPolicy(**defaults)
+
+
+def _engine_with(policy: RepoPolicy) -> PolicyEngine:
+    return PolicyEngine.from_config(PolicyConfig(repo_policies=[policy], default_policy=policy))
+
+
+# ---------------------------------------------------------------------------
+# Constructors
+# ---------------------------------------------------------------------------
+
+
+def test_from_defaults_builds_engine():
+    engine = PolicyEngine.from_defaults()
+    assert isinstance(engine, PolicyEngine)
+
+
+def test_from_config_builds_engine():
+    cfg = PolicyConfig(repo_policies=[_simple_policy()])
+    engine = PolicyEngine.from_config(cfg)
+    assert isinstance(engine, PolicyEngine)
+
+
+# ---------------------------------------------------------------------------
+# Happy path / clean allow
+# ---------------------------------------------------------------------------
+
+
+def test_clean_allow():
+    engine = _engine_with(_simple_policy())
+    decision = engine.evaluate(_make_proposal(), _make_decision())
+    assert decision.status == PolicyStatus.ALLOW
+    assert decision.is_allowed
+    assert not decision.is_blocked
+    assert decision.violations == []
+    assert decision.warnings == []
+    assert decision.effective_validation_profile == "standard"
+    assert decision.effective_review_requirement == "autonomous"
+    assert decision.notes == ""
+
+
+# ---------------------------------------------------------------------------
+# 1. Repo enabled (early return on blocking)
+# ---------------------------------------------------------------------------
+
+
+def test_repo_disabled_blocks_and_short_circuits():
+    engine = _engine_with(_simple_policy(enabled=False))
+    decision = engine.evaluate(_make_proposal(), _make_decision())
+    assert decision.is_blocked
+    assert any(v.rule_id == "repo.disabled" for v in decision.violations)
+    # short-circuit: only the one violation
+    assert len(decision.violations) == 1
+
+
+def test_check_repo_enabled_when_enabled_adds_nothing():
+    out: list[PolicyViolation] = []
+    _check_repo_enabled(_simple_policy(enabled=True), out)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Task type restrictions
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_task_type():
+    pol = _simple_policy(blocked_task_types=["simple_edit"])
+    engine = _engine_with(pol)
+    decision = engine.evaluate(_make_proposal(task_type=TaskType.SIMPLE_EDIT), _make_decision())
+    assert decision.is_blocked
+    assert any(v.rule_id == "task_type.blocked" for v in decision.violations)
+
+
+def test_task_type_not_in_allowlist():
+    pol = _simple_policy(allowed_task_types=["bug_fix"])
+    engine = _engine_with(pol)
+    decision = engine.evaluate(_make_proposal(task_type=TaskType.SIMPLE_EDIT), _make_decision())
+    assert decision.is_blocked
+    assert any(v.rule_id == "task_type.not_in_allowlist" for v in decision.violations)
+
+
+def test_task_type_in_allowlist_ok():
+    pol = _simple_policy(allowed_task_types=["simple_edit"])
+    out: list[PolicyViolation] = []
+    _check_task_type(_make_proposal(task_type=TaskType.SIMPLE_EDIT), pol, out)
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Routing constraints
+# ---------------------------------------------------------------------------
+
+
+def test_routing_local_only_violated_on_remote_lane():
+    out: list[PolicyViolation] = []
+    _check_routing_constraints(
+        _make_proposal(labels=["local_only"]),
+        _make_decision(LaneName.CLAUDE_CLI),
+        out,
+    )
+    assert any(v.rule_id == "routing.local_only_violated" for v in out)
+    assert out[0].blocking
+
+
+def test_routing_local_only_satisfied_on_local_lane():
+    out: list[PolicyViolation] = []
+    _check_routing_constraints(
+        _make_proposal(labels=["no_remote"]),
+        _make_decision(LaneName.AIDER_LOCAL),
+        out,
+    )
+    assert out == []
+
+
+def test_routing_no_local_label_skips():
+    out: list[PolicyViolation] = []
+    _check_routing_constraints(
+        _make_proposal(labels=["whatever"]),
+        _make_decision(LaneName.CLAUDE_CLI),
+        out,
+    )
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Path restrictions
+# ---------------------------------------------------------------------------
+
+
+def test_no_paths_default_block():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="block"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=[]), pol, None, v, w)
+    assert any(x.rule_id == "path.unrestricted_writes_blocked" for x in v)
+
+
+def test_no_paths_default_review_required_warns():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="review_required"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=[]), pol, None, v, w)
+    assert v == []
+    assert any(x.rule_id == "path.unrestricted_writes_review" for x in w)
+
+
+def test_no_paths_default_allow_silent():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="allow"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=[]), pol, None, v, w)
+    assert v == [] and w == []
+
+
+def test_path_no_rule_match_default_block():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="block"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["src/x.py"]), pol, None, v, w)
+    assert any(x.rule_id == "path.default_blocked" for x in v)
+
+
+def test_path_no_rule_match_default_review_required():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="review_required"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["src/x.py"]), pol, None, v, w)
+    rule = next(x for x in v if x.rule_id == "path.default_review_required")
+    assert rule.blocking is False
+    assert rule.related_path == "src/x.py"
+
+
+def test_path_no_rule_match_default_allow_silent():
+    pol = _simple_policy(path_policy=PathPolicy(rules=[], default_mode="allow"))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["src/x.py"]), pol, None, v, w)
+    assert v == [] and w == []
+
+
+def test_path_matched_block_rule():
+    pol = _simple_policy(
+        path_policy=PathPolicy(
+            rules=[PathScopeRule(path_pattern="secrets/*", access_mode="block")],
+            default_mode="allow",
+        )
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["secrets/key"]), pol, None, v, w)
+    assert any(x.rule_id == "path.blocked" and x.blocking for x in v)
+
+
+def test_path_matched_review_rule():
+    pol = _simple_policy(
+        path_policy=PathPolicy(
+            rules=[PathScopeRule(path_pattern="*.env", access_mode="review_required")],
+            default_mode="allow",
+        )
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["app.env"]), pol, None, v, w)
+    rule = next(x for x in v if x.rule_id == "path.review_required")
+    assert rule.blocking is False
+
+
+def test_path_matched_read_only_rule():
+    pol = _simple_policy(
+        path_policy=PathPolicy(
+            rules=[PathScopeRule(path_pattern="ro/*", access_mode="read_only")],
+            default_mode="allow",
+        )
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["ro/file"]), pol, None, v, w)
+    assert any(x.rule_id == "path.review_required" for x in v)
+
+
+def test_path_matched_allow_rule_silent():
+    pol = _simple_policy(
+        path_policy=PathPolicy(
+            rules=[PathScopeRule(path_pattern="ok/*", access_mode="allow")],
+            default_mode="block",
+        )
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_path_restrictions(_make_proposal(allowed_paths=["ok/file"]), pol, None, v, w)
+    assert v == [] and w == []
+
+
+def test_path_request_overrides_proposal(tmp_path):
+    pol = _simple_policy(
+        path_policy=PathPolicy(
+            rules=[PathScopeRule(path_pattern="secrets/*", access_mode="block")],
+            default_mode="allow",
+        )
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    req = _make_request(allowed_paths=["secrets/key"], tmp_path=tmp_path)
+    # proposal has a benign path, request has the sensitive one — request wins
+    _check_path_restrictions(_make_proposal(allowed_paths=["ok/file"]), pol, req, v, w)
+    assert any(x.rule_id == "path.blocked" for x in v)
+
+
+# ---------------------------------------------------------------------------
+# _match_path_rule
+# ---------------------------------------------------------------------------
+
+
+def test_match_path_rule_first_match_wins():
+    pp = PathPolicy(
+        rules=[
+            PathScopeRule(path_pattern="a/*", access_mode="allow"),
+            PathScopeRule(path_pattern="a/b", access_mode="block"),
+        ]
+    )
+    rule = _match_path_rule("a/b", pp, "simple_edit")
+    assert rule.access_mode == "allow"
+
+
+def test_match_path_rule_task_type_filter_skips():
+    pp = PathPolicy(
+        rules=[
+            PathScopeRule(
+                path_pattern="a/*", access_mode="block", applies_to_task_types=["feature"]
+            )
+        ]
+    )
+    # task type does not match the rule's applies_to_task_types
+    assert _match_path_rule("a/x", pp, "simple_edit") is None
+    # matching task type uses the rule
+    assert _match_path_rule("a/x", pp, "feature").access_mode == "block"
+
+
+def test_match_path_rule_no_match_returns_none():
+    pp = PathPolicy(rules=[PathScopeRule(path_pattern="z/*", access_mode="block")])
+    assert _match_path_rule("a/x", pp, "simple_edit") is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Branch guardrail
+# ---------------------------------------------------------------------------
+
+
+def test_branch_no_prefix_warns():
+    pol = _simple_policy(branch_guardrail=BranchGuardrail(allow_direct_commit=False))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(branch_prefix=""), pol, v, w)
+    assert any(x.rule_id == "branch.no_prefix_set" for x in w)
+
+
+def test_branch_prefix_present_no_warn():
+    pol = _simple_policy(branch_guardrail=BranchGuardrail(allow_direct_commit=False))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(branch_prefix="auto/"), pol, v, w)
+    assert not any(x.rule_id == "branch.no_prefix_set" for x in w)
+
+
+def test_branch_allow_direct_commit_no_warn():
+    pol = _simple_policy(branch_guardrail=BranchGuardrail(allow_direct_commit=True))
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(branch_prefix=""), pol, v, w)
+    assert w == []
+
+
+def test_branch_base_not_allowed_blocks():
+    pol = _simple_policy(
+        branch_guardrail=BranchGuardrail(allow_direct_commit=True, allowed_base_branches=["main"])
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(base_branch="dev"), pol, v, w)
+    assert any(x.rule_id == "branch.base_branch_not_allowed" and x.blocking for x in v)
+
+
+def test_branch_base_allowed_ok():
+    pol = _simple_policy(
+        branch_guardrail=BranchGuardrail(allow_direct_commit=True, allowed_base_branches=["main"])
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(base_branch="main"), pol, v, w)
+    assert v == []
+
+
+def test_branch_pr_required_but_missing():
+    pol = _simple_policy(
+        branch_guardrail=BranchGuardrail(allow_direct_commit=True, require_pr=True)
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(open_pr=False), pol, v, w)
+    rule = next(x for x in v if x.rule_id == "branch.pr_required")
+    assert rule.blocking is False
+
+
+def test_branch_pr_required_and_present_ok():
+    pol = _simple_policy(
+        branch_guardrail=BranchGuardrail(allow_direct_commit=True, require_pr=True)
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_branch_guardrail(_make_proposal(open_pr=True), pol, v, w)
+    assert not any(x.rule_id == "branch.pr_required" for x in v)
+
+
+# ---------------------------------------------------------------------------
+# 6. Tool guardrail
+# ---------------------------------------------------------------------------
+
+
+def test_tool_network_local_only_remote_blocks():
+    pol = _simple_policy(tool_guardrail=ToolGuardrail(network_mode="local_only"))
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(_make_proposal(), _make_decision(LaneName.CLAUDE_CLI), pol, v)
+    assert any(x.rule_id == "tool.network_local_only" for x in v)
+
+
+def test_tool_network_local_only_local_ok():
+    pol = _simple_policy(tool_guardrail=ToolGuardrail(network_mode="local_only"))
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(_make_proposal(), _make_decision(LaneName.AIDER_LOCAL), pol, v)
+    assert v == []
+
+
+def test_tool_network_blocked():
+    pol = _simple_policy(tool_guardrail=ToolGuardrail(network_mode="blocked"))
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(_make_proposal(), _make_decision(LaneName.AIDER_LOCAL), pol, v)
+    assert any(x.rule_id == "tool.network_blocked" for x in v)
+
+
+def test_tool_network_allowed_silent():
+    pol = _simple_policy(tool_guardrail=ToolGuardrail(network_mode="allowed"))
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(_make_proposal(), _make_decision(LaneName.CLAUDE_CLI), pol, v)
+    assert v == []
+
+
+def test_tool_destructive_blocked():
+    pol = _simple_policy(
+        tool_guardrail=ToolGuardrail(network_mode="allowed", allow_destructive_actions=False)
+    )
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(
+        _make_proposal(labels=["Force_Push"]), _make_decision(LaneName.AIDER_LOCAL), pol, v
+    )
+    assert any(x.rule_id == "tool.destructive_blocked" for x in v)
+
+
+def test_tool_destructive_allowed_silent():
+    pol = _simple_policy(
+        tool_guardrail=ToolGuardrail(network_mode="allowed", allow_destructive_actions=True)
+    )
+    v: list[PolicyViolation] = []
+    _check_tool_guardrail(
+        _make_proposal(labels=["force_push"]), _make_decision(LaneName.AIDER_LOCAL), pol, v
+    )
+    assert v == []
+
+
+# ---------------------------------------------------------------------------
+# 7. Validation requirements
+# ---------------------------------------------------------------------------
+
+
+def test_validation_required_unavailable_blocks():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(
+                applies_to_risk_levels=["high"],
+                required_profile="strict",
+                block_if_unavailable=True,
+            )
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, validation_commands=[]), pol, None, v, w
+    )
+    assert any(x.rule_id == "validation.required_unavailable" for x in v)
+
+
+def test_validation_recommended_unavailable_warns():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(
+                applies_to_risk_levels=["medium"],
+                required_profile="standard",
+                block_if_unavailable=False,
+            )
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.MEDIUM, validation_commands=[]), pol, None, v, w
+    )
+    assert any(x.rule_id == "validation.recommended_unavailable" for x in w)
+
+
+def test_validation_available_via_proposal_silent():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(applies_to_risk_levels=["high"], block_if_unavailable=True)
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, validation_commands=["pytest"]), pol, None, v, w
+    )
+    assert v == [] and w == []
+
+
+def test_validation_available_via_request_silent(tmp_path):
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(applies_to_risk_levels=["high"], block_if_unavailable=True)
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    req = _make_request(validation_commands=["pytest"], tmp_path=tmp_path)
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, validation_commands=[]), pol, req, v, w
+    )
+    assert v == [] and w == []
+
+
+def test_validation_no_applicable_requirement():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(applies_to_risk_levels=["high"], block_if_unavailable=True)
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.LOW, validation_commands=[]), pol, None, v, w
+    )
+    assert v == [] and w == []
+
+
+def test_validation_only_first_match_used():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(applies_to_risk_levels=["high"], block_if_unavailable=True),
+            ValidationRequirement(applies_to_risk_levels=["high"], block_if_unavailable=True),
+        ]
+    )
+    v: list[PolicyViolation] = []
+    w: list[PolicyWarning] = []
+    _check_validation_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, validation_commands=[]), pol, None, v, w
+    )
+    assert len(v) == 1
+
+
+# ---------------------------------------------------------------------------
+# _validation_req_applies
+# ---------------------------------------------------------------------------
+
+
+def test_validation_req_applies_matrix():
+    vr_all = ValidationRequirement()
+    assert _validation_req_applies(vr_all, "low", "feature") is True
+
+    vr_risk = ValidationRequirement(applies_to_risk_levels=["high"])
+    assert _validation_req_applies(vr_risk, "high", "x") is True
+    assert _validation_req_applies(vr_risk, "low", "x") is False
+
+    vr_type = ValidationRequirement(applies_to_task_types=["feature"])
+    assert _validation_req_applies(vr_type, "low", "feature") is True
+    assert _validation_req_applies(vr_type, "low", "bug_fix") is False
+
+
+# ---------------------------------------------------------------------------
+# 8. Review requirements
+# ---------------------------------------------------------------------------
+
+
+def test_review_blocked_without_human():
+    pol = _simple_policy(review_requirement=ReviewRequirement(blocked_without_human=True))
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(), pol, v)
+    assert len(v) == 1
+    assert v[0].rule_id == "review.blocked_without_human" and v[0].blocking
+
+
+def test_review_required_when_not_autonomous():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=False))
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(), pol, v)
+    assert any(x.rule_id == "review.required" and not x.blocking for x in v)
+
+
+def test_review_required_label():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=True))
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(labels=["review_required"]), pol, v)
+    assert any(x.rule_id == "review.required" for x in v)
+
+
+def test_review_required_by_risk():
+    pol = _simple_policy(
+        review_requirement=ReviewRequirement(require_review_for_risk_levels=["high"])
+    )
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(risk_level=RiskLevel.HIGH), pol, v)
+    assert any(x.rule_id == "review.required" for x in v)
+
+
+def test_review_required_by_task_type():
+    pol = _simple_policy(
+        review_requirement=ReviewRequirement(require_review_for_task_types=["feature"])
+    )
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(task_type=TaskType.FEATURE), pol, v)
+    assert any(x.rule_id == "review.required" for x in v)
+
+
+def test_review_trusted_source_bypasses_risk_gate():
+    pol = _simple_policy(
+        review_requirement=ReviewRequirement(require_review_for_risk_levels=["high"])
+    )
+    v: list[PolicyViolation] = []
+    _check_review_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, labels=["source: autonomy"]), pol, v
+    )
+    assert v == []
+
+
+def test_review_trusted_source_still_honors_review_required_label():
+    pol = _simple_policy(
+        review_requirement=ReviewRequirement(require_review_for_risk_levels=["high"])
+    )
+    v: list[PolicyViolation] = []
+    _check_review_requirements(
+        _make_proposal(risk_level=RiskLevel.HIGH, labels=["source: autonomy", "review_required"]),
+        pol,
+        v,
+    )
+    assert any(x.rule_id == "review.required" for x in v)
+
+
+def test_review_clean_no_violation():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=True))
+    v: list[PolicyViolation] = []
+    _check_review_requirements(_make_proposal(risk_level=RiskLevel.LOW), pol, v)
+    assert v == []
+
+
+# ---------------------------------------------------------------------------
+# Decision builder helpers
+# ---------------------------------------------------------------------------
+
+
+def test_determine_status_block():
+    assert _determine_status(
+        [PolicyViolation(rule_id="r", category="c", blocking=True, message="m")], []
+    ) == (PolicyStatus.BLOCK)
+
+
+def test_determine_status_require_review():
+    assert (
+        _determine_status(
+            [PolicyViolation(rule_id="r", category="c", blocking=False, message="m")], []
+        )
+        == PolicyStatus.REQUIRE_REVIEW
+    )
+
+
+def test_determine_status_allow_with_warnings():
+    assert _determine_status([], [PolicyWarning(rule_id="r", category="c", message="m")]) == (
+        PolicyStatus.ALLOW_WITH_WARNINGS
+    )
+
+
+def test_determine_status_allow():
+    assert _determine_status([], []) == PolicyStatus.ALLOW
+
+
+def test_effective_validation_profile_match():
+    pol = _simple_policy(
+        validation_requirements=[
+            ValidationRequirement(applies_to_risk_levels=["high"], required_profile="strict")
+        ]
+    )
+    assert _effective_validation_profile(_make_proposal(risk_level=RiskLevel.HIGH), pol, None) == (
+        "strict"
+    )
+
+
+def test_effective_validation_profile_default():
+    pol = _simple_policy(validation_requirements=[])
+    assert _effective_validation_profile(_make_proposal(), pol, None) == "standard"
+
+
+def test_effective_review_requirement_from_violation():
+    pol = _simple_policy()
+    v = [PolicyViolation(rule_id="review.required", category="review", blocking=False, message="m")]
+    assert _effective_review_requirement(_make_proposal(), pol, v) == "required"
+
+
+def test_effective_review_requirement_from_policy_flag():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=False))
+    assert _effective_review_requirement(_make_proposal(), pol, []) == "required"
+
+
+def test_effective_review_requirement_autonomous():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=True))
+    assert _effective_review_requirement(_make_proposal(), pol, []) == "autonomous"
+
+
+def test_effective_scope_request_priority(tmp_path):
+    req = _make_request(allowed_paths=["a/*"], tmp_path=tmp_path)
+    assert _effective_scope(_make_proposal(allowed_paths=["b/*"]), req) == ["a/*"]
+
+
+def test_effective_scope_proposal_fallback():
+    assert _effective_scope(_make_proposal(allowed_paths=["b/*"]), None) == ["b/*"]
+
+
+def test_build_notes_violations_and_warnings():
+    notes = _build_notes(
+        [PolicyViolation(rule_id="v1", category="c", blocking=True, message="m")],
+        [PolicyWarning(rule_id="w1", category="c", message="m")],
+    )
+    assert "violations: v1" in notes and "warnings: w1" in notes
+
+
+def test_build_notes_empty():
+    assert _build_notes([], []) == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end evaluate combinations
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_require_review_status():
+    pol = _simple_policy(review_requirement=ReviewRequirement(autonomous_allowed=False))
+    engine = _engine_with(pol)
+    decision = engine.evaluate(_make_proposal(), _make_decision())
+    assert decision.requires_review
+    assert decision.effective_review_requirement == "required"
+
+
+def test_evaluate_allow_with_warnings_status():
+    pol = _simple_policy(branch_guardrail=BranchGuardrail(allow_direct_commit=False))
+    engine = _engine_with(pol)
+    decision = engine.evaluate(_make_proposal(branch_prefix=""), _make_decision())
+    assert decision.status == PolicyStatus.ALLOW_WITH_WARNINGS
+    assert isinstance(decision, PolicyDecision)
+
+
+def test_evaluate_block_status_full_pipeline():
+    pol = _simple_policy(tool_guardrail=ToolGuardrail(network_mode="blocked"))
+    engine = _engine_with(pol)
+    decision = engine.evaluate(_make_proposal(), _make_decision())
+    assert decision.is_blocked
+    assert "tool.network_blocked" in decision.notes
+
+
+def test_evaluate_with_request(tmp_path):
+    pol = _simple_policy()
+    engine = _engine_with(pol)
+    req = _make_request(allowed_paths=["src/*"], tmp_path=tmp_path)
+    decision = engine.evaluate(_make_proposal(), _make_decision(), req)
+    assert decision.effective_scope == ["src/*"]
+
+
+def test_evaluate_uses_default_policy_for_unknown_repo():
+    engine = PolicyEngine.from_defaults()
+    decision = engine.evaluate(
+        _make_proposal(repo_key="never-configured", risk_level=RiskLevel.LOW), _make_decision()
+    )
+    assert isinstance(decision, PolicyDecision)

--- a/tests/unit/operations_center/tuning/__init__.py
+++ b/tests/unit/operations_center/tuning/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/operations_center/tuning/test_applier_cov.py
+++ b/tests/unit/operations_center/tuning/test_applier_cov.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from operations_center.tuning.applier import (
+    TuningApplier,
+    _DEFAULTS,
+    load_tuning_config,
+)
+from operations_center.tuning.models import TuningChange, TuningConfig
+
+_GEN_AT = datetime(2026, 6, 2, 12, 0, 0)
+
+
+def _write_config(path: Path, overrides: dict, version: int = 1) -> None:
+    cfg = TuningConfig(version=version, updated_at=_GEN_AT, overrides=overrides)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(cfg.model_dump_json(indent=2), encoding="utf-8")
+
+
+# --- load_tuning_config -------------------------------------------------
+
+
+def test_load_tuning_config_missing_returns_none(tmp_path):
+    assert load_tuning_config(tmp_path / "nope.json") is None
+
+
+def test_load_tuning_config_valid(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(p, {"observation_coverage": {"min_consecutive_runs": 3}})
+    cfg = load_tuning_config(p)
+    assert cfg is not None
+    assert cfg.overrides["observation_coverage"]["min_consecutive_runs"] == 3
+
+
+def test_load_tuning_config_invalid_json_returns_none(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert load_tuning_config(p) is None
+
+
+def test_load_tuning_config_invalid_schema_returns_none(tmp_path):
+    p = tmp_path / "schema.json"
+    # Missing required updated_at field -> validation error -> None.
+    p.write_text(json.dumps({"version": "abc", "overrides": []}), encoding="utf-8")
+    assert load_tuning_config(p) is None
+
+
+def test_load_tuning_config_default_path(monkeypatch, tmp_path):
+    # No path given -> uses module default, which does not exist here.
+    monkeypatch.chdir(tmp_path)
+    assert load_tuning_config() is None
+
+
+# --- current_value ------------------------------------------------------
+
+
+def test_current_value_from_file(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(p, {"test_visibility": {"min_consecutive_runs": 4}})
+    applier = TuningApplier(config_path=p)
+    assert applier.current_value("test_visibility", "min_consecutive_runs") == 4
+
+
+def test_current_value_falls_back_to_defaults_when_no_file(tmp_path):
+    applier = TuningApplier(config_path=tmp_path / "missing.json")
+    assert applier.current_value("observation_coverage", "min_consecutive_runs") == 2
+    assert applier.current_value("test_visibility", "min_consecutive_runs") == 3
+    assert applier.current_value("dependency_drift", "min_consecutive_runs") == 2
+
+
+def test_current_value_unknown_family_returns_two(tmp_path):
+    applier = TuningApplier(config_path=tmp_path / "missing.json")
+    assert applier.current_value("unknown_family", "min_consecutive_runs") == 2
+
+
+def test_current_value_non_int_override_falls_back(tmp_path):
+    p = tmp_path / "tuning.json"
+    # Override present but not an int -> isinstance check fails -> defaults.
+    _write_config(p, {"observation_coverage": {"min_consecutive_runs": "five"}})
+    applier = TuningApplier(config_path=p)
+    assert applier.current_value("observation_coverage", "min_consecutive_runs") == 2
+
+
+def test_current_value_family_present_key_absent(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(p, {"observation_coverage": {"other_key": 9}})
+    applier = TuningApplier(config_path=p)
+    # Key not in overrides -> default for family.
+    assert applier.current_value("observation_coverage", "min_consecutive_runs") == 2
+
+
+# --- apply --------------------------------------------------------------
+
+
+def test_apply_key_not_in_auto_apply_keys_returns_none(tmp_path):
+    p = tmp_path / "tuning.json"
+    applier = TuningApplier(config_path=p)
+    result = applier.apply(
+        "observation_coverage", "not_a_key", "loosen_threshold", "because", _GEN_AT
+    )
+    assert result is None
+    assert not p.exists()
+
+
+def test_apply_invalid_action_returns_none(tmp_path):
+    p = tmp_path / "tuning.json"
+    applier = TuningApplier(config_path=p)
+    # Valid key but action yields new_value None.
+    result = applier.apply("observation_coverage", "min_consecutive_runs", "keep", "noop", _GEN_AT)
+    assert result is None
+    assert not p.exists()
+
+
+def test_apply_new_value_out_of_range_returns_none(tmp_path):
+    p = tmp_path / "tuning.json"
+    # current = 1 (min), loosen -> 0 which is below MIN -> None.
+    _write_config(p, {"observation_coverage": {"min_consecutive_runs": 1}})
+    applier = TuningApplier(config_path=p)
+    result = applier.apply(
+        "observation_coverage", "min_consecutive_runs", "loosen_threshold", "r", _GEN_AT
+    )
+    assert result is None
+
+
+def test_apply_tighten_creates_file_when_none_exists(tmp_path):
+    p = tmp_path / "nested" / "tuning.json"
+    applier = TuningApplier(config_path=p)
+    # Default for observation_coverage is 2; tighten -> 3.
+    change = applier.apply(
+        "observation_coverage", "min_consecutive_runs", "tighten_threshold", "drift up", _GEN_AT
+    )
+    assert isinstance(change, TuningChange)
+    assert change.before == 2
+    assert change.after == 3
+    assert change.family == "observation_coverage"
+    assert change.key == "min_consecutive_runs"
+    assert change.reason == "drift up"
+    assert change.applied_at == _GEN_AT
+
+    assert p.exists()
+    written = load_tuning_config(p)
+    assert written is not None
+    assert written.overrides["observation_coverage"]["min_consecutive_runs"] == 3
+    assert written.updated_at == _GEN_AT
+    # Default version on a freshly created config.
+    assert written.version == 1
+
+
+def test_apply_loosen_existing_config_preserves_other_families(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(
+        p,
+        {
+            "observation_coverage": {"min_consecutive_runs": 3},
+            "test_visibility": {"min_consecutive_runs": 4},
+        },
+        version=7,
+    )
+    applier = TuningApplier(config_path=p)
+    change = applier.apply(
+        "observation_coverage", "min_consecutive_runs", "loosen_threshold", "fewer", _GEN_AT
+    )
+    assert change is not None
+    assert change.before == 3
+    assert change.after == 2
+
+    written = load_tuning_config(p)
+    assert written is not None
+    # Preserves version from existing config.
+    assert written.version == 7
+    # Untouched family preserved.
+    assert written.overrides["test_visibility"]["min_consecutive_runs"] == 4
+    assert written.overrides["observation_coverage"]["min_consecutive_runs"] == 2
+
+
+def test_apply_does_not_mutate_original_config_overrides(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(p, {"observation_coverage": {"min_consecutive_runs": 2, "extra": 1}})
+    applier = TuningApplier(config_path=p)
+    change = applier.apply(
+        "observation_coverage", "min_consecutive_runs", "tighten_threshold", "r", _GEN_AT
+    )
+    assert change is not None
+    written = load_tuning_config(p)
+    assert written is not None
+    # Sibling key inside the family override is preserved.
+    assert written.overrides["observation_coverage"]["extra"] == 1
+    assert written.overrides["observation_coverage"]["min_consecutive_runs"] == 3
+
+
+def test_apply_adds_new_family_to_existing_config(tmp_path):
+    p = tmp_path / "tuning.json"
+    _write_config(p, {"test_visibility": {"min_consecutive_runs": 3}})
+    applier = TuningApplier(config_path=p)
+    # dependency_drift not yet in overrides; default 2, tighten -> 3.
+    change = applier.apply(
+        "dependency_drift", "min_consecutive_runs", "tighten_threshold", "r", _GEN_AT
+    )
+    assert change is not None
+    assert change.before == 2
+    assert change.after == 3
+    written = load_tuning_config(p)
+    assert written is not None
+    assert written.overrides["dependency_drift"]["min_consecutive_runs"] == 3
+    assert written.overrides["test_visibility"]["min_consecutive_runs"] == 3
+
+
+def test_defaults_table_contents():
+    # Guard the module-level defaults so behavior is pinned.
+    assert _DEFAULTS["observation_coverage"]["min_consecutive_runs"] == 2
+    assert _DEFAULTS["test_visibility"]["min_consecutive_runs"] == 3
+    assert _DEFAULTS["dependency_drift"]["min_consecutive_runs"] == 2

--- a/tests/unit/operations_center/tuning/test_artifact_writer_cov.py
+++ b/tests/unit/operations_center/tuning/test_artifact_writer_cov.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from operations_center.tuning.artifact_writer import (
+    _DEFAULT_TUNING_ROOT,
+    TuningArtifactWriter,
+    _json_dumps,
+)
+from operations_center.tuning.models import (
+    FamilyMetrics,
+    SkippedTuningChange,
+    TuningChange,
+    TuningRecommendation,
+    TuningRunArtifact,
+)
+
+
+def _ts() -> datetime:
+    return datetime(2026, 6, 2, 12, 30, 0, tzinfo=timezone.utc)
+
+
+def _full_artifact(run_id: str = "run-001") -> TuningRunArtifact:
+    return TuningRunArtifact(
+        run_id=run_id,
+        generated_at=_ts(),
+        source_command="oc tune",
+        dry_run=False,
+        auto_apply=True,
+        window_runs=10,
+        window_start=_ts(),
+        window_end=_ts(),
+        family_metrics=[
+            FamilyMetrics(family="observation_coverage", sample_runs=5, candidates_emitted=3)
+        ],
+        recommendations=[
+            TuningRecommendation(
+                family="observation_coverage",
+                action="loosen_threshold",
+                rationale="too strict",
+                confidence="high",
+                suggested_change={"min_consecutive_runs": {"from": 2, "to": 1}},
+            )
+        ],
+        changes_applied=[
+            TuningChange(
+                family="observation_coverage",
+                key="min_consecutive_runs",
+                before=2,
+                after=1,
+                reason="loosen",
+                applied_at=_ts(),
+            )
+        ],
+        changes_skipped=[
+            SkippedTuningChange(
+                family="other",
+                intended_action="tighten_threshold",
+                reason="cooldown_active",
+            )
+        ],
+    )
+
+
+def _empty_artifact() -> TuningRunArtifact:
+    # Exercises the None branches for window_start / window_end and empty lists.
+    return TuningRunArtifact(
+        run_id="run-empty",
+        generated_at=_ts(),
+        source_command="oc tune",
+        window_runs=0,
+    )
+
+
+def test_default_root_when_none() -> None:
+    writer = TuningArtifactWriter()
+    assert writer.tuning_root == _DEFAULT_TUNING_ROOT
+
+
+def test_explicit_root(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path / "custom")
+    assert writer.tuning_root == tmp_path / "custom"
+
+
+def test_write_returns_four_paths_under_run_dir(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    paths = writer.write(_full_artifact())
+
+    assert len(paths) == 4
+    run_dir = tmp_path / "run-001"
+    assert paths == [
+        str(run_dir / "tuning_run.json"),
+        str(run_dir / "family_tuning_summary.json"),
+        str(run_dir / "tuning_recommendations.json"),
+        str(run_dir / "tuning_changes.json"),
+    ]
+    for p in paths:
+        assert Path(p).is_file()
+
+
+def test_write_creates_nested_dirs(tmp_path: Path) -> None:
+    root = tmp_path / "a" / "b" / "c"
+    writer = TuningArtifactWriter(tuning_root=root)
+    writer.write(_full_artifact())
+    assert (root / "run-001").is_dir()
+
+
+def test_run_json_matches_model_dump(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    artifact = _full_artifact()
+    paths = writer.write(artifact)
+    run_data = json.loads(Path(paths[0]).read_text(encoding="utf-8"))
+    assert run_data == json.loads(artifact.model_dump_json(indent=2))
+
+
+def test_summary_json_content(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    artifact = _full_artifact()
+    paths = writer.write(artifact)
+    summary = json.loads(Path(paths[1]).read_text(encoding="utf-8"))
+
+    assert summary["run_id"] == "run-001"
+    assert summary["generated_at"] == _ts().isoformat()
+    assert summary["window_runs"] == 10
+    assert summary["window_start"] == _ts().isoformat()
+    assert summary["window_end"] == _ts().isoformat()
+    assert summary["family_metrics"][0]["family"] == "observation_coverage"
+
+
+def test_recommendations_json_content(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    paths = writer.write(_full_artifact())
+    rec = json.loads(Path(paths[2]).read_text(encoding="utf-8"))
+    assert rec["run_id"] == "run-001"
+    assert rec["recommendations"][0]["action"] == "loosen_threshold"
+
+
+def test_changes_json_content(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    paths = writer.write(_full_artifact())
+    changes = json.loads(Path(paths[3]).read_text(encoding="utf-8"))
+    assert changes["auto_apply"] is True
+    assert changes["changes_applied"][0]["key"] == "min_consecutive_runs"
+    assert changes["changes_skipped"][0]["reason"] == "cooldown_active"
+
+
+def test_write_with_none_windows_and_empty_lists(tmp_path: Path) -> None:
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    paths = writer.write(_empty_artifact())
+
+    summary = json.loads(Path(paths[1]).read_text(encoding="utf-8"))
+    assert summary["window_start"] is None
+    assert summary["window_end"] is None
+    assert summary["family_metrics"] == []
+
+    changes = json.loads(Path(paths[3]).read_text(encoding="utf-8"))
+    assert changes["auto_apply"] is False
+    assert changes["changes_applied"] == []
+    assert changes["changes_skipped"] == []
+
+
+def test_write_is_idempotent_existing_dir(tmp_path: Path) -> None:
+    # exist_ok=True: writing twice into the same run dir must not raise.
+    writer = TuningArtifactWriter(tuning_root=tmp_path)
+    writer.write(_full_artifact())
+    paths = writer.write(_full_artifact())
+    assert all(Path(p).is_file() for p in paths)
+
+
+def test_json_dumps_datetime_default_str() -> None:
+    out = _json_dumps({"ts": _ts()})
+    # default=str serializes via str(datetime), not isoformat().
+    assert str(_ts()) in out
+    assert json.loads(out)["ts"] == str(_ts())
+
+
+def test_json_dumps_non_ascii_preserved() -> None:
+    out = _json_dumps({"name": "café"})
+    assert "café" in out
+    assert "\\u" not in out
+
+
+def test_json_dumps_is_indented() -> None:
+    out = _json_dumps({"a": 1})
+    assert "\n" in out
+    assert "  " in out

--- a/tests/unit/operations_center/tuning/test_calibration_cov.py
+++ b/tests/unit/operations_center/tuning/test_calibration_cov.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from operations_center.tuning.calibration import (
+    _EXPECTED_RATES,
+    _MIN_SAMPLE_SIZE,
+    CalibrationRecord,
+    ConfidenceCalibrationStore,
+)
+
+
+@pytest.fixture
+def store_path(tmp_path: Path) -> Path:
+    return tmp_path / "state" / "calibration_store.json"
+
+
+@pytest.fixture
+def store(store_path: Path) -> ConfidenceCalibrationStore:
+    return ConfidenceCalibrationStore(path=store_path)
+
+
+def _iso_days_ago(days: float) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
+# --------------------------------------------------------------------------
+# CalibrationRecord
+# --------------------------------------------------------------------------
+def test_calibration_record_to_dict_roundtrip() -> None:
+    rec = CalibrationRecord(
+        family="lint_fix",
+        confidence="high",
+        total=10,
+        merged=8,
+        escalated=1,
+        abandoned=1,
+        acceptance_rate=0.8,
+        expected_rate=0.8,
+        calibration_ratio=1.0,
+        repo_key="repoA",
+    )
+    d = rec.to_dict()
+    assert d["family"] == "lint_fix"
+    assert d["repo_key"] == "repoA"
+    assert d["acceptance_rate"] == 0.8
+    # default repo_key is None
+    rec2 = CalibrationRecord(
+        family="f",
+        confidence="low",
+        total=1,
+        merged=0,
+        escalated=0,
+        abandoned=1,
+        acceptance_rate=0.0,
+        expected_rate=0.3,
+        calibration_ratio=0.0,
+    )
+    assert rec2.to_dict()["repo_key"] is None
+
+
+# --------------------------------------------------------------------------
+# record()
+# --------------------------------------------------------------------------
+def test_record_unknown_confidence_ignored(store: ConfidenceCalibrationStore) -> None:
+    store.record("lint_fix", "ultra", "merged")
+    assert not store._path.exists()
+
+
+def test_record_unknown_outcome_ignored(store: ConfidenceCalibrationStore) -> None:
+    store.record("lint_fix", "high", "exploded")
+    assert not store._path.exists()
+
+
+def test_record_persists_event_without_repo_key(
+    store: ConfidenceCalibrationStore, store_path: Path
+) -> None:
+    store.record("lint_fix", "high", "merged")
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert len(data["events"]) == 1
+    ev = data["events"][0]
+    assert ev["family"] == "lint_fix"
+    assert ev["confidence"] == "high"
+    assert ev["outcome"] == "merged"
+    assert "recorded_at" in ev
+    assert "repo_key" not in ev
+
+
+def test_record_with_repo_key(store: ConfidenceCalibrationStore, store_path: Path) -> None:
+    store.record("type_fix", "medium", "escalated", repo_key="repoB")
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert data["events"][0]["repo_key"] == "repoB"
+
+
+def test_record_appends_multiple(store: ConfidenceCalibrationStore, store_path: Path) -> None:
+    store.record("f", "high", "merged")
+    store.record("f", "high", "abandoned")
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert len(data["events"]) == 2
+
+
+# --------------------------------------------------------------------------
+# calibration_for()
+# --------------------------------------------------------------------------
+def test_calibration_for_below_min_sample(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(_MIN_SAMPLE_SIZE - 1):
+        store.record("f", "high", "merged")
+    assert store.calibration_for("f", "high") is None
+
+
+def test_calibration_for_returns_rate(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(3):
+        store.record("f", "high", "merged")
+    for _ in range(2):
+        store.record("f", "high", "escalated")
+    # 3 merged of 5 total
+    assert store.calibration_for("f", "high") == pytest.approx(3 / 5)
+
+
+def test_calibration_for_filters_by_repo_key(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(_MIN_SAMPLE_SIZE):
+        store.record("f", "high", "merged", repo_key="repoA")
+    # different repo present but should not be counted
+    store.record("f", "high", "merged", repo_key="repoB")
+    assert store.calibration_for("f", "high", repo_key="repoA") == 1.0
+    # repoB alone is below min sample
+    assert store.calibration_for("f", "high", repo_key="repoB") is None
+
+
+def test_calibration_for_global_counts_all_repos(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(3):
+        store.record("f", "high", "merged", repo_key="repoA")
+    for _ in range(2):
+        store.record("f", "high", "escalated", repo_key="repoB")
+    # global (repo_key=None) sees all 5
+    assert store.calibration_for("f", "high") == pytest.approx(3 / 5)
+
+
+def test_calibration_for_window_excludes_stale(
+    store: ConfidenceCalibrationStore, store_path: Path
+) -> None:
+    events = [
+        {
+            "recorded_at": _iso_days_ago(200),
+            "family": "f",
+            "confidence": "high",
+            "outcome": "merged",
+        }
+        for _ in range(_MIN_SAMPLE_SIZE)
+    ]
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"events": events}), encoding="utf-8")
+    # default window 90 days excludes everything
+    assert store.calibration_for("f", "high") is None
+    # window_days=None disables filtering
+    assert store.calibration_for("f", "high", window_days=None) == 1.0
+
+
+# --------------------------------------------------------------------------
+# cleanup_old_events()
+# --------------------------------------------------------------------------
+def test_cleanup_removes_stale_events(store: ConfidenceCalibrationStore, store_path: Path) -> None:
+    events = [
+        {
+            "recorded_at": _iso_days_ago(200),
+            "family": "f",
+            "confidence": "high",
+            "outcome": "merged",
+        },
+        {"recorded_at": _iso_days_ago(1), "family": "f", "confidence": "high", "outcome": "merged"},
+    ]
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"events": events}), encoding="utf-8")
+    removed = store.cleanup_old_events(window_days=90)
+    assert removed == 1
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    assert len(data["events"]) == 1
+
+
+def test_cleanup_no_removal_keeps_file_untouched(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(2):
+        store.record("f", "high", "merged")
+    removed = store.cleanup_old_events(window_days=90)
+    assert removed == 0
+
+
+def test_cleanup_window_none_short_circuits(
+    store: ConfidenceCalibrationStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # _cutoff(None) -> None, returns 0 without touching store
+    monkeypatch.setattr(
+        ConfidenceCalibrationStore, "_cutoff", staticmethod(lambda window_days: None)
+    )
+    assert store.cleanup_old_events(window_days=90) == 0
+
+
+# --------------------------------------------------------------------------
+# _cutoff()
+# --------------------------------------------------------------------------
+def test_cutoff_none() -> None:
+    assert ConfidenceCalibrationStore._cutoff(None) is None
+
+
+def test_cutoff_returns_iso() -> None:
+    cutoff = ConfidenceCalibrationStore._cutoff(90)
+    assert cutoff is not None
+    parsed = datetime.fromisoformat(cutoff)
+    delta = datetime.now(UTC) - parsed
+    assert timedelta(days=89) < delta < timedelta(days=91)
+
+
+# --------------------------------------------------------------------------
+# report()
+# --------------------------------------------------------------------------
+def test_report_skips_below_min_sample(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(_MIN_SAMPLE_SIZE - 1):
+        store.record("f", "high", "merged")
+    assert store.report() == []
+
+
+def test_report_global_aggregate(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(4):
+        store.record("lint_fix", "high", "merged", repo_key="repoA")
+    store.record("lint_fix", "high", "escalated", repo_key="repoB")
+    records = store.report()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.family == "lint_fix"
+    assert rec.confidence == "high"
+    assert rec.total == 5
+    assert rec.merged == 4
+    assert rec.escalated == 1
+    assert rec.abandoned == 0
+    assert rec.acceptance_rate == pytest.approx(0.8)
+    assert rec.expected_rate == _EXPECTED_RATES["high"]
+    assert rec.calibration_ratio == pytest.approx(1.0)
+    assert rec.repo_key is None  # global aggregate -> rk_val "" -> None
+
+
+def test_report_per_repo_grouping(store: ConfidenceCalibrationStore) -> None:
+    for _ in range(_MIN_SAMPLE_SIZE):
+        store.record("f", "medium", "merged", repo_key="repoA")
+    for _ in range(_MIN_SAMPLE_SIZE):
+        store.record("f", "medium", "abandoned", repo_key="repoB")
+    records = store.report(per_repo=True)
+    by_repo = {r.repo_key: r for r in records}
+    assert set(by_repo) == {"repoA", "repoB"}
+    assert by_repo["repoA"].merged == _MIN_SAMPLE_SIZE
+    assert by_repo["repoB"].abandoned == _MIN_SAMPLE_SIZE
+    assert by_repo["repoB"].acceptance_rate == 0.0
+    assert by_repo["repoB"].calibration_ratio == 0.0
+
+
+def test_report_per_repo_missing_repo_key_groups_empty(
+    store: ConfidenceCalibrationStore,
+) -> None:
+    # records without repo_key -> rk "" in per_repo grouping
+    for _ in range(_MIN_SAMPLE_SIZE):
+        store.record("f", "low", "merged")
+    records = store.report(per_repo=True)
+    assert len(records) == 1
+    assert records[0].repo_key is None  # rk_val "" -> None
+
+
+def test_report_ignores_invalid_family_or_confidence(
+    store: ConfidenceCalibrationStore, store_path: Path
+) -> None:
+    events = []
+    # empty family -> skipped
+    for _ in range(_MIN_SAMPLE_SIZE):
+        events.append(
+            {
+                "recorded_at": _iso_days_ago(1),
+                "family": "",
+                "confidence": "high",
+                "outcome": "merged",
+            }
+        )
+    # invalid confidence -> skipped
+    for _ in range(_MIN_SAMPLE_SIZE):
+        events.append(
+            {
+                "recorded_at": _iso_days_ago(1),
+                "family": "f",
+                "confidence": "ultra",
+                "outcome": "merged",
+            }
+        )
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"events": events}), encoding="utf-8")
+    assert store.report() == []
+    assert store.report(per_repo=True) == []
+
+
+def test_report_window_none_uses_all_events(
+    store: ConfidenceCalibrationStore, store_path: Path
+) -> None:
+    events = [
+        {
+            "recorded_at": _iso_days_ago(500),
+            "family": "f",
+            "confidence": "high",
+            "outcome": "merged",
+        }
+        for _ in range(_MIN_SAMPLE_SIZE)
+    ]
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"events": events}), encoding="utf-8")
+    assert store.report(window_days=None)  # not filtered
+    assert store.report(window_days=90) == []  # filtered out
+
+
+# --------------------------------------------------------------------------
+# _load() / _save()
+# --------------------------------------------------------------------------
+def test_load_missing_file_returns_empty(store: ConfidenceCalibrationStore) -> None:
+    assert store._load() == {"events": []}
+
+
+def test_load_corrupt_file_returns_empty(
+    store: ConfidenceCalibrationStore, store_path: Path
+) -> None:
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text("{not valid json", encoding="utf-8")
+    assert store._load() == {"events": []}
+
+
+def test_save_creates_parent_dirs(tmp_path: Path) -> None:
+    path = tmp_path / "deep" / "nested" / "store.json"
+    store = ConfidenceCalibrationStore(path=path)
+    store._save({"events": [{"x": 1}]})
+    assert path.exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == {"events": [{"x": 1}]}
+
+
+def test_default_path_constant() -> None:
+    s = ConfidenceCalibrationStore()
+    assert s._path == Path("state/calibration_store.json")

--- a/tests/unit/operations_center/tuning/test_guardrails_cov.py
+++ b/tests/unit/operations_center/tuning/test_guardrails_cov.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from operations_center.tuning import guardrails as gr
+from operations_center.tuning.guardrails import (
+    TuningGuardrails,
+    _compute_new_value,
+    _env_int,
+    compute_new_value,
+)
+from operations_center.tuning.models import (
+    TuningChange,
+    TuningRecommendation,
+    TuningRunArtifact,
+)
+
+_NOW = datetime(2026, 4, 4, 12, tzinfo=UTC)
+
+
+def _rec(
+    family: str = "observation_coverage",
+    action: str = "loosen_threshold",
+    evidence: dict[str, object] | None = None,
+) -> TuningRecommendation:
+    return TuningRecommendation(
+        family=family,
+        action=action,
+        rationale="test",
+        confidence="high",
+        evidence={} if evidence is None else evidence,
+    )
+
+
+def _prior_run_with_change(
+    family: str, before: int, after: int, applied_at: datetime
+) -> TuningRunArtifact:
+    return TuningRunArtifact(
+        run_id="tun_prior",
+        generated_at=applied_at,
+        source_command="test",
+        window_runs=10,
+        changes_applied=[
+            TuningChange(
+                family=family,
+                key="min_consecutive_runs",
+                before=before,
+                after=after,
+                reason="test",
+                applied_at=applied_at,
+            )
+        ],
+    )
+
+
+# --- _env_int ---
+
+
+def test_env_int_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOME_TUNING_KEY", raising=False)
+    assert _env_int("SOME_TUNING_KEY", 7) == 7
+
+
+def test_env_int_parses_valid_int(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOME_TUNING_KEY", "11")
+    assert _env_int("SOME_TUNING_KEY", 7) == 11
+
+
+def test_env_int_falls_back_on_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOME_TUNING_KEY", "not-a-number")
+    assert _env_int("SOME_TUNING_KEY", 7) == 7
+
+
+# --- constructor / defaults ---
+
+
+def test_constructor_uses_explicit_values() -> None:
+    g = TuningGuardrails(max_changes_per_day=9, family_cooldown_hours=3, min_sample_for_apply=4)
+    assert g.max_changes_per_day == 9
+    assert g.family_cooldown_hours == 3
+    assert g.min_sample_for_apply == 4
+
+
+def test_constructor_reads_env_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPERATIONS_CENTER_TUNING_MAX_CHANGES_PER_DAY", "8")
+    monkeypatch.setenv("OPERATIONS_CENTER_TUNING_FAMILY_COOLDOWN_HOURS", "24")
+    g = TuningGuardrails()
+    assert g.max_changes_per_day == 8
+    assert g.family_cooldown_hours == 24
+    assert g.min_sample_for_apply == gr._DEFAULT_MIN_SAMPLE_FOR_APPLY
+
+
+def test_constructor_uses_hardcoded_defaults_when_env_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPERATIONS_CENTER_TUNING_MAX_CHANGES_PER_DAY", raising=False)
+    monkeypatch.delenv("OPERATIONS_CENTER_TUNING_FAMILY_COOLDOWN_HOURS", raising=False)
+    g = TuningGuardrails()
+    assert g.max_changes_per_day == gr._DEFAULT_MAX_CHANGES_PER_DAY
+    assert g.family_cooldown_hours == gr._DEFAULT_FAMILY_COOLDOWN_HOURS
+
+
+def test_constructor_zero_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 0 is falsy so the `or` clause kicks in; env unset -> hardcoded default
+    monkeypatch.delenv("OPERATIONS_CENTER_TUNING_MAX_CHANGES_PER_DAY", raising=False)
+    g = TuningGuardrails(max_changes_per_day=0)
+    assert g.max_changes_per_day == gr._DEFAULT_MAX_CHANGES_PER_DAY
+
+
+# --- evaluate: families / actions ---
+
+
+def test_each_allowed_family_passes() -> None:
+    g = TuningGuardrails(max_changes_per_day=2, family_cooldown_hours=48, min_sample_for_apply=5)
+    for family in ("observation_coverage", "test_visibility", "dependency_drift"):
+        can, reason = g.evaluate(_rec(family=family), 2, [], [], _NOW, 10)
+        assert can, family
+        assert reason == ""
+
+
+def test_action_not_applicable_includes_action_name() -> None:
+    g = TuningGuardrails(min_sample_for_apply=5)
+    can, reason = g.evaluate(_rec(action="no_data"), 2, [], [], _NOW, 10)
+    assert not can
+    assert reason == "action_not_applicable:no_data"
+
+
+def test_sample_equal_to_minimum_passes() -> None:
+    g = TuningGuardrails(min_sample_for_apply=5)
+    can, reason = g.evaluate(_rec(), 2, [], [], _NOW, sample_runs=5)
+    assert can
+    assert reason == ""
+
+
+# --- evaluate: cooldown does not match other families ---
+
+
+def test_cooldown_ignores_other_family() -> None:
+    g = TuningGuardrails(max_changes_per_day=5, family_cooldown_hours=48, min_sample_for_apply=5)
+    prior = [_prior_run_with_change("test_visibility", 2, 1, _NOW - timedelta(hours=1))]
+    can, reason = g.evaluate(_rec("observation_coverage"), 2, prior, [], _NOW, 10)
+    assert can
+    assert reason == ""
+
+
+def test_cooldown_boundary_exactly_at_cutoff_blocks() -> None:
+    g = TuningGuardrails(max_changes_per_day=5, family_cooldown_hours=48, min_sample_for_apply=5)
+    prior = [_prior_run_with_change("observation_coverage", 2, 1, _NOW - timedelta(hours=48))]
+    can, reason = g.evaluate(_rec(), 2, prior, [], _NOW, 10)
+    assert not can
+    assert reason == "cooldown_active"
+
+
+# --- evaluate: quota counts only today and respects changes_so_far ---
+
+
+def test_quota_ignores_changes_before_today() -> None:
+    g = TuningGuardrails(max_changes_per_day=2, family_cooldown_hours=1, min_sample_for_apply=5)
+    # Two changes yesterday for a different family -> outside cooldown, before today.
+    yesterday = _NOW - timedelta(days=1)
+    prior = [
+        _prior_run_with_change("test_visibility", 2, 1, yesterday),
+        _prior_run_with_change("dependency_drift", 2, 1, yesterday),
+    ]
+    can, reason = g.evaluate(_rec("observation_coverage"), 2, prior, [], _NOW, 10)
+    assert can
+    assert reason == ""
+
+
+# --- evaluate: oscillation when directions match (no detection) ---
+
+
+def test_no_oscillation_when_same_direction() -> None:
+    # Prior decrease (2->1), now another loosen (decrease) but cooldown long
+    # enough that quota/cooldown pass. Use short cooldown to skip cooldown block
+    # but the prior change still within... need cooldown to NOT trigger.
+    # Set cooldown to 0 so prior change is outside the window for cooldown,
+    # which also skips oscillation loop. So instead keep cooldown but make
+    # prior change a same-direction one and verify it is allowed via quota path.
+    g = TuningGuardrails(max_changes_per_day=5, family_cooldown_hours=48, min_sample_for_apply=5)
+    # Same family + recent change triggers cooldown first, so directions matching
+    # is only reachable if cooldown passes. Make the change just outside cooldown
+    # so it does not block, then oscillation loop also skips it.
+    prior = [_prior_run_with_change("observation_coverage", 2, 1, _NOW - timedelta(hours=49))]
+    can, reason = g.evaluate(_rec(action="loosen_threshold"), 2, prior, [], _NOW, 10)
+    assert can
+    assert reason == ""
+
+
+def test_oscillation_tighten_after_loosen() -> None:
+    # Prior decrease (2->1) recent; now tighten (increase) -> oscillation.
+    # But cooldown fires first for same family within window. Confirm one of them.
+    g = TuningGuardrails(max_changes_per_day=5, family_cooldown_hours=48, min_sample_for_apply=5)
+    prior = [_prior_run_with_change("observation_coverage", 2, 1, _NOW - timedelta(hours=5))]
+    can, reason = g.evaluate(_rec(action="tighten_threshold"), 2, prior, [], _NOW, 10)
+    assert not can
+    assert reason in ("cooldown_active", "oscillation_detected")
+
+
+# --- _compute_new_value / compute_new_value ---
+
+
+def test_compute_new_value_unknown_action_returns_none() -> None:
+    assert _compute_new_value(3, "review") is None
+    assert compute_new_value(3, "keep") is None
+
+
+def test_compute_new_value_in_range() -> None:
+    assert _compute_new_value(3, "loosen_threshold") == 2
+    assert _compute_new_value(3, "tighten_threshold") == 4
+
+
+def test_compute_new_value_boundaries() -> None:
+    assert _compute_new_value(1, "loosen_threshold") is None
+    assert _compute_new_value(5, "tighten_threshold") is None
+    assert _compute_new_value(2, "loosen_threshold") == 1
+    assert _compute_new_value(4, "tighten_threshold") == 5
+
+
+# --- build_skipped ---
+
+
+def test_build_skipped_merges_recommendation_evidence() -> None:
+    g = TuningGuardrails()
+    rec = _rec(evidence={"sample_runs": 999, "extra": "kept"})
+    skipped = g.build_skipped(rec, "outside_range", sample_runs=12)
+    assert skipped.family == "observation_coverage"
+    assert skipped.intended_action == "loosen_threshold"
+    assert skipped.reason == "outside_range"
+    # explicit sample_runs key wins over merged evidence (placed before **evidence)
+    assert skipped.evidence["sample_runs"] == 999
+    assert skipped.evidence["extra"] == "kept"
+    assert skipped.evidence["family"] == "observation_coverage"
+    assert skipped.evidence["action"] == "loosen_threshold"
+
+
+def test_build_skipped_without_overlapping_evidence_keeps_sample_runs() -> None:
+    g = TuningGuardrails()
+    skipped = g.build_skipped(_rec(evidence={}), "sample_too_small", sample_runs=3)
+    assert skipped.evidence["sample_runs"] == 3

--- a/tests/unit/operations_center/tuning/test_metrics_cov.py
+++ b/tests/unit/operations_center/tuning/test_metrics_cov.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from operations_center.tuning.metrics import (
+    _iter_list,
+    _sorted_artifact_dirs,
+    aggregate_family_metrics,
+)
+
+
+def _write_decision(
+    root: Path,
+    run_id: str,
+    *,
+    candidates: list | None = None,
+    suppressed: list | None = None,
+    dry_run: bool = False,
+    generated_at: str | None = "2026-04-04T12:00:00+00:00",
+) -> Path:
+    d = root / run_id
+    d.mkdir(parents=True)
+    artifact: dict[str, object] = {
+        "run_id": run_id,
+        "source_command": "test",
+        "dry_run": dry_run,
+        "candidates": candidates or [],
+        "suppressed": suppressed or [],
+    }
+    if generated_at is not None:
+        artifact["generated_at"] = generated_at
+    (d / "proposal_candidates.json").write_text(json.dumps(artifact))
+    return d
+
+
+def _write_proposer(
+    root: Path,
+    run_id: str,
+    decision_run_id: str,
+    *,
+    created: list | None = None,
+    skipped: list | None = None,
+    failed: list | None = None,
+    dry_run: bool = False,
+) -> Path:
+    d = root / run_id
+    d.mkdir(parents=True)
+    artifact = {
+        "run_id": run_id,
+        "source_decision_run_id": decision_run_id,
+        "dry_run": dry_run,
+        "created": created or [],
+        "skipped": skipped or [],
+        "failed": failed or [],
+    }
+    (d / "proposal_results.json").write_text(json.dumps(artifact))
+    return d
+
+
+# ----- _sorted_artifact_dirs -----
+
+
+def test_sorted_artifact_dirs_missing_root(tmp_path: Path) -> None:
+    assert _sorted_artifact_dirs(tmp_path / "nope") == []
+
+
+def test_sorted_artifact_dirs_reverse_and_skips_files(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "c").mkdir()
+    (tmp_path / "loose.txt").write_text("x")
+    dirs = _sorted_artifact_dirs(tmp_path)
+    assert [d.name for d in dirs] == ["c", "b", "a"]  # reverse sorted, no file
+
+
+# ----- _iter_list -----
+
+
+def test_iter_list_yields_only_dicts() -> None:
+    data = {"items": [{"x": 1}, "scalar", 5, {"y": 2}, None]}
+    out = list(_iter_list(data, "items"))
+    assert out == [{"x": 1}, {"y": 2}]
+
+
+def test_iter_list_missing_key() -> None:
+    assert list(_iter_list({}, "items")) == []
+
+
+def test_iter_list_non_list_value() -> None:
+    assert list(_iter_list({"items": {"not": "a list"}}, "items")) == []
+
+
+# ----- aggregate: empty / dry-run-only paths -----
+
+
+def test_returns_empty_when_dirs_exist_but_no_candidate_files(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    (dec / "dec_1").mkdir(parents=True)  # dir without proposal_candidates.json
+    metrics, runs, start, end = aggregate_family_metrics(
+        decision_root=dec, proposer_root=tmp_path / "p"
+    )
+    assert metrics == []
+    assert runs == 0
+    assert start is None and end is None
+
+
+def test_returns_empty_when_only_dry_run_artifacts(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}], dry_run=True)
+    metrics, runs, start, end = aggregate_family_metrics(
+        decision_root=dec, proposer_root=tmp_path / "p"
+    )
+    assert metrics == []
+    assert runs == 0
+
+
+def test_malformed_decision_json_is_skipped(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    bad = dec / "dec_bad"
+    bad.mkdir(parents=True)
+    (bad / "proposal_candidates.json").write_text("{not valid json")
+    _write_decision(dec, "dec_ok", candidates=[{"family": "good"}])
+    metrics, runs, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert runs == 1
+    assert {m.family for m in metrics} == {"good"}
+
+
+# ----- timestamps / window_start / window_end -----
+
+
+def test_window_start_end_from_timestamps(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(
+        dec, "dec_1", candidates=[{"family": "f"}], generated_at="2026-04-01T00:00:00+00:00"
+    )
+    _write_decision(
+        dec, "dec_2", candidates=[{"family": "f"}], generated_at="2026-04-05T00:00:00+00:00"
+    )
+    _, _, start, end = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert start == datetime.fromisoformat("2026-04-01T00:00:00+00:00")
+    assert end == datetime.fromisoformat("2026-04-05T00:00:00+00:00")
+
+
+def test_invalid_timestamp_ignored(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}], generated_at="not-a-date")
+    _, _, start, end = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert start is None and end is None
+
+
+def test_missing_generated_at_yields_no_window(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}], generated_at=None)
+    _, _, start, end = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert start is None and end is None
+
+
+# ----- no_creation_rate -----
+
+
+def test_no_creation_rate(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(
+        dec,
+        "dec_1",
+        candidates=[{"family": "f"}, {"family": "f"}, {"family": "f"}, {"family": "f"}],
+    )
+    _write_proposer(prop, "prop_1", "dec_1", created=[{"family": "f"}])
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=prop)
+    m = next(m for m in metrics if m.family == "f")
+    assert m.candidates_emitted == 4
+    assert m.candidates_created == 1
+    assert m.create_rate == 0.25
+    assert m.no_creation_rate == 0.75
+
+
+# ----- proposer indexing: malformed / dry_run / missing source -----
+
+
+def test_proposer_dry_run_and_malformed_skipped(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}])
+    _write_proposer(prop, "prop_dry", "dec_1", created=[{"family": "f"}], dry_run=True)
+    bad = prop / "prop_bad"
+    bad.mkdir(parents=True)
+    (bad / "proposal_results.json").write_text("<<bad")
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=prop)
+    m = next(m for m in metrics if m.family == "f")
+    # dry_run proposer excluded from index -> no creations attributed
+    assert m.candidates_created == 0
+
+
+def test_proposer_without_source_decision_id_not_indexed(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}])
+    _write_proposer(prop, "prop_1", "", created=[{"family": "f"}])
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=prop)
+    m = next(m for m in metrics if m.family == "f")
+    assert m.candidates_created == 0
+
+
+def test_proposer_missing_results_file_skipped(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}])
+    (prop / "prop_empty").mkdir(parents=True)  # dir but no results file
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=prop)
+    assert any(m.family == "f" for m in metrics)
+
+
+# ----- feedback: merged / escalated / acceptance_rate -----
+
+
+def _write_feedback(root: Path, name: str, record: dict) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / name).write_text(json.dumps(record))
+
+
+def test_feedback_merged_and_escalated_acceptance_rate(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    fb = tmp_path / "feedback"
+    _write_decision(dec, "dec_1", candidates=[{"family": "obs"}])
+    # proposer 'created' builds issue_to_family map (task_id -> family)
+    _write_proposer(
+        prop,
+        "prop_1",
+        "dec_1",
+        created=[{"plane_issue_id": "ISSUE-1", "family": "obs"}],
+    )
+    _write_feedback(fb, "f1.json", {"task_id": "ISSUE-1", "outcome": "merged"})
+    _write_feedback(fb, "f2.json", {"task_id": "ISSUE-1", "outcome": "merged"})
+    _write_feedback(fb, "f3.json", {"task_id": "ISSUE-1", "outcome": "escalated"})
+    metrics, _, _, _ = aggregate_family_metrics(
+        decision_root=dec, proposer_root=prop, feedback_root=fb
+    )
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.proposals_merged == 2
+    assert m.proposals_escalated == 1
+    assert m.acceptance_rate == round(2 / 3, 3)
+
+
+def test_feedback_via_plane_issue_id_fallback(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    fb = tmp_path / "feedback"
+    _write_decision(dec, "dec_1", candidates=[{"family": "obs"}])
+    _write_proposer(
+        prop, "prop_1", "dec_1", created=[{"plane_issue_id": "ISSUE-9", "family": "obs"}]
+    )
+    # No task_id; use plane_issue_id fallback branch
+    _write_feedback(fb, "f1.json", {"plane_issue_id": "ISSUE-9", "outcome": "merged"})
+    metrics, _, _, _ = aggregate_family_metrics(
+        decision_root=dec, proposer_root=prop, feedback_root=fb
+    )
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.proposals_merged == 1
+    assert m.acceptance_rate == 1.0
+
+
+def test_feedback_unmapped_and_malformed_skipped(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    fb = tmp_path / "feedback"
+    _write_decision(dec, "dec_1", candidates=[{"family": "obs"}])
+    _write_proposer(
+        prop, "prop_1", "dec_1", created=[{"plane_issue_id": "ISSUE-1", "family": "obs"}]
+    )
+    # unknown task -> no family -> skipped
+    _write_feedback(fb, "f1.json", {"task_id": "UNKNOWN", "outcome": "merged"})
+    # malformed json -> skipped
+    (fb / "bad.json").write_text("{broken")
+    metrics, _, _, _ = aggregate_family_metrics(
+        decision_root=dec, proposer_root=prop, feedback_root=fb
+    )
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.proposals_merged == 0
+    assert m.acceptance_rate == 0.0
+
+
+def test_default_feedback_root_used_when_none(tmp_path: Path, monkeypatch) -> None:
+    # feedback_root None -> defaults to Path("state/proposal_feedback") relative to cwd
+    monkeypatch.chdir(tmp_path)
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(dec, "dec_1", candidates=[{"family": "obs"}])
+    _write_proposer(
+        prop, "prop_1", "dec_1", created=[{"plane_issue_id": "ISSUE-1", "family": "obs"}]
+    )
+    fb = tmp_path / "state" / "proposal_feedback"
+    _write_feedback(fb, "f1.json", {"task_id": "ISSUE-1", "outcome": "merged"})
+    metrics, _, _, _ = aggregate_family_metrics(
+        decision_root=dec, proposer_root=prop, feedback_root=None
+    )
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.proposals_merged == 1
+
+
+# ----- top_suppression_reasons truncated to 5 -----
+
+
+def test_top_suppression_reasons_truncated_to_five(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    suppressed = []
+    for i, reason in enumerate(["r1", "r2", "r3", "r4", "r5", "r6"]):
+        # give decreasing counts so ordering is deterministic
+        for _ in range(6 - i):
+            suppressed.append({"family": "obs", "reason": reason})
+    _write_decision(dec, "dec_1", candidates=[], suppressed=suppressed)
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    m = next(m for m in metrics if m.family == "obs")
+    assert len(m.top_suppression_reasons) == 5
+    assert "r6" not in m.top_suppression_reasons
+
+
+def test_suppression_default_reason_unknown(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(dec, "dec_1", candidates=[], suppressed=[{"family": "obs"}])
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.top_suppression_reasons == {"unknown": 1}
+
+
+# ----- candidates/suppressed/items without family are ignored -----
+
+
+def test_entries_without_family_ignored(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    prop = tmp_path / "proposer"
+    _write_decision(
+        dec,
+        "dec_1",
+        candidates=[{"status": "emit"}, {"family": "obs"}],
+        suppressed=[{"reason": "x"}],
+    )
+    _write_proposer(
+        prop,
+        "prop_1",
+        "dec_1",
+        created=[{}],
+        skipped=[{}],
+        failed=[{}],
+    )
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=prop)
+    families = {m.family for m in metrics}
+    assert families == {"obs"}
+    m = next(m for m in metrics if m.family == "obs")
+    assert m.candidates_emitted == 1
+    assert m.candidates_suppressed == 0
+
+
+# ----- families sorted in output -----
+
+
+def test_families_sorted(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(
+        dec,
+        "dec_1",
+        candidates=[{"family": "zeta"}, {"family": "alpha"}, {"family": "mid"}],
+    )
+    metrics, _, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert [m.family for m in metrics] == ["alpha", "mid", "zeta"]
+
+
+def test_sample_runs_reflects_real_artifact_count(tmp_path: Path) -> None:
+    dec = tmp_path / "decision"
+    _write_decision(dec, "dec_1", candidates=[{"family": "f"}])
+    _write_decision(dec, "dec_2", candidates=[{"family": "f"}], dry_run=True)
+    metrics, runs, _, _ = aggregate_family_metrics(decision_root=dec, proposer_root=tmp_path / "p")
+    assert runs == 1
+    assert all(m.sample_runs == 1 for m in metrics)

--- a/tests/unit/operations_center/tuning/test_recommendations_cov.py
+++ b/tests/unit/operations_center/tuning/test_recommendations_cov.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from operations_center.tuning.models import FamilyMetrics
+from operations_center.tuning.recommendations import RecommendationEngine
+
+engine = RecommendationEngine()
+
+
+def _m(
+    family: str = "fam",
+    *,
+    sample_runs: int = 10,
+    emitted: int = 0,
+    suppressed: int = 0,
+    created: int = 0,
+    suppression_rate: float | None = None,
+    create_rate: float | None = None,
+    top_suppression_reasons: dict[str, int] | None = None,
+    merged: int = 0,
+    escalated: int = 0,
+    acceptance_rate: float = 0.0,
+) -> FamilyMetrics:
+    total_seen = emitted + suppressed
+    if suppression_rate is None:
+        suppression_rate = suppressed / total_seen if total_seen else 0.0
+    if create_rate is None:
+        create_rate = created / emitted if emitted else 0.0
+    return FamilyMetrics(
+        family=family,
+        sample_runs=sample_runs,
+        candidates_emitted=emitted,
+        candidates_suppressed=suppressed,
+        candidates_created=created,
+        suppression_rate=suppression_rate,
+        create_rate=create_rate,
+        top_suppression_reasons=top_suppression_reasons or {},
+        proposals_merged=merged,
+        proposals_escalated=escalated,
+        acceptance_rate=acceptance_rate,
+    )
+
+
+# --- over-suppressed: top reason resolution ------------------------------
+
+
+def test_over_suppressed_picks_highest_top_reason() -> None:
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=12,
+            emitted=1,
+            suppressed=19,
+            suppression_rate=0.95,
+            top_suppression_reasons={"min_consecutive_runs": 5, "cooldown": 12},
+        )
+    )
+    assert rec.action == "loosen_threshold"
+    assert rec.evidence["top_suppression_reason"] == "cooldown"
+    assert "cooldown" in rec.rationale
+
+
+def test_over_suppressed_unknown_reason_when_empty_map() -> None:
+    rec = engine._evaluate_one(_m(sample_runs=12, emitted=1, suppressed=19, suppression_rate=0.95))
+    assert rec.action == "loosen_threshold"
+    assert rec.evidence["top_suppression_reason"] == "unknown"
+
+
+def test_over_suppressed_at_exact_threshold() -> None:
+    rec = engine._evaluate_one(_m(sample_runs=6, emitted=10, suppressed=90, suppression_rate=0.90))
+    assert rec.action == "loosen_threshold"
+    # sample_runs 6 < 10 -> medium
+    assert rec.confidence == "medium"
+
+
+# --- noisy/tighten confidence boundaries ---------------------------------
+
+
+def test_noisy_high_confidence_at_ten_emitted() -> None:
+    rec = engine._evaluate_one(
+        _m(sample_runs=10, emitted=10, suppressed=0, created=0, create_rate=0.0)
+    )
+    assert rec.action == "tighten_threshold"
+    assert rec.confidence == "high"
+
+
+def test_noisy_medium_confidence_below_ten_emitted() -> None:
+    rec = engine._evaluate_one(
+        _m(sample_runs=10, emitted=5, suppressed=0, created=0, create_rate=0.0)
+    )
+    assert rec.action == "tighten_threshold"
+    assert rec.confidence == "medium"
+
+
+def test_noisy_at_ceiling_create_rate() -> None:
+    # create_rate exactly at ceiling (0.10) still noisy (<=)
+    rec = engine._evaluate_one(_m(sample_runs=10, emitted=10, created=1, create_rate=0.10))
+    assert rec.action == "tighten_threshold"
+
+
+# --- healthy confidence boundaries ---------------------------------------
+
+
+def test_healthy_high_confidence_at_five_emitted() -> None:
+    rec = engine._evaluate_one(_m(sample_runs=10, emitted=5, created=2, create_rate=0.40))
+    assert rec.action == "keep"
+    assert rec.confidence == "high"
+
+
+def test_healthy_medium_confidence_below_five_emitted() -> None:
+    rec = engine._evaluate_one(_m(sample_runs=10, emitted=3, created=1, create_rate=0.333))
+    assert rec.action == "keep"
+    assert rec.confidence == "medium"
+
+
+def test_healthy_at_floor_create_rate() -> None:
+    rec = engine._evaluate_one(_m(sample_runs=10, emitted=4, created=1, create_rate=0.25))
+    assert rec.action == "keep"
+
+
+# --- low acceptance rate -> tighten + tier demotion ----------------------
+# To reach the acceptance branches we must avoid the noisy and healthy
+# branches: emitted in [HEALTHY_MIN_EMITTED..) but create_rate between
+# the noisy ceiling and the healthy floor (e.g. 0.20).
+
+
+def test_low_acceptance_tightens_and_demotes_tier() -> None:
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=12,
+            emitted=5,
+            created=1,
+            create_rate=0.20,
+            merged=1,
+            escalated=9,
+            acceptance_rate=0.10,
+        )
+    )
+    assert rec.action == "tighten_threshold"
+    assert rec.suggested_change is not None
+    assert rec.suggested_change["autonomy_tier"]["direction"] == "decrease"
+    assert rec.confidence == "high"  # feedback_total 10 >= 10
+
+
+def test_low_acceptance_medium_confidence_small_feedback() -> None:
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=12,
+            emitted=5,
+            created=1,
+            create_rate=0.20,
+            merged=1,
+            escalated=4,
+            acceptance_rate=0.20,
+        )
+    )
+    assert rec.action == "tighten_threshold"
+    assert rec.confidence == "medium"  # feedback_total 5 < 10
+
+
+# --- high acceptance rate -> keep + tier promotion -----------------------
+
+
+def test_high_acceptance_keeps_and_promotes_tier() -> None:
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=12,
+            emitted=5,
+            created=1,
+            create_rate=0.20,
+            merged=9,
+            escalated=1,
+            acceptance_rate=0.90,
+        )
+    )
+    assert rec.action == "keep"
+    assert rec.suggested_change is not None
+    assert rec.suggested_change["autonomy_tier"]["direction"] == "increase"
+    assert rec.confidence == "high"
+
+
+def test_high_acceptance_medium_confidence_small_feedback() -> None:
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=12,
+            emitted=5,
+            created=1,
+            create_rate=0.20,
+            merged=4,
+            escalated=1,
+            acceptance_rate=0.80,
+        )
+    )
+    assert rec.action == "keep"
+    assert rec.confidence == "medium"
+
+
+# --- final fallback: moderate / not enough signal ------------------------
+
+
+def test_moderate_review_fallback_no_feedback() -> None:
+    # emitted between healthy floor needs, create_rate in dead zone, no feedback
+    rec = engine._evaluate_one(_m(sample_runs=10, emitted=5, created=1, create_rate=0.20))
+    assert rec.action == "review"
+    assert rec.confidence == "low"
+    assert "monitor" in rec.rationale.lower()
+
+
+def test_moderate_review_feedback_in_neutral_band() -> None:
+    # acceptance_rate between LOW (0.3) and HIGH (0.8) -> neither branch fires
+    rec = engine._evaluate_one(
+        _m(
+            sample_runs=10,
+            emitted=5,
+            created=1,
+            create_rate=0.20,
+            merged=5,
+            escalated=5,
+            acceptance_rate=0.50,
+        )
+    )
+    assert rec.action == "review"
+    assert rec.confidence == "low"
+
+
+# --- evaluate over a heterogeneous batch ---------------------------------
+
+
+def test_evaluate_batch_covers_multiple_actions() -> None:
+    recs = engine.evaluate(
+        [
+            _m("a", sample_runs=2),  # no_data
+            _m("b", sample_runs=10, emitted=0, suppressed=0),  # silent review
+            _m("c", sample_runs=10, emitted=5, created=2, create_rate=0.40),  # keep
+        ]
+    )
+    actions = {r.family: r.action for r in recs}
+    assert actions == {"a": "no_data", "b": "review", "c": "keep"}

--- a/tests/unit/operations_center/tuning/test_service_cov.py
+++ b/tests/unit/operations_center/tuning/test_service_cov.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from operations_center.tuning import service as service_mod
+from operations_center.tuning.models import (
+    FamilyMetrics,
+    SkippedTuningChange,
+    TuningRecommendation,
+    TuningRunArtifact,
+)
+from operations_center.tuning.service import (
+    TuningContext,
+    TuningRegulatorService,
+    new_tuning_context,
+)
+
+
+def _rec(family: str, action: str) -> TuningRecommendation:
+    return TuningRecommendation(
+        family=family,
+        action=action,
+        rationale="because",
+        confidence="high",
+    )
+
+
+def _metrics(family: str) -> FamilyMetrics:
+    return FamilyMetrics(family=family, sample_runs=5)
+
+
+def _patch_aggregate(monkeypatch, family_metrics, sample_runs, start, end):
+    def fake_aggregate(*, decision_root, proposer_root, window):
+        return family_metrics, sample_runs, start, end
+
+    monkeypatch.setattr(service_mod, "aggregate_family_metrics", fake_aggregate)
+
+
+# ---------------------------------------------------------------------------
+# new_tuning_context
+# ---------------------------------------------------------------------------
+
+
+def test_new_tuning_context_defaults(tmp_path: Path) -> None:
+    ctx = new_tuning_context(
+        decision_root=tmp_path / "dec",
+        proposer_root=tmp_path / "prop",
+    )
+    assert ctx.auto_apply is False
+    assert ctx.window == 20
+    assert ctx.source_command == "operations-center tune-autonomy"
+    assert ctx.decision_root == tmp_path / "dec"
+    assert ctx.proposer_root == tmp_path / "prop"
+    assert ctx.dry_run is False
+    assert isinstance(ctx.generated_at, datetime)
+    assert ctx.generated_at.tzinfo is UTC
+    # run_id format: tun_<timestamp>_<microsecond hex>, capped at 31 chars
+    assert ctx.run_id.startswith("tun_")
+    assert len(ctx.run_id) <= 31
+    assert re.match(r"tun_\d{8}T\d{6}Z_[0-9a-f]{6}$", ctx.run_id)
+
+
+def test_new_tuning_context_overrides(tmp_path: Path) -> None:
+    ctx = new_tuning_context(
+        decision_root=tmp_path,
+        proposer_root=tmp_path,
+        auto_apply=True,
+        window=7,
+        source_command="custom-cmd",
+    )
+    assert ctx.auto_apply is True
+    assert ctx.window == 7
+    assert ctx.source_command == "custom-cmd"
+
+
+def test_new_tuning_context_run_id_unique(tmp_path: Path) -> None:
+    a = new_tuning_context(decision_root=tmp_path, proposer_root=tmp_path)
+    b = new_tuning_context(decision_root=tmp_path, proposer_root=tmp_path)
+    # microsecond component makes these distinct in practice
+    assert a.run_id != b.run_id or a.generated_at != b.generated_at
+
+
+# ---------------------------------------------------------------------------
+# TuningRegulatorService.__init__ defaults
+# ---------------------------------------------------------------------------
+
+
+def test_service_init_defaults() -> None:
+    svc = TuningRegulatorService()
+    assert svc.engine is not None
+    assert svc.guardrails is not None
+    assert svc.applier is not None
+    assert svc.loader is not None
+    assert svc.writer is not None
+
+
+def test_service_init_injection() -> None:
+    engine = MagicMock()
+    guardrails = MagicMock()
+    applier = MagicMock()
+    loader = MagicMock()
+    writer = MagicMock()
+    svc = TuningRegulatorService(
+        recommendation_engine=engine,
+        guardrails=guardrails,
+        applier=applier,
+        loader=loader,
+        artifact_writer=writer,
+    )
+    assert svc.engine is engine
+    assert svc.guardrails is guardrails
+    assert svc.applier is applier
+    assert svc.loader is loader
+    assert svc.writer is writer
+
+
+# ---------------------------------------------------------------------------
+# run() — dry_run path (no write)
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(tmp_path: Path, **kw) -> TuningContext:
+    base = dict(
+        run_id="tun_test",
+        generated_at=datetime(2026, 6, 2, tzinfo=UTC),
+        source_command="cmd",
+        decision_root=tmp_path / "dec",
+        proposer_root=tmp_path / "prop",
+    )
+    base.update(kw)
+    return TuningContext(**base)
+
+
+def test_run_dry_run_returns_empty_paths(monkeypatch, tmp_path: Path) -> None:
+    fm = [_metrics("observation_coverage")]
+    start = datetime(2026, 6, 1, tzinfo=UTC)
+    end = datetime(2026, 6, 2, tzinfo=UTC)
+    _patch_aggregate(monkeypatch, fm, 5, start, end)
+
+    engine = MagicMock()
+    engine.evaluate.return_value = [_rec("observation_coverage", "keep")]
+    writer = MagicMock()
+    svc = TuningRegulatorService(recommendation_engine=engine, artifact_writer=writer)
+
+    ctx = _make_ctx(tmp_path, dry_run=True)
+    artifact, paths = svc.run(ctx)
+
+    assert paths == []
+    writer.write.assert_not_called()
+    engine.evaluate.assert_called_once_with(fm)
+    assert isinstance(artifact, TuningRunArtifact)
+    assert artifact.run_id == "tun_test"
+    assert artifact.dry_run is True
+    assert artifact.auto_apply is False
+    assert artifact.window_runs == 5
+    assert artifact.window_start == start
+    assert artifact.window_end == end
+    assert artifact.family_metrics == fm
+    assert artifact.changes_applied == []
+    assert artifact.changes_skipped == []
+
+
+def test_run_passes_context_to_aggregate(monkeypatch, tmp_path: Path) -> None:
+    captured = {}
+
+    def fake_aggregate(*, decision_root, proposer_root, window):
+        captured["decision_root"] = decision_root
+        captured["proposer_root"] = proposer_root
+        captured["window"] = window
+        return [], 0, None, None
+
+    monkeypatch.setattr(service_mod, "aggregate_family_metrics", fake_aggregate)
+    engine = MagicMock()
+    engine.evaluate.return_value = []
+    svc = TuningRegulatorService(recommendation_engine=engine)
+
+    ctx = _make_ctx(tmp_path, dry_run=True, window=13)
+    svc.run(ctx)
+
+    assert captured["decision_root"] == tmp_path / "dec"
+    assert captured["proposer_root"] == tmp_path / "prop"
+    assert captured["window"] == 13
+
+
+# ---------------------------------------------------------------------------
+# run() — write path
+# ---------------------------------------------------------------------------
+
+
+def test_run_writes_artifact_when_not_dry_run(monkeypatch, tmp_path: Path) -> None:
+    _patch_aggregate(monkeypatch, [], 3, None, None)
+    engine = MagicMock()
+    engine.evaluate.return_value = []
+    writer = MagicMock()
+    writer.write.return_value = ["/some/path.json"]
+    svc = TuningRegulatorService(recommendation_engine=engine, artifact_writer=writer)
+
+    ctx = _make_ctx(tmp_path, dry_run=False)
+    artifact, paths = svc.run(ctx)
+
+    writer.write.assert_called_once_with(artifact)
+    assert paths == ["/some/path.json"]
+
+
+# ---------------------------------------------------------------------------
+# run() — auto_apply -> skipped changes
+# ---------------------------------------------------------------------------
+
+
+def test_run_auto_apply_records_skipped_for_threshold_actions(monkeypatch, tmp_path: Path) -> None:
+    _patch_aggregate(monkeypatch, [], 9, None, None)
+    recs = [
+        _rec("fam_a", "loosen_threshold"),
+        _rec("fam_b", "tighten_threshold"),
+        _rec("fam_c", "keep"),
+        _rec("fam_d", "review"),
+    ]
+    engine = MagicMock()
+    engine.evaluate.return_value = recs
+    svc = TuningRegulatorService(recommendation_engine=engine)
+
+    ctx = _make_ctx(tmp_path, dry_run=True, auto_apply=True)
+    artifact, _ = svc.run(ctx)
+
+    # Only the two threshold actions become skipped changes
+    assert len(artifact.changes_skipped) == 2
+    families = {c.family for c in artifact.changes_skipped}
+    assert families == {"fam_a", "fam_b"}
+    for c in artifact.changes_skipped:
+        assert isinstance(c, SkippedTuningChange)
+        assert c.reason == "review_only_runtime"
+        assert c.evidence == {"requested_auto_apply": True, "sample_runs": 9}
+    # Intended action preserved
+    by_family = {c.family: c.intended_action for c in artifact.changes_skipped}
+    assert by_family["fam_a"] == "loosen_threshold"
+    assert by_family["fam_b"] == "tighten_threshold"
+    # artifact always reports auto_apply False (runtime is recommendation-only)
+    assert artifact.auto_apply is False
+    assert artifact.changes_applied == []
+
+
+def test_run_auto_apply_no_threshold_actions(monkeypatch, tmp_path: Path) -> None:
+    _patch_aggregate(monkeypatch, [], 4, None, None)
+    engine = MagicMock()
+    engine.evaluate.return_value = [_rec("fam", "keep"), _rec("fam2", "no_data")]
+    svc = TuningRegulatorService(recommendation_engine=engine)
+
+    ctx = _make_ctx(tmp_path, dry_run=True, auto_apply=True)
+    artifact, _ = svc.run(ctx)
+
+    assert artifact.changes_skipped == []
+
+
+def test_run_no_auto_apply_skips_no_changes(monkeypatch, tmp_path: Path) -> None:
+    _patch_aggregate(monkeypatch, [], 4, None, None)
+    engine = MagicMock()
+    # Even with threshold actions, no skipped changes when auto_apply is False
+    engine.evaluate.return_value = [_rec("fam", "loosen_threshold")]
+    svc = TuningRegulatorService(recommendation_engine=engine)
+
+    ctx = _make_ctx(tmp_path, dry_run=True, auto_apply=False)
+    artifact, _ = svc.run(ctx)
+
+    assert artifact.changes_skipped == []
+
+
+def test_run_recommendations_attached_to_artifact(monkeypatch, tmp_path: Path) -> None:
+    _patch_aggregate(monkeypatch, [], 2, None, None)
+    recs = [_rec("fam", "review")]
+    engine = MagicMock()
+    engine.evaluate.return_value = recs
+    svc = TuningRegulatorService(recommendation_engine=engine)
+
+    ctx = _make_ctx(tmp_path, dry_run=True)
+    artifact, _ = svc.run(ctx)
+    assert artifact.recommendations == recs

--- a/tests/unit/proposer/__init__.py
+++ b/tests/unit/proposer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/proposer/test_backlog_promoter_cov.py
+++ b/tests/unit/proposer/test_backlog_promoter_cov.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from operations_center.proposer.backlog_promoter import (
+    BacklogPromoteResult,
+    BacklogPromoterService,
+    PromotedTask,
+    SkippedTask,
+    _family_from_labels,
+    _issue_label_names,
+    _issue_state_name,
+    _parse_recorded_tier,
+    _parse_source_family,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    """Hermetic stand-in for PlaneClientProtocol."""
+
+    def __init__(self, issues=None, list_exc=None, transition_exc=None):
+        self._issues = issues or []
+        self._list_exc = list_exc
+        self._transition_exc = transition_exc
+        self.list_calls = 0
+        self.transitions: list[tuple[str, str]] = []
+
+    def list_issues(self):
+        self.list_calls += 1
+        if self._list_exc is not None:
+            raise self._list_exc
+        return self._issues
+
+    def transition_issue(self, task_id, state):
+        if self._transition_exc is not None:
+            raise self._transition_exc
+        self.transitions.append((task_id, state))
+
+
+def _make_issue(
+    *,
+    id="T-1",
+    name="A task",
+    state="Backlog",
+    labels=("source: autonomy",),
+    description="source_family: alpha\nautonomy_tier: 1",
+    description_stripped=None,
+):
+    issue = {
+        "id": id,
+        "name": name,
+        "state": state,
+        "labels": list(labels),
+    }
+    if description is not None:
+        issue["description"] = description
+    if description_stripped is not None:
+        issue["description_stripped"] = description_stripped
+    return issue
+
+
+def _tier_lookup(mapping, default=0):
+    return lambda family: mapping.get(family, default)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_parse_source_family_found():
+    assert _parse_source_family("foo\nsource_family: alpha\nbar") == "alpha"
+
+
+def test_parse_source_family_strips_trailing():
+    # \S+ stops at whitespace; strip() is a no-op safety net.
+    assert _parse_source_family("source_family:   beta") == "beta"
+
+
+def test_parse_source_family_missing():
+    assert _parse_source_family("nothing here") is None
+
+
+def test_family_from_labels_found():
+    assert _family_from_labels(["Source-Family: Gamma"]) == "gamma"
+
+
+def test_family_from_labels_none():
+    assert _family_from_labels(["unrelated", "source: autonomy"]) is None
+
+
+def test_family_from_labels_empty():
+    assert _family_from_labels([]) is None
+
+
+def test_parse_recorded_tier_found():
+    assert _parse_recorded_tier("autonomy_tier: 3") == 3
+
+
+def test_parse_recorded_tier_missing():
+    assert _parse_recorded_tier("no tier here") is None
+
+
+def test_issue_state_name_dict():
+    assert _issue_state_name({"state": {"name": "Ready"}}) == "Ready"
+
+
+def test_issue_state_name_dict_missing_name():
+    assert _issue_state_name({"state": {}}) == ""
+
+
+def test_issue_state_name_string():
+    assert _issue_state_name({"state": "Backlog"}) == "Backlog"
+
+
+def test_issue_state_name_none():
+    assert _issue_state_name({}) == ""
+
+
+def test_issue_label_names_mixed():
+    # int 123 is neither dict nor str, so it is dropped entirely.
+    issue = {"labels": [{"name": "a"}, "b", {"other": "x"}, 123]}
+    assert _issue_label_names(issue) == ["a", "b", ""]
+
+
+def test_issue_label_names_default_empty():
+    assert _issue_label_names({}) == []
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_promote_count_property():
+    res = BacklogPromoteResult(generated_at=datetime.now(UTC), dry_run=True)
+    assert res.promote_count == 0
+    res.promoted.append(
+        PromotedTask(task_id="x", title="t", family="f", current_tier=2, recorded_tier=1)
+    )
+    assert res.promote_count == 1
+
+
+def test_skipped_task_defaults():
+    st = SkippedTask(task_id="x", title="t", reason="r")
+    assert st.family is None
+    assert st.current_tier is None
+
+
+# ---------------------------------------------------------------------------
+# Service: list_issues error path
+# ---------------------------------------------------------------------------
+
+
+def test_list_issues_failure_records_error():
+    client = FakeClient(list_exc=RuntimeError("boom"))
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({}))
+    res = svc.promote()
+    assert res.promoted == []
+    assert len(res.errors) == 1
+    assert "Failed to list Plane issues: boom" in res.errors[0]
+    assert client.list_calls == 1
+
+
+def test_issues_passed_in_skips_client_call():
+    client = FakeClient(list_exc=RuntimeError("should not be called"))
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    res = svc.promote(issues=[_make_issue()])
+    assert client.list_calls == 0
+    assert res.promote_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Service: filtering branches (continue without skip record)
+# ---------------------------------------------------------------------------
+
+
+def test_skip_non_backlog_state():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    res = svc.promote(issues=[_make_issue(state="Ready for AI")])
+    assert res.promoted == []
+    assert res.skipped == []
+
+
+def test_skip_missing_autonomy_label():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    res = svc.promote(issues=[_make_issue(labels=["something else"])])
+    assert res.promoted == []
+    assert res.skipped == []
+
+
+def test_family_filter_excludes_other_family():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    res = svc.promote(issues=[_make_issue()], family_filter="beta")
+    assert res.promoted == []
+    assert res.skipped == []
+
+
+def test_family_filter_includes_matching_family():
+    client = FakeClient()
+    svc = BacklogPromoterService(
+        plane_client=client, get_tier=_tier_lookup({"alpha": 2}), dry_run=False
+    )
+    res = svc.promote(issues=[_make_issue()], family_filter="alpha")
+    assert res.promote_count == 1
+    assert client.transitions == [("T-1", "Ready for AI")]
+
+
+# ---------------------------------------------------------------------------
+# Service: skip records
+# ---------------------------------------------------------------------------
+
+
+def test_skip_no_source_family():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({}))
+    issue = _make_issue(description="no family marker", labels=["source: autonomy"])
+    res = svc.promote(issues=[issue])
+    assert res.promoted == []
+    assert len(res.skipped) == 1
+    assert res.skipped[0].reason == "no_source_family_in_provenance"
+    assert res.skipped[0].family is None
+
+
+def test_skip_tier_below_2():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 1}))
+    res = svc.promote(issues=[_make_issue()])
+    assert res.promoted == []
+    assert len(res.skipped) == 1
+    assert res.skipped[0].reason == "tier_below_2"
+    assert res.skipped[0].family == "alpha"
+    assert res.skipped[0].current_tier == 1
+
+
+def test_family_resolved_from_labels_when_absent_in_description():
+    client = FakeClient()
+    svc = BacklogPromoterService(
+        plane_client=client, get_tier=_tier_lookup({"delta": 2}), dry_run=False
+    )
+    issue = _make_issue(
+        description="no marker here",
+        labels=["source: autonomy", "source-family: delta"],
+    )
+    res = svc.promote(issues=[issue])
+    assert res.promote_count == 1
+    assert res.promoted[0].family == "delta"
+
+
+def test_description_stripped_fallback():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    issue = _make_issue(
+        description=None,
+        description_stripped="source_family: alpha\nautonomy_tier: 2",
+    )
+    res = svc.promote(issues=[issue])
+    assert res.promote_count == 1
+    assert res.promoted[0].recorded_tier == 2
+
+
+# ---------------------------------------------------------------------------
+# Service: promotion happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_transition():
+    client = FakeClient()
+    svc = BacklogPromoterService(
+        plane_client=client, get_tier=_tier_lookup({"alpha": 2}), dry_run=True
+    )
+    res = svc.promote(issues=[_make_issue()])
+    assert res.promote_count == 1
+    assert res.dry_run is True
+    assert client.transitions == []
+    p = res.promoted[0]
+    assert p.task_id == "T-1"
+    assert p.title == "A task"
+    assert p.family == "alpha"
+    assert p.current_tier == 2
+    assert p.recorded_tier == 1
+
+
+def test_live_run_transitions():
+    client = FakeClient()
+    svc = BacklogPromoterService(
+        plane_client=client, get_tier=_tier_lookup({"alpha": 5}), dry_run=False
+    )
+    res = svc.promote(issues=[_make_issue()])
+    assert res.promote_count == 1
+    assert client.transitions == [("T-1", "Ready for AI")]
+
+
+def test_transition_failure_records_error_and_skips_promote():
+    client = FakeClient(transition_exc=ValueError("nope"))
+    svc = BacklogPromoterService(
+        plane_client=client, get_tier=_tier_lookup({"alpha": 2}), dry_run=False
+    )
+    res = svc.promote(issues=[_make_issue()])
+    assert res.promoted == []
+    assert len(res.errors) == 1
+    assert "Failed to promote T-1 (A task): nope" in res.errors[0]
+
+
+def test_state_dict_form_and_label_dict_form():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    issue = {
+        "id": "T-9",
+        "name": "Dicty",
+        "state": {"name": "  BACKLOG  "},
+        "labels": [{"name": "Source: Autonomy"}],
+        "description": "source_family: alpha",
+    }
+    res = svc.promote(issues=[issue])
+    assert res.promote_count == 1
+    assert res.promoted[0].recorded_tier is None
+
+
+def test_missing_id_and_name_defaults():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({"alpha": 2}))
+    issue = {
+        "state": "Backlog",
+        "labels": ["source: autonomy"],
+        "description": "source_family: alpha",
+    }
+    res = svc.promote(issues=[issue])
+    assert res.promote_count == 1
+    assert res.promoted[0].task_id == ""
+    assert res.promoted[0].title == "Untitled"
+
+
+def test_multiple_issues_mixed_outcomes():
+    issues = [
+        _make_issue(id="ok", description="source_family: alpha\nautonomy_tier: 2"),
+        _make_issue(id="low", description="source_family: beta", labels=["source: autonomy"]),
+        _make_issue(id="nofam", description="nothing"),
+        _make_issue(id="notbacklog", state="Done"),
+    ]
+    client = FakeClient()
+    svc = BacklogPromoterService(
+        plane_client=client,
+        get_tier=_tier_lookup({"alpha": 2, "beta": 1}),
+        dry_run=True,
+    )
+    res = svc.promote(issues=issues)
+    assert {p.task_id for p in res.promoted} == {"ok"}
+    reasons = {s.task_id: s.reason for s in res.skipped}
+    assert reasons == {"low": "tier_below_2", "nofam": "no_source_family_in_provenance"}
+
+
+def test_generated_at_is_tz_aware():
+    client = FakeClient()
+    svc = BacklogPromoterService(plane_client=client, get_tier=_tier_lookup({}))
+    res = svc.promote(issues=[])
+    assert res.generated_at.tzinfo is not None

--- a/tests/unit/proposer/test_candidate_integration_cov.py
+++ b/tests/unit/proposer/test_candidate_integration_cov.py
@@ -1,0 +1,532 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.proposer import candidate_integration as ci
+from operations_center.proposer.candidate_integration import (
+    CandidateProposerIntegrationService,
+    ProposerIntegrationContext,
+    new_proposer_integration_context,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / fakes                                                             #
+# --------------------------------------------------------------------------- #
+def _make_outline(title_hint: str = "") -> SimpleNamespace:
+    return SimpleNamespace(title_hint=title_hint)
+
+
+def _make_candidate(
+    *,
+    candidate_id: str = "cand-1",
+    dedup_key: str = "dk-1",
+    family: str = "lint_fix",
+    subject: str = "Subject",
+    status: str = "emit",
+    title_hint: str = "",
+    repo_key: str | None = None,
+    provenance_repo_key: str | None = None,
+    changed_files: list[str] | None = None,
+    target_paths: list[str] | None = None,
+) -> SimpleNamespace:
+    provenance = None
+    if provenance_repo_key is not None:
+        provenance = SimpleNamespace(repo_key=provenance_repo_key)
+    return SimpleNamespace(
+        candidate_id=candidate_id,
+        dedup_key=dedup_key,
+        family=family,
+        subject=subject,
+        status=status,
+        proposal_outline=_make_outline(title_hint),
+        provenance=provenance,
+        repo_key=repo_key,
+        changed_files=changed_files or [],
+        target_paths=target_paths or [],
+    )
+
+
+def _make_decision_artifact(candidates: list, run_id: str = "dec-run-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        candidates=candidates,
+        run_id=run_id,
+        repo=SimpleNamespace(name="repo-name", path=Path("/tmp/repo")),
+    )
+
+
+def _make_draft(
+    *,
+    name: str = "Drafted Title",
+    description: str = "body\nproposer_run_id: run-xyz\nmore",
+    state: str = "Backlog",
+    label_names: list[str] | None = None,
+    task_kind: str = "lint_fix",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        state=state,
+        label_names=label_names or ["auto"],
+        task_kind=task_kind,
+    )
+
+
+def _make_settings(*, propose_skip_when_ready_count: int = 0, repos: dict | None = None):
+    return SimpleNamespace(
+        propose_skip_when_ready_count=propose_skip_when_ready_count,
+        repos=repos or {},
+    )
+
+
+def _make_context(
+    *,
+    run_id: str = "run-1",
+    max_create: int = 10,
+    dry_run: bool = False,
+    repo_filter: str | None = None,
+    decision_run_id: str | None = None,
+    source_command: str = "propose",
+) -> ProposerIntegrationContext:
+    return ProposerIntegrationContext(
+        repo_filter=repo_filter,
+        decision_run_id=decision_run_id,
+        run_id=run_id,
+        generated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        source_command=source_command,
+        max_create=max_create,
+        dry_run=dry_run,
+    )
+
+
+def _build_service(
+    *,
+    settings,
+    candidates: list,
+    insight_artifact=None,
+    decision_artifact=None,
+    guardrail_allowed: bool = True,
+    guardrail=None,
+    mapper_raises: bool = False,
+    client=None,
+):
+    if decision_artifact is None:
+        decision_artifact = _make_decision_artifact(candidates)
+    loader = MagicMock()
+    loader.load.return_value = (decision_artifact, insight_artifact)
+
+    mapper = MagicMock()
+    if mapper_raises:
+        mapper.map_to_task.side_effect = RuntimeError("map boom")
+    else:
+        mapper.map_to_task.return_value = _make_draft()
+
+    guardrails = MagicMock()
+    if guardrail is None:
+        guardrail = SimpleNamespace(allowed=guardrail_allowed, reason=None, evidence=None)
+    guardrails.evaluate.return_value = guardrail
+
+    artifact_writer = MagicMock()
+    artifact_writer.write.return_value = ["/tmp/out.json"]
+
+    if client is None:
+        client = MagicMock()
+        client.list_issues.return_value = []
+        client.create_issue.return_value = {"id": "issue-99"}
+
+    service = CandidateProposerIntegrationService(
+        settings=settings,
+        client=client,
+        loader=loader,
+        mapper=mapper,
+        guardrails=guardrails,
+        artifact_writer=artifact_writer,
+    )
+    return service, decision_artifact
+
+
+@pytest.fixture(autouse=True)
+def _no_spec_suppression(monkeypatch):
+    # Default: spec suppression off and no active campaigns. Individual tests
+    # override as needed.
+    monkeypatch.setattr(ci, "_spec_suppressed", lambda *a, **k: False)
+
+    # build_provenance is a real collaborator that walks decision/insight
+    # artifacts; stub it so the mapper input is hermetic.
+    monkeypatch.setattr(ci, "build_provenance", lambda **kwargs: SimpleNamespace())
+
+    # Patch CampaignStateManager at its source so the in-run import resolves
+    # to a benign default (no active campaigns).
+    import operations_center.spec_author.state as state_mod
+
+    fake_mgr = MagicMock()
+    fake_mgr.load.return_value.active_campaigns.return_value = []
+    monkeypatch.setattr(state_mod, "CampaignStateManager", lambda: fake_mgr)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# Defaults / constructor                                                      #
+# --------------------------------------------------------------------------- #
+def test_constructor_defaults_instantiated():
+    service = CandidateProposerIntegrationService(settings=_make_settings(), client=MagicMock())
+    assert service.loader is not None
+    assert service.mapper is not None
+    assert service.guardrails is not None
+    assert service.artifact_writer is not None
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: create issue                                                    #
+# --------------------------------------------------------------------------- #
+def test_run_creates_issue_happy_path():
+    cand = _make_candidate()
+    settings = _make_settings()
+    service, dec = _build_service(settings=settings, candidates=[cand])
+
+    artifact, written = service.run(_make_context())
+
+    assert len(artifact.created) == 1
+    assert artifact.created[0].status == "created"
+    assert artifact.created[0].plane_issue_id == "issue-99"
+    assert artifact.created[0].plane_title == "Drafted Title"
+    assert artifact.skipped == []
+    assert artifact.failed == []
+    assert written == ["/tmp/out.json"]
+    service.client.create_issue.assert_called_once()
+    service.client.comment_issue.assert_called_once()
+
+
+def test_run_filters_non_emit_candidates():
+    cand = _make_candidate(status="suppressed")
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert artifact.skipped == []
+    service.client.create_issue.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Dry run                                                                     #
+# --------------------------------------------------------------------------- #
+def test_run_dry_run_does_not_call_client_create():
+    cand = _make_candidate()
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    artifact, _ = service.run(_make_context(dry_run=True))
+    assert len(artifact.created) == 1
+    assert artifact.created[0].status == "dry_run"
+    assert artifact.created[0].plane_issue_id is None
+    assert artifact.dry_run is True
+    service.client.create_issue.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Back-pressure / ready-queue saturation                                      #
+# --------------------------------------------------------------------------- #
+def test_run_queue_saturated_skips_all():
+    cand = _make_candidate()
+    settings = _make_settings(propose_skip_when_ready_count=2)
+    client = MagicMock()
+    client.list_issues.return_value = [
+        {"state": {"name": "Ready for AI"}},
+        {"state": {"name": "ready for ai"}},
+        {"state": {"name": "Other"}},
+    ]
+    service, _ = _build_service(settings=settings, candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert len(artifact.skipped) == 1
+    skip = artifact.skipped[0]
+    assert skip.reason == "ready_queue_saturated"
+    assert skip.evidence == {"ready_count": 2, "cap": 2}
+
+
+def test_run_queue_not_saturated_below_cap():
+    cand = _make_candidate()
+    settings = _make_settings(propose_skip_when_ready_count=5)
+    client = MagicMock()
+    client.list_issues.return_value = [{"state": {"name": "Ready for AI"}}]
+    client.create_issue.return_value = {"id": "i1"}
+    service, _ = _build_service(settings=settings, candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.created) == 1
+
+
+def test_run_queue_state_not_dict_counts_zero():
+    cand = _make_candidate()
+    settings = _make_settings(propose_skip_when_ready_count=1)
+    client = MagicMock()
+    # state is not a dict -> treated as empty string -> not "ready for ai"
+    client.list_issues.return_value = [{"state": "Ready for AI"}, {}]
+    client.create_issue.return_value = {"id": "i1"}
+    service, _ = _build_service(settings=settings, candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.created) == 1
+
+
+def test_run_list_issues_raises_falls_through():
+    cand = _make_candidate()
+    settings = _make_settings(propose_skip_when_ready_count=1)
+    client = MagicMock()
+    client.list_issues.side_effect = RuntimeError("plane down")
+    client.create_issue.return_value = {"id": "i1"}
+    service, _ = _build_service(settings=settings, candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    # measurement failed -> proceed normally
+    assert len(artifact.created) == 1
+
+
+# --------------------------------------------------------------------------- #
+# propose_enabled per-repo gate                                               #
+# --------------------------------------------------------------------------- #
+def test_run_propose_disabled_repo_skipped_via_provenance():
+    cand = _make_candidate(provenance_repo_key="repoX")
+    repos = {"repoX": SimpleNamespace(propose_enabled=False)}
+    settings = _make_settings(repos=repos)
+    service, _ = _build_service(settings=settings, candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert len(artifact.skipped) == 1
+    assert artifact.skipped[0].reason == "propose_disabled_for_repo"
+    assert artifact.skipped[0].evidence == {"repo_key": "repoX"}
+
+
+def test_run_propose_disabled_repo_resolved_via_repo_key_attr():
+    cand = _make_candidate(repo_key="repoY")
+    repos = {"repoY": SimpleNamespace(propose_enabled=False)}
+    settings = _make_settings(repos=repos)
+    service, _ = _build_service(settings=settings, candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.skipped) == 1
+    assert artifact.skipped[0].reason == "propose_disabled_for_repo"
+
+
+def test_run_propose_enabled_repo_proceeds():
+    cand = _make_candidate(provenance_repo_key="repoZ")
+    repos = {"repoZ": SimpleNamespace(propose_enabled=True)}
+    settings = _make_settings(repos=repos)
+    service, _ = _build_service(settings=settings, candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.created) == 1
+
+
+# --------------------------------------------------------------------------- #
+# max_create gate                                                             #
+# --------------------------------------------------------------------------- #
+def test_run_max_create_reached_skips_extra():
+    cands = [_make_candidate(candidate_id=f"c{i}", dedup_key=f"d{i}") for i in range(3)]
+    service, _ = _build_service(settings=_make_settings(), candidates=cands)
+    artifact, _ = service.run(_make_context(max_create=2))
+    assert len(artifact.created) == 2
+    assert len(artifact.skipped) == 1
+    assert artifact.skipped[0].reason == "max_create_reached"
+    assert artifact.skipped[0].evidence == {"max_create": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Spec suppression                                                            #
+# --------------------------------------------------------------------------- #
+def test_run_spec_suppressed_skips(monkeypatch):
+    cand = _make_candidate(title_hint="Some Title", changed_files=["a.py"], target_paths=["b.py"])
+    captured = {}
+
+    def fake_suppressed(title, paths, campaigns, *, specs_dir):
+        captured["title"] = title
+        captured["paths"] = paths
+        captured["specs_dir"] = specs_dir
+        return True
+
+    monkeypatch.setattr(ci, "_spec_suppressed", fake_suppressed)
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.skipped) == 1
+    assert artifact.skipped[0].reason == "active_spec_campaign"
+    assert captured["title"] == "Some Title"
+    assert captured["paths"] == ["a.py", "b.py"]
+    assert captured["specs_dir"] == Path("docs/specs")
+
+
+def test_run_title_falls_back_to_subject_when_no_hint(monkeypatch):
+    cand = _make_candidate(title_hint="", subject="The Subject")
+    seen = {}
+
+    def fake_suppressed(title, paths, campaigns, *, specs_dir):
+        seen["title"] = title
+        return False
+
+    monkeypatch.setattr(ci, "_spec_suppressed", fake_suppressed)
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    service.run(_make_context())
+    assert seen["title"] == "The Subject"
+
+
+# --------------------------------------------------------------------------- #
+# Campaign state manager exception path                                       #
+# --------------------------------------------------------------------------- #
+def test_run_campaign_state_manager_exception_handled(monkeypatch):
+    import operations_center.spec_author.state as state_mod
+
+    def boom():
+        raise RuntimeError("state unavailable")
+
+    monkeypatch.setattr(state_mod, "CampaignStateManager", boom)
+
+    captured = {}
+
+    def fake_suppressed(title, paths, campaigns, *, specs_dir):
+        captured["campaigns"] = campaigns
+        return False
+
+    monkeypatch.setattr(ci, "_spec_suppressed", fake_suppressed)
+    cand = _make_candidate()
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.created) == 1
+    assert captured["campaigns"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Mapper failure                                                              #
+# --------------------------------------------------------------------------- #
+def test_run_mapper_failure_records_failed():
+    cand = _make_candidate()
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], mapper_raises=True)
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert len(artifact.failed) == 1
+    assert artifact.failed[0].reason == "candidate_mapping_failed"
+    assert "map boom" in artifact.failed[0].error
+
+
+# --------------------------------------------------------------------------- #
+# Guardrail blocked                                                           #
+# --------------------------------------------------------------------------- #
+def test_run_guardrail_blocked_with_reason_and_evidence():
+    cand = _make_candidate()
+    guardrail = SimpleNamespace(allowed=False, reason="cooldown_active", evidence={"x": 1})
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], guardrail=guardrail)
+    artifact, _ = service.run(_make_context())
+    assert len(artifact.skipped) == 1
+    assert artifact.skipped[0].reason == "cooldown_active"
+    assert artifact.skipped[0].evidence == {"x": 1}
+
+
+def test_run_guardrail_blocked_defaults_when_reason_evidence_none():
+    cand = _make_candidate()
+    guardrail = SimpleNamespace(allowed=False, reason=None, evidence=None)
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], guardrail=guardrail)
+    artifact, _ = service.run(_make_context())
+    assert artifact.skipped[0].reason == "guardrail_blocked"
+    assert artifact.skipped[0].evidence == {}
+
+
+# --------------------------------------------------------------------------- #
+# Plane create failure                                                        #
+# --------------------------------------------------------------------------- #
+def test_run_create_issue_failure_records_failed():
+    cand = _make_candidate()
+    client = MagicMock()
+    client.list_issues.return_value = []
+    client.create_issue.side_effect = RuntimeError("create boom")
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert len(artifact.failed) == 1
+    assert artifact.failed[0].reason == "plane_create_failed"
+    assert "create boom" in artifact.failed[0].error
+
+
+def test_run_comment_issue_failure_records_failed():
+    cand = _make_candidate()
+    client = MagicMock()
+    client.list_issues.return_value = []
+    client.create_issue.return_value = {"id": "i1"}
+    client.comment_issue.side_effect = RuntimeError("comment boom")
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], client=client)
+    artifact, _ = service.run(_make_context())
+    assert artifact.created == []
+    assert len(artifact.failed) == 1
+    assert artifact.failed[0].reason == "plane_create_failed"
+
+
+# --------------------------------------------------------------------------- #
+# Artifact assembly fields                                                    #
+# --------------------------------------------------------------------------- #
+def test_run_artifact_top_level_fields():
+    cand = _make_candidate()
+    dec = _make_decision_artifact([cand], run_id="dec-99")
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand], decision_artifact=dec)
+    ctx = _make_context(run_id="myrun", source_command="cmd-x")
+    artifact, _ = service.run(ctx)
+    assert artifact.run_id == "myrun"
+    assert artifact.source_command == "cmd-x"
+    assert artifact.source_decision_run_id == "dec-99"
+    assert artifact.repo.name == "repo-name"
+    assert artifact.repo.path == Path("/tmp/repo")
+
+
+# --------------------------------------------------------------------------- #
+# _created_comment                                                            #
+# --------------------------------------------------------------------------- #
+def test_created_comment_extracts_proposer_run_id():
+    cand = _make_candidate(family="type_fix", candidate_id="cc", dedup_key="dd")
+    draft = _make_draft(
+        task_kind="type_fix",
+        description="header\nproposer_run_id: abc123\ntrailer",
+    )
+    out = CandidateProposerIntegrationService._created_comment(
+        candidate=cand, draft=draft, decision_run_id="dr-1"
+    )
+    assert "task_kind: type_fix" in out
+    assert "result_status: created" in out
+    assert "source_family: type_fix" in out
+    assert "candidate_id: cc" in out
+    assert "dedup_key: dd" in out
+    assert "decision_run_id: dr-1" in out
+    assert "proposer_run_id: abc123" in out
+    assert "handoff_reason: proposer_candidate_type_fix" in out
+
+
+def test_created_comment_unknown_proposer_run_id_when_absent():
+    cand = _make_candidate()
+    draft = _make_draft(description="no run id here")
+    out = CandidateProposerIntegrationService._created_comment(
+        candidate=cand, draft=draft, decision_run_id="dr-2"
+    )
+    assert "proposer_run_id: unknown" in out
+
+
+# --------------------------------------------------------------------------- #
+# new_proposer_integration_context                                            #
+# --------------------------------------------------------------------------- #
+def test_new_proposer_integration_context_builds_run_id():
+    ctx = new_proposer_integration_context(
+        repo_filter="r",
+        decision_run_id="d",
+        max_create=4,
+        dry_run=True,
+        source_command="src",
+    )
+    assert ctx.repo_filter == "r"
+    assert ctx.decision_run_id == "d"
+    assert ctx.max_create == 4
+    assert ctx.dry_run is True
+    assert ctx.source_command == "src"
+    assert ctx.run_id.startswith("prop_")
+    assert len(ctx.run_id) <= 32
+    assert ctx.generated_at.tzinfo is UTC
+
+
+def test_loader_called_with_context_filters():
+    cand = _make_candidate()
+    service, _ = _build_service(settings=_make_settings(), candidates=[cand])
+    ctx = _make_context(repo_filter="myrepo", decision_run_id="drun")
+    service.run(ctx)
+    service.loader.load.assert_called_once_with(repo="myrepo", decision_run_id="drun")

--- a/tests/unit/proposer/test_candidate_mapper_cov.py
+++ b/tests/unit/proposer/test_candidate_mapper_cov.py
@@ -1,0 +1,513 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from operations_center.autonomy_tiers.config import AutonomyTiersConfig
+from operations_center.decision.models import (
+    CandidateRationale,
+    EvidenceBundle,
+    ProposalCandidate,
+    ProposalOutline,
+)
+from operations_center.proposer.candidate_mapper import (
+    PlaneTaskDraft,
+    ProposalCandidateMapper,
+)
+from operations_center.proposer.provenance import ProposalProvenance
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+def _make_candidate(
+    *,
+    family: str = "lint_fix",
+    risk_class: str = "logic",
+    confidence: str = "medium",
+    validation_profile: str = "",
+    expires_after_runs: int = 5,
+    evidence_lines: list[str] | None = None,
+    evidence_bundle: EvidenceBundle | None = None,
+    labels_hint: list[str] | None = None,
+    title_hint: str = "Fix lint",
+    summary_hint: str = "Reduce ruff violations",
+) -> ProposalCandidate:
+    return ProposalCandidate(
+        candidate_id="cand-1",
+        dedup_key="dk-1",
+        family=family,
+        subject="subject",
+        confidence=confidence,
+        evidence_lines=evidence_lines or [],
+        risk_class=risk_class,
+        expires_after_runs=expires_after_runs,
+        validation_profile=validation_profile,
+        evidence_bundle=evidence_bundle,
+        rationale=CandidateRationale(),
+        proposal_outline=ProposalOutline(
+            title_hint=title_hint,
+            summary_hint=summary_hint,
+            labels_hint=labels_hint or [],
+        ),
+    )
+
+
+def _make_provenance(*, repo_name: str = "some-repo") -> ProposalProvenance:
+    return ProposalProvenance(
+        repo_name=repo_name,
+        source_family="lint_fix",
+        candidate_id="cand-1",
+        candidate_dedup_key="dk-1",
+        observer_run_ids=["obs-1", "obs-2"],
+        insight_run_id="ins-1",
+        decision_run_id="dec-1",
+        proposer_run_id="prop-1",
+    )
+
+
+def _make_settings(
+    *,
+    repo_keys: dict[str, str] | None = None,
+    self_repo_key: str | None = None,
+    include_self_attr: bool = True,
+) -> SimpleNamespace:
+    """Build a minimal Settings-like object.
+
+    repo_keys maps repo_key -> default_branch.
+    """
+    if repo_keys is None:
+        repo_keys = {"some-repo": "main"}
+    repos = {key: SimpleNamespace(default_branch=branch) for key, branch in repo_keys.items()}
+    kwargs: dict = {"repos": repos}
+    if include_self_attr:
+        kwargs["self_repo_key"] = self_repo_key
+    return SimpleNamespace(**kwargs)
+
+
+def _tiers_config(overrides: dict[str, int] | None = None) -> AutonomyTiersConfig:
+    return AutonomyTiersConfig(
+        updated_at=datetime.now(UTC),
+        overrides=overrides or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# map_to_task: state derivation by tier
+# ---------------------------------------------------------------------------
+def test_tier0_falls_back_to_backlog():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="arch_promotion")  # default tier 0
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert draft.state == "Backlog"
+    assert "requires_human_approval: true" in draft.description
+
+
+def test_tier2_ready_for_ai():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="lint_fix")  # default tier 2
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert draft.state == "Ready for AI"
+    assert "requires_human_approval: false" in draft.description
+
+
+def test_tier1_style_risk_is_ready_for_ai():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="type_fix", risk_class="style")  # default tier 1
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert draft.state == "Ready for AI"
+
+
+def test_tier1_nonstyle_risk_is_backlog():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="type_fix", risk_class="logic")  # default tier 1
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert draft.state == "Backlog"
+
+
+def test_overrides_change_tier():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="type_fix", risk_class="logic")
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(overrides={"type_fix": 2}),
+    )
+    assert draft.state == "Ready for AI"
+
+
+# ---------------------------------------------------------------------------
+# map_to_task: tiers_config None triggers load_tiers_config
+# ---------------------------------------------------------------------------
+def test_loads_tiers_config_when_none(monkeypatch):
+    called = {}
+
+    def fake_load():
+        called["loaded"] = True
+        return _tiers_config(overrides={"lint_fix": 0})
+
+    monkeypatch.setattr("operations_center.proposer.candidate_mapper.load_tiers_config", fake_load)
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="lint_fix")
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+    )
+    assert called.get("loaded") is True
+    # override of 0 => Backlog
+    assert draft.state == "Backlog"
+
+
+def test_loads_tiers_config_none_returned(monkeypatch):
+    # load_tiers_config returning None should still work (get_family_tier handles None)
+    monkeypatch.setattr(
+        "operations_center.proposer.candidate_mapper.load_tiers_config", lambda: None
+    )
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="lint_fix")  # default tier 2
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+    )
+    assert draft.state == "Ready for AI"
+
+
+# ---------------------------------------------------------------------------
+# allowed_paths branches
+# ---------------------------------------------------------------------------
+def test_allowed_paths_for_operations_center():
+    assert ProposalCandidateMapper._allowed_paths("operations-center") == [
+        "src/",
+        "tests/",
+        "docs/",
+    ]
+    assert ProposalCandidateMapper._allowed_paths("Operations_Center") == [
+        "src/",
+        "tests/",
+        "docs/",
+    ]
+
+
+def test_allowed_paths_for_other_repo_empty():
+    assert ProposalCandidateMapper._allowed_paths("some-repo") == []
+
+
+def test_allowed_paths_appear_in_description():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="lint_fix")
+    settings = _make_settings(repo_keys={"operations-center": "trunk"})
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=settings,
+        provenance=_make_provenance(repo_name="operations-center"),
+        tiers_config=_tiers_config(),
+    )
+    assert "allowed_paths:" in draft.description
+    assert "  - src/" in draft.description
+    assert "base_branch: trunk" in draft.description
+
+
+def test_no_allowed_paths_section_for_other_repo():
+    mapper = ProposalCandidateMapper()
+    cand = _make_candidate(family="lint_fix")
+    draft = mapper.map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "allowed_paths:" not in draft.description
+
+
+# ---------------------------------------------------------------------------
+# _repo_key_for_candidate branches
+# ---------------------------------------------------------------------------
+def test_repo_key_exact_match():
+    settings = _make_settings(repo_keys={"some-repo": "main"})
+    key = ProposalCandidateMapper._repo_key_for_candidate(
+        settings=settings, provenance=_make_provenance(repo_name="some-repo")
+    )
+    assert key == "some-repo"
+
+
+def test_repo_key_case_insensitive_match():
+    settings = _make_settings(repo_keys={"Some-Repo": "main"})
+    key = ProposalCandidateMapper._repo_key_for_candidate(
+        settings=settings, provenance=_make_provenance(repo_name="some-repo")
+    )
+    assert key == "Some-Repo"
+
+
+def test_repo_key_unknown_raises():
+    settings = _make_settings(repo_keys={"a-repo": "main", "b-repo": "dev"})
+    with pytest.raises(ValueError) as excinfo:
+        ProposalCandidateMapper._repo_key_for_candidate(
+            settings=settings, provenance=_make_provenance(repo_name="ghost")
+        )
+    msg = str(excinfo.value)
+    assert "ghost" in msg
+    # known repos sorted in message
+    assert "a-repo" in msg and "b-repo" in msg
+
+
+# ---------------------------------------------------------------------------
+# _task_kind_for_candidate branches
+# ---------------------------------------------------------------------------
+def test_task_kind_from_label_hint():
+    cand = _make_candidate(labels_hint=["foo", "Task-Kind: Refactor "])
+    assert ProposalCandidateMapper._task_kind_for_candidate(cand) == "refactor"
+
+
+def test_task_kind_goal_for_special_families():
+    for fam in ("observation_coverage", "test_visibility"):
+        cand = _make_candidate(family=fam)
+        assert ProposalCandidateMapper._task_kind_for_candidate(cand) == "goal"
+
+
+def test_task_kind_default_improve():
+    cand = _make_candidate(family="lint_fix")
+    assert ProposalCandidateMapper._task_kind_for_candidate(cand) == "improve"
+
+
+def test_task_kind_label_takes_precedence_over_family():
+    cand = _make_candidate(family="observation_coverage", labels_hint=["task-kind:custom"])
+    assert ProposalCandidateMapper._task_kind_for_candidate(cand) == "custom"
+
+
+# ---------------------------------------------------------------------------
+# _constraints_for_candidate branches
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "family",
+    [
+        "test_visibility",
+        "dependency_drift_followup",
+        "hotspot_concentration",
+        "todo_accumulation",
+        "observation_coverage",
+        "lint_fix",
+        "type_fix",
+        "ci_pattern",
+        "validation_pattern_followup",
+    ],
+)
+def test_constraints_known_families(family):
+    cand = _make_candidate(family=family)
+    constraints = ProposalCandidateMapper._constraints_for_candidate(cand)
+    assert isinstance(constraints, list) and constraints
+    assert all(line.startswith("- ") for line in constraints)
+
+
+def test_constraints_default_family():
+    cand = _make_candidate(family="totally_unknown_family")
+    constraints = ProposalCandidateMapper._constraints_for_candidate(cand)
+    assert constraints == [
+        "- Keep the change scoped to the identified issue.",
+        "- Do not expand into unrelated refactors.",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# evidence_bundle schema version & evidence lines
+# ---------------------------------------------------------------------------
+def test_evidence_schema_version_from_bundle():
+    bundle = EvidenceBundle(schema_version=7, kind="lint_count")
+    cand = _make_candidate(family="lint_fix", evidence_bundle=bundle)
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "evidence_schema_version: 7" in draft.description
+
+
+def test_evidence_schema_version_default_when_no_bundle():
+    cand = _make_candidate(family="lint_fix", evidence_bundle=None)
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "evidence_schema_version: 1" in draft.description
+
+
+def test_evidence_lines_rendered():
+    cand = _make_candidate(family="lint_fix", evidence_lines=["line one", "line two"])
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "## Evidence" in draft.description
+    assert "- line one" in draft.description
+    assert "- line two" in draft.description
+
+
+def test_no_evidence_section_when_empty():
+    cand = _make_candidate(family="lint_fix", evidence_lines=[])
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "## Evidence" not in draft.description
+
+
+# ---------------------------------------------------------------------------
+# expires_at computation
+# ---------------------------------------------------------------------------
+def test_expires_at_uses_expires_after_runs(monkeypatch):
+    fixed = datetime(2026, 1, 1, tzinfo=UTC)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    monkeypatch.setattr("operations_center.proposer.candidate_mapper.datetime", FixedDateTime)
+    cand = _make_candidate(family="lint_fix", expires_after_runs=3)
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(),
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    expected = (fixed + timedelta(days=6)).strftime("%Y-%m-%d")
+    assert f"expires_at: {expected}" in draft.description
+
+
+# ---------------------------------------------------------------------------
+# self-modify label branches
+# ---------------------------------------------------------------------------
+def test_self_modify_label_added_when_matches():
+    cand = _make_candidate(family="lint_fix")
+    settings = _make_settings(
+        repo_keys={"operations-center": "main"}, self_repo_key="Operations-Center"
+    )
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=settings,
+        provenance=_make_provenance(repo_name="operations-center"),
+        tiers_config=_tiers_config(),
+    )
+    assert "self-modify: approved" in draft.label_names
+
+
+def test_self_modify_label_absent_when_no_self_repo_key():
+    cand = _make_candidate(family="lint_fix")
+    settings = _make_settings(repo_keys={"some-repo": "main"}, self_repo_key=None)
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=settings,
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "self-modify: approved" not in draft.label_names
+
+
+def test_self_modify_label_absent_when_attr_missing():
+    # getattr fallback path: settings without self_repo_key attribute at all
+    cand = _make_candidate(family="lint_fix")
+    settings = _make_settings(repo_keys={"some-repo": "main"}, include_self_attr=False)
+    assert not hasattr(settings, "self_repo_key")
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=settings,
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "self-modify: approved" not in draft.label_names
+
+
+def test_self_modify_label_absent_when_different_repo():
+    cand = _make_candidate(family="lint_fix")
+    settings = _make_settings(repo_keys={"some-repo": "main"}, self_repo_key="other-repo")
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=settings,
+        provenance=_make_provenance(),
+        tiers_config=_tiers_config(),
+    )
+    assert "self-modify: approved" not in draft.label_names
+
+
+# ---------------------------------------------------------------------------
+# Full draft shape / labels / provenance block
+# ---------------------------------------------------------------------------
+def test_full_draft_structure():
+    cand = _make_candidate(
+        family="lint_fix",
+        confidence="high",
+        validation_profile="fast",
+        title_hint="My Title",
+        summary_hint="My Summary",
+    )
+    prov = _make_provenance(repo_name="some-repo")
+    draft = ProposalCandidateMapper().map_to_task(
+        candidate=cand,
+        settings=_make_settings(repo_keys={"some-repo": "main"}),
+        provenance=prov,
+        tiers_config=_tiers_config(),
+    )
+    assert isinstance(draft, PlaneTaskDraft)
+    assert draft.name == "My Title"
+    assert draft.task_kind == "improve"
+    # labels
+    assert "task-kind: improve" in draft.label_names
+    assert "repo: some-repo" in draft.label_names
+    assert "source: autonomy" in draft.label_names
+    assert "source: propose" in draft.label_names
+    assert "source-family: lint_fix" in draft.label_names
+    # description sections & provenance fields
+    desc = draft.description
+    assert desc.startswith("## Execution")
+    assert "## Goal" in desc
+    assert "My Summary" in desc
+    assert "## Constraints" in desc
+    assert "## Provenance" in desc
+    assert "source: autonomy-proposer" in desc
+    assert "candidate_id: cand-1" in desc
+    assert "candidate_dedup_key: dk-1" in desc
+    assert "confidence: high" in desc
+    assert "risk_class: logic" in desc
+    assert "autonomy_tier: 2" in desc
+    assert "validation_profile: fast" in desc
+    assert "insight_run_id: ins-1" in desc
+    assert "decision_run_id: dec-1" in desc
+    assert "proposer_run_id: prop-1" in desc
+    # observer run ids
+    assert "  - obs-1" in desc
+    assert "  - obs-2" in desc
+    # description is stripped
+    assert desc == desc.strip()

--- a/tests/unit/proposer/test_guardrail_adapter_cov.py
+++ b/tests/unit/proposer/test_guardrail_adapter_cov.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.proposer.guardrail_adapter import (
+    GuardrailResult,
+    ProposerGuardrailAdapter,
+)
+from operations_center.proposer.result_models import (
+    CreatedProposalResult,
+    ProposalResultsArtifact,
+    ProposerRepoRef,
+)
+
+NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers / fakes                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _make_usage_store(*, remaining: int = 100, min_remaining: int = 10) -> MagicMock:
+    store = MagicMock()
+    store.remaining_exec_capacity.return_value = remaining
+    store.settings.min_remaining_exec_for_proposals = min_remaining
+    store.record_proposal_budget_suppression.return_value = None
+    return store
+
+
+def _make_rejection_store(*, rejected: bool = False) -> MagicMock:
+    store = MagicMock()
+    store.is_rejected.return_value = rejected
+    return store
+
+
+def _make_client(issues: list[dict] | None = None) -> MagicMock:
+    client = MagicMock()
+    client.list_issues.return_value = issues or []
+    return client
+
+
+def _make_adapter(
+    *,
+    proposer_root: Path | None = None,
+    cooldown_minutes: int = 120,
+    recently_done_window_days: int = 7,
+    usage_store: MagicMock | None = None,
+    rejection_store: MagicMock | None = None,
+) -> ProposerGuardrailAdapter:
+    return ProposerGuardrailAdapter(
+        proposer_root=proposer_root,
+        cooldown_minutes=cooldown_minutes,
+        recently_done_window_days=recently_done_window_days,
+        usage_store=usage_store or _make_usage_store(),
+        rejection_store=rejection_store or _make_rejection_store(),
+    )
+
+
+def _write_artifact(
+    root: Path,
+    run_id: str,
+    *,
+    generated_at: datetime,
+    created: list[CreatedProposalResult],
+) -> Path:
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    artifact = ProposalResultsArtifact(
+        run_id=run_id,
+        generated_at=generated_at,
+        source_command="proposer",
+        repo=ProposerRepoRef(name="repo", path=Path("/tmp/repo")),
+        source_decision_run_id="dec-1",
+        created=created,
+    )
+    path = run_dir / "proposal_results.json"
+    path.write_text(artifact.model_dump_json(), encoding="utf-8")
+    return path
+
+
+def _created_item(dedup_key: str, status: str = "created") -> CreatedProposalResult:
+    return CreatedProposalResult(
+        candidate_id="c1",
+        dedup_key=dedup_key,
+        family="fam",
+        plane_title="Title",
+        status=status,
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Construction / defaults                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_default_proposer_root_and_rejection_store(monkeypatch):
+    monkeypatch.delenv("OPERATIONS_CENTER_REJECTION_STORE_PATH", raising=False)
+    adapter = ProposerGuardrailAdapter()
+    assert adapter.proposer_root == Path("tools/report/operations_center/proposer")
+    assert adapter.cooldown_minutes == 120
+    assert adapter.recently_done_window_days == 7
+    assert adapter._usage_store is None
+    # rejection store defaulted to a real ProposalRejectionStore instance
+    assert adapter._rejection_store is not None
+
+
+def test_dataclass_result_defaults():
+    res = GuardrailResult(allowed=True)
+    assert res.allowed is True
+    assert res.reason is None
+    assert res.evidence is None
+
+
+# --------------------------------------------------------------------------- #
+#  evaluate: rejection branch (first check)                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_permanently_rejected(tmp_path):
+    rej = _make_rejection_store(rejected=True)
+    usage = _make_usage_store()
+    adapter = _make_adapter(proposer_root=tmp_path, rejection_store=rej, usage_store=usage)
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is False
+    assert res.reason == "permanently_rejected_by_human"
+    assert res.evidence == {"dedup_key": "k1"}
+    # rejection short-circuits before usage / client
+    usage.remaining_exec_capacity.assert_not_called()
+    client.list_issues.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+#  evaluate: budget branch                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_budget_too_low(tmp_path):
+    usage = _make_usage_store(remaining=5, min_remaining=10)
+    adapter = _make_adapter(proposer_root=tmp_path, usage_store=usage)
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is False
+    assert res.reason == "proposal_budget_too_low"
+    assert res.evidence == {"remaining_exec_capacity": 5, "min_required": 10}
+    usage.record_proposal_budget_suppression.assert_called_once()
+    kwargs = usage.record_proposal_budget_suppression.call_args.kwargs
+    assert kwargs["reason"] == "proposal_budget_too_low"
+    assert kwargs["now"] == NOW
+    assert kwargs["evidence"] == {"remaining_exec_capacity": 5, "min_required": 10}
+    client.list_issues.assert_not_called()
+
+
+def test_evaluate_budget_equal_to_min_is_allowed(tmp_path):
+    # remaining == min_remaining is NOT < min, so passes the budget gate.
+    usage = _make_usage_store(remaining=10, min_remaining=10)
+    adapter = _make_adapter(proposer_root=tmp_path, usage_store=usage)
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is True
+    usage.record_proposal_budget_suppression.assert_not_called()
+
+
+def test_evaluate_uses_internal_usage_store_when_not_injected(tmp_path, monkeypatch):
+    # _usage_store is None -> constructs a UsageStore(); patch that symbol.
+    import operations_center.proposer.guardrail_adapter as mod
+
+    fake = _make_usage_store(remaining=100, min_remaining=10)
+    monkeypatch.setattr(mod, "UsageStore", lambda: fake)
+    adapter = ProposerGuardrailAdapter(
+        proposer_root=tmp_path,
+        usage_store=None,
+        rejection_store=_make_rejection_store(),
+    )
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is True
+    fake.remaining_exec_capacity.assert_called_once_with(now=NOW)
+
+
+# --------------------------------------------------------------------------- #
+#  evaluate: open task match                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_open_task_match_by_title(tmp_path):
+    issues = [{"id": "I1", "name": "My Task", "state": {"name": "In Progress"}}]
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client(issues)
+    res = adapter.evaluate(client=client, dedup_key="k1", title="  my task  ", now=NOW)
+    assert res.allowed is False
+    assert res.reason == "existing_open_equivalent_task"
+    assert res.evidence == {"plane_issue_id": "I1", "plane_title": "My Task"}
+
+
+# --------------------------------------------------------------------------- #
+#  evaluate: recently-done match                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_recently_done_match(tmp_path):
+    issues = [
+        {
+            "id": "I2",
+            "name": "Done Task",
+            "state": {"name": "Done"},
+            "updated_at": (NOW - timedelta(days=1)).isoformat(),
+        }
+    ]
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client(issues)
+    res = adapter.evaluate(client=client, dedup_key="k1", title="done task", now=NOW)
+    assert res.allowed is False
+    assert res.reason == "recently_completed_equivalent_task"
+    assert res.evidence == {
+        "plane_issue_id": "I2",
+        "plane_title": "Done Task",
+        "recently_done_window_days": 7,
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  evaluate: cooldown                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_cooldown_active(tmp_path):
+    last_created = NOW - timedelta(minutes=30)
+    _write_artifact(
+        tmp_path,
+        "run-1",
+        generated_at=last_created,
+        created=[_created_item("k1")],
+    )
+    adapter = _make_adapter(proposer_root=tmp_path, cooldown_minutes=120)
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is False
+    assert res.reason == "cooldown_active"
+    assert res.evidence["cooldown_minutes"] == 120
+    assert res.evidence["last_created_at"] == last_created.isoformat()
+
+
+def test_evaluate_cooldown_expired_allows(tmp_path):
+    last_created = NOW - timedelta(minutes=200)
+    _write_artifact(
+        tmp_path,
+        "run-1",
+        generated_at=last_created,
+        created=[_created_item("k1")],
+    )
+    adapter = _make_adapter(proposer_root=tmp_path, cooldown_minutes=120)
+    client = _make_client()
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res.allowed is True
+
+
+def test_evaluate_all_clear_allows(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client([])
+    res = adapter.evaluate(client=client, dedup_key="k1", title="T", now=NOW)
+    assert res == GuardrailResult(allowed=True)
+
+
+# --------------------------------------------------------------------------- #
+#  _find_open_task_match                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_find_open_skips_done_and_cancelled(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    issues = [
+        {"id": "D", "name": "match", "state": {"name": "Done"}},
+        {"id": "C", "name": "match", "state": {"name": "Cancelled"}},
+    ]
+    client = _make_client(issues)
+    assert adapter._find_open_task_match(client, dedup_key="k", title="match") is None
+
+
+def test_find_open_match_by_candidate_dedup_key_line(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    issues = [
+        {
+            "id": "I9",
+            "name": "Different",
+            "state": {"name": "Todo"},
+            "description": "intro\ncandidate_dedup_key: ABC\nmore",
+        }
+    ]
+    client = _make_client(issues)
+    out = adapter._find_open_task_match(client, dedup_key="abc", title="x")
+    assert out == ("I9", "Different")
+
+
+def test_find_open_match_by_proposal_dedup_key_line(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    issues = [
+        {
+            "id": "I10",
+            "name": "Different",
+            "state": {"name": "Todo"},
+            "description_stripped": "- proposal_dedup_key: xyz",
+        }
+    ]
+    client = _make_client(issues)
+    out = adapter._find_open_task_match(client, dedup_key="XYZ", title="x")
+    assert out == ("I10", "Different")
+
+
+def test_find_open_no_match_when_state_not_dict(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    # state is not a dict -> state_name stays "", not skipped, but no match content
+    issues = [{"id": "I", "name": "other", "state": "weird", "description": ""}]
+    client = _make_client(issues)
+    assert adapter._find_open_task_match(client, dedup_key="k", title="t") is None
+
+
+def test_find_open_no_match_returns_none(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    issues = [
+        {
+            "id": "I",
+            "name": "other",
+            "state": {"name": "Todo"},
+            "description": "candidate_dedup_key: zzz",
+        }
+    ]
+    client = _make_client(issues)
+    assert adapter._find_open_task_match(client, dedup_key="k", title="t") is None
+
+
+# --------------------------------------------------------------------------- #
+#  _find_recently_done_match                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_recently_done_window_zero_returns_none(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path, recently_done_window_days=0)
+    client = _make_client([{"id": "X", "name": "t", "state": {"name": "Done"}}])
+    assert adapter._find_recently_done_match(client, dedup_key="k", title="t", now=NOW) is None
+
+
+def test_recently_done_skips_non_terminal_state(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client([{"id": "X", "name": "t", "state": {"name": "In Progress"}}])
+    assert adapter._find_recently_done_match(client, dedup_key="k", title="t", now=NOW) is None
+
+
+def test_recently_done_skips_too_old(tmp_path):
+    old = NOW - timedelta(days=30)
+    adapter = _make_adapter(proposer_root=tmp_path, recently_done_window_days=7)
+    client = _make_client(
+        [
+            {
+                "id": "X",
+                "name": "t",
+                "state": {"name": "Done"},
+                "updated_at": old.isoformat(),
+            }
+        ]
+    )
+    assert adapter._find_recently_done_match(client, dedup_key="k", title="t", now=NOW) is None
+
+
+def test_recently_done_uses_completed_at_with_z_suffix(tmp_path):
+    recent = (NOW - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client(
+        [
+            {
+                "id": "X",
+                "name": "Match",
+                "state": {"name": "Cancelled"},
+                "completed_at": recent,
+            }
+        ]
+    )
+    out = adapter._find_recently_done_match(client, dedup_key="k", title="match", now=NOW)
+    assert out == ("X", "Match")
+
+
+def test_recently_done_naive_timestamp_treated_as_utc(tmp_path):
+    naive = (NOW - timedelta(days=1)).replace(tzinfo=None).isoformat()
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client(
+        [
+            {
+                "id": "N",
+                "name": "Match",
+                "state": {"name": "Done"},
+                "updated_at": naive,
+            }
+        ]
+    )
+    out = adapter._find_recently_done_match(client, dedup_key="k", title="match", now=NOW)
+    assert out == ("N", "Match")
+
+
+def test_recently_done_bad_timestamp_falls_through_to_match(tmp_path):
+    # ValueError on parse is swallowed; matching by title still works.
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client(
+        [
+            {
+                "id": "B",
+                "name": "Match",
+                "state": {"name": "Done"},
+                "updated_at": "not-a-date",
+            }
+        ]
+    )
+    out = adapter._find_recently_done_match(client, dedup_key="k", title="match", now=NOW)
+    assert out == ("B", "Match")
+
+
+def test_recently_done_empty_timestamp_skips_window_check(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client([{"id": "E", "name": "Match", "state": {"name": "Done"}}])
+    out = adapter._find_recently_done_match(client, dedup_key="k", title="match", now=NOW)
+    assert out == ("E", "Match")
+
+
+def test_recently_done_match_by_dedup_key_lines(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    client = _make_client(
+        [
+            {
+                "id": "D1",
+                "name": "Other",
+                "state": {"name": "Done"},
+                "updated_at": recent,
+                "description": "- proposal_dedup_key: kk",
+            }
+        ]
+    )
+    out = adapter._find_recently_done_match(client, dedup_key="KK", title="x", now=NOW)
+    assert out == ("D1", "Other")
+
+
+def test_recently_done_candidate_dedup_key_line(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    client = _make_client(
+        [
+            {
+                "id": "D2",
+                "name": "Other",
+                "state": {"name": "Done"},
+                "updated_at": recent,
+                "description": "candidate_dedup_key: kk",
+            }
+        ]
+    )
+    out = adapter._find_recently_done_match(client, dedup_key="kk", title="x", now=NOW)
+    assert out == ("D2", "Other")
+
+
+def test_recently_done_no_match_returns_none(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    client = _make_client(
+        [
+            {
+                "id": "D3",
+                "name": "Other",
+                "state": {"name": "Done"},
+                "updated_at": recent,
+                "description": "nope",
+            }
+        ]
+    )
+    assert adapter._find_recently_done_match(client, dedup_key="kk", title="x", now=NOW) is None
+
+
+def test_recently_done_state_not_dict_skipped(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client([{"id": "X", "name": "match", "state": None}])
+    assert adapter._find_recently_done_match(client, dedup_key="k", title="match", now=NOW) is None
+
+
+# --------------------------------------------------------------------------- #
+#  _last_created_at                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_last_created_none_when_no_artifacts(tmp_path):
+    adapter = _make_adapter(proposer_root=tmp_path)
+    assert adapter._last_created_at("k1") is None
+
+
+def test_last_created_returns_generated_at_for_matching_key(tmp_path):
+    gen = NOW - timedelta(minutes=5)
+    _write_artifact(tmp_path, "run-1", generated_at=gen, created=[_created_item("k1", "created")])
+    adapter = _make_adapter(proposer_root=tmp_path)
+    assert adapter._last_created_at("k1") == gen
+
+
+def test_last_created_matches_dry_run_status(tmp_path):
+    gen = NOW - timedelta(minutes=5)
+    _write_artifact(tmp_path, "run-1", generated_at=gen, created=[_created_item("k2", "dry_run")])
+    adapter = _make_adapter(proposer_root=tmp_path)
+    assert adapter._last_created_at("k2") == gen
+
+
+def test_last_created_ignores_other_status(tmp_path):
+    gen = NOW - timedelta(minutes=5)
+    _write_artifact(tmp_path, "run-1", generated_at=gen, created=[_created_item("k3", "failed")])
+    adapter = _make_adapter(proposer_root=tmp_path)
+    assert adapter._last_created_at("k3") is None
+
+
+def test_last_created_ignores_other_keys(tmp_path):
+    gen = NOW - timedelta(minutes=5)
+    _write_artifact(
+        tmp_path, "run-1", generated_at=gen, created=[_created_item("other", "created")]
+    )
+    adapter = _make_adapter(proposer_root=tmp_path)
+    assert adapter._last_created_at("k1") is None
+
+
+def test_last_created_scans_newest_first(tmp_path):
+    import os
+
+    older = NOW - timedelta(minutes=100)
+    newer = NOW - timedelta(minutes=1)
+    p_old = _write_artifact(tmp_path, "run-old", generated_at=older, created=[_created_item("k1")])
+    p_new = _write_artifact(tmp_path, "run-new", generated_at=newer, created=[_created_item("k1")])
+    # Force mtime ordering: new file newer than old.
+    os.utime(p_old, (1000, 1000))
+    os.utime(p_new, (2000, 2000))
+    adapter = _make_adapter(proposer_root=tmp_path)
+    # Newest-mtime artifact is scanned first and returned.
+    assert adapter._last_created_at("k1") == newer
+
+
+def test_evaluate_cooldown_with_last_created_none_allows(tmp_path):
+    # No artifacts -> _last_created_at is None -> cooldown skipped -> allowed.
+    adapter = _make_adapter(proposer_root=tmp_path)
+    client = _make_client([])
+    res = adapter.evaluate(client=client, dedup_key="missing", title="T", now=NOW)
+    assert res.allowed is True
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/run_memory/test_index_cov.py
+++ b/tests/unit/run_memory/test_index_cov.py
@@ -1,0 +1,410 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Branch/edge coverage for operations_center.run_memory.index.
+
+Complements test_run_memory.py: focuses on the tolerant accessor in
+``_record_from_result``, query filter branches, rebuild edge cases, and
+artifact iteration directory skips. Uses plain dicts / lightweight fakes
+to stay hermetic.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+
+from operations_center.run_memory.index import (
+    RunMemoryIndexWriter,
+    RunMemoryQueryService,
+    _iter_result_artifacts,
+    _matches,
+    _record_from_result,
+    deterministic_record_id,
+    rebuild_index_from_artifacts,
+    record_execution_result,
+)
+from operations_center.run_memory.models import (
+    RunMemoryQuery,
+    RunMemoryRecord,
+    SourceType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rec(**overrides) -> RunMemoryRecord:
+    base = dict(
+        record_id="rmr-x",
+        run_id="run-1",
+        request_id="req-1",
+        result_id="res-1",
+        repo_id="repo-1",
+        artifact_paths=("a/b.json",),
+        contract_kinds=("kindA",),
+        status="succeeded",
+        summary="hello world",
+        tags=("alpha", "beta"),
+        created_at="2026-06-01T00:00:00Z",
+        source_type=SourceType.EXECUTION_RESULT,
+    )
+    base.update(overrides)
+    return RunMemoryRecord(**base)
+
+
+class _Status(str, Enum):
+    OK = "succeeded"
+
+
+@dataclass
+class _FakeResult:
+    run_id: str = "run-99"
+    status: object = "running"
+    # other optional fields intentionally absent unless set
+
+
+# ---------------------------------------------------------------------------
+# deterministic_record_id
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_record_id_shape() -> None:
+    rid = deterministic_record_id("abc")
+    assert rid.startswith("rmr-")
+    assert len(rid) == len("rmr-") + 16
+    assert rid == deterministic_record_id("abc")
+    assert rid != deterministic_record_id("abd")
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def test_writer_creates_dir_and_path(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "idx"
+    w = RunMemoryIndexWriter(target)
+    assert target.is_dir()
+    assert w.path == target / "records.jsonl"
+
+
+def test_writer_append_then_truncate(tmp_path: Path) -> None:
+    w = RunMemoryIndexWriter(tmp_path)
+    w.append(_rec())
+    w.append(_rec(record_id="rmr-y"))
+    assert len(w.path.read_text().splitlines()) == 2
+    w.truncate()
+    assert w.path.read_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# _record_from_result tolerant accessor
+# ---------------------------------------------------------------------------
+
+
+def test_record_from_dict_full_fields() -> None:
+    data = {
+        "run_id": "run-d",
+        "request_id": "req-d",
+        "decision_id": "dec-d",
+        "result_id": "res-explicit",
+        "status": "failed",
+        "failure_reason": "boom",
+    }
+    rec = _record_from_result(
+        data,
+        repo_id="repo-d",
+        artifact_paths=("p.json",),
+        contract_kinds=("ck",),
+        tags=("t",),
+        summary=None,
+    )
+    assert rec.run_id == "run-d"
+    assert rec.request_id == "req-d"
+    assert rec.result_id == "res-explicit"
+    assert rec.status == "failed"
+    assert rec.summary == "boom"  # failure_reason wins when no summary
+    assert rec.record_id == deterministic_record_id("res-explicit")
+
+
+def test_record_from_dict_proposal_id_preferred_over_request_id() -> None:
+    data = {"run_id": "r", "proposal_id": "prop", "request_id": "req"}
+    rec = _record_from_result(
+        data,
+        repo_id=None,
+        artifact_paths=(),
+        contract_kinds=(),
+        tags=(),
+        summary=None,
+    )
+    assert rec.request_id == "prop"
+
+
+def test_record_from_dict_lane_decision_id_fallback_and_derived_result_id() -> None:
+    # No result_id, no decision_id, but lane_decision_id present.
+    data = {"run_id": "rl", "lane_decision_id": "lane-9"}
+    rec = _record_from_result(
+        data,
+        repo_id=None,
+        artifact_paths=(),
+        contract_kinds=(),
+        tags=(),
+        summary=None,
+    )
+    assert rec.result_id == "rl::lane-9"
+
+
+def test_record_from_dict_no_decision_derives_no_decision_token() -> None:
+    data = {"run_id": "rn"}
+    rec = _record_from_result(
+        data,
+        repo_id=None,
+        artifact_paths=(),
+        contract_kinds=(),
+        tags=(),
+        summary=None,
+    )
+    assert rec.result_id == "rn::no-decision"
+    # No failure_reason -> synthesized summary uses status + run id.
+    assert rec.summary == "unknown: run rn"
+    assert rec.status == "unknown"
+
+
+def test_record_from_object_status_enum_value() -> None:
+    obj = _FakeResult(run_id="ro", status=_Status.OK)
+    rec = _record_from_result(
+        obj,
+        repo_id=None,
+        artifact_paths=(),
+        contract_kinds=(),
+        tags=(),
+        summary="explicit summary",
+    )
+    assert rec.status == "succeeded"
+    assert rec.summary == "explicit summary"  # explicit summary preserved
+    assert rec.source_type is SourceType.EXECUTION_RESULT
+
+
+def test_record_from_non_dict_non_object_uses_defaults() -> None:
+    # A bare value lacking attributes and not a dict exercises the final
+    # ``return default`` branch of _get for every field.
+    rec = _record_from_result(
+        42,
+        repo_id=None,
+        artifact_paths=(),
+        contract_kinds=(),
+        tags=(),
+        summary=None,
+    )
+    assert rec.run_id == "None"
+    assert rec.status == "unknown"
+    assert rec.result_id == "None::no-decision"
+
+
+# ---------------------------------------------------------------------------
+# record_execution_result (single write site)
+# ---------------------------------------------------------------------------
+
+
+def test_record_execution_result_appends_and_returns(tmp_path: Path) -> None:
+    rec = record_execution_result(
+        {"run_id": "rw", "result_id": "res-w"},
+        tmp_path,
+        repo_id="repo-w",
+        artifact_paths=["x.json"],
+        contract_kinds=["ck1"],
+        tags=["tg"],
+        summary="written",
+    )
+    svc = RunMemoryQueryService(tmp_path)
+    stored = svc.all()
+    assert len(stored) == 1
+    assert stored[0].record_id == rec.record_id
+    assert stored[0].summary == "written"
+    assert stored[0].artifact_paths == ("x.json",)
+
+
+# ---------------------------------------------------------------------------
+# Query service
+# ---------------------------------------------------------------------------
+
+
+def test_iter_records_missing_path(tmp_path: Path) -> None:
+    svc = RunMemoryQueryService(tmp_path / "absent")
+    assert svc.all() == []
+
+
+def test_iter_records_skips_blank_lines(tmp_path: Path) -> None:
+    w = RunMemoryIndexWriter(tmp_path)
+    w.append(_rec(record_id="rmr-1", result_id="r1"))
+    # Inject blank/whitespace lines.
+    with w.path.open("a", encoding="utf-8") as fh:
+        fh.write("\n   \n")
+    w.append(_rec(record_id="rmr-2", result_id="r2"))
+    svc = RunMemoryQueryService(tmp_path)
+    assert len(svc.all()) == 2
+
+
+def test_query_sorts_by_created_at_then_record_id(tmp_path: Path) -> None:
+    w = RunMemoryIndexWriter(tmp_path)
+    w.append(_rec(record_id="rmr-b", created_at="2026-06-01T00:00:00Z"))
+    w.append(_rec(record_id="rmr-a", created_at="2026-06-01T00:00:00Z"))
+    w.append(_rec(record_id="rmr-z", created_at="2026-05-01T00:00:00Z"))
+    svc = RunMemoryQueryService(tmp_path)
+    ids = [r.record_id for r in svc.all()]
+    assert ids == ["rmr-z", "rmr-a", "rmr-b"]
+
+
+# ---------------------------------------------------------------------------
+# _matches branches
+# ---------------------------------------------------------------------------
+
+
+def test_matches_empty_query_true() -> None:
+    assert _matches(_rec(), RunMemoryQuery()) is True
+
+
+def test_matches_repo_id_mismatch() -> None:
+    assert _matches(_rec(repo_id="a"), RunMemoryQuery(repo_id="b")) is False
+
+
+def test_matches_run_id_mismatch() -> None:
+    assert _matches(_rec(run_id="a"), RunMemoryQuery(run_id="b")) is False
+
+
+def test_matches_request_id_mismatch() -> None:
+    assert _matches(_rec(request_id="a"), RunMemoryQuery(request_id="b")) is False
+
+
+def test_matches_result_id_mismatch() -> None:
+    assert _matches(_rec(result_id="a"), RunMemoryQuery(result_id="b")) is False
+
+
+def test_matches_status_mismatch() -> None:
+    assert _matches(_rec(status="ok"), RunMemoryQuery(status="bad")) is False
+
+
+def test_matches_contract_kind_not_present() -> None:
+    assert _matches(_rec(contract_kinds=("x",)), RunMemoryQuery(contract_kind="y")) is False
+    assert _matches(_rec(contract_kinds=("y",)), RunMemoryQuery(contract_kind="y")) is True
+
+
+def test_matches_tag_not_present() -> None:
+    assert _matches(_rec(tags=("x",)), RunMemoryQuery(tag="y")) is False
+
+
+def test_matches_text_searches_artifact_paths_and_repo() -> None:
+    rec = _rec(summary="", repo_id="REPO-special", artifact_paths=("dir/thing.json",))
+    assert _matches(rec, RunMemoryQuery(text="repo-special")) is True
+    assert _matches(rec, RunMemoryQuery(text="thing.json")) is True
+    assert _matches(rec, RunMemoryQuery(text="absent")) is False
+
+
+def test_matches_text_none_summary_and_repo() -> None:
+    # None summary/repo_id exercise the ``or ""`` fallbacks without error.
+    rec = _rec(summary="", repo_id=None, run_id="runX", tags=(), artifact_paths=())
+    assert _matches(rec, RunMemoryQuery(text="runx")) is True
+    assert _matches(rec, RunMemoryQuery(text="nope")) is False
+
+
+def test_matches_time_range_in_and_out() -> None:
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    inside = _rec(created_at="2026-06-01T12:00:00Z")
+    before = _rec(created_at="2026-05-31T12:00:00Z")
+    after = _rec(created_at="2026-06-03T12:00:00Z")
+    q = RunMemoryQuery(time_range=(start, end))
+    assert _matches(inside, q) is True
+    assert _matches(before, q) is False
+    assert _matches(after, q) is False
+
+
+def test_matches_time_range_unparseable_created_at() -> None:
+    start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    rec = _rec(created_at="not-a-timestamp")
+    assert _matches(rec, RunMemoryQuery(time_range=(start, end))) is False
+
+
+# ---------------------------------------------------------------------------
+# rebuild_index_from_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_missing_dir_returns_zero(tmp_path: Path) -> None:
+    idx = tmp_path / "idx"
+    n = rebuild_index_from_artifacts(tmp_path / "no-artifacts", idx)
+    assert n == 0
+    # Truncate still ran, creating an empty file.
+    assert (idx / "records.jsonl").read_text() == ""
+
+
+def test_rebuild_skips_bad_json_and_non_dict(tmp_path: Path) -> None:
+    arts = tmp_path / "arts"
+    arts.mkdir()
+    (arts / "execution_result_bad.json").write_text("{not json", encoding="utf-8")
+    (arts / "execution_result_list.json").write_text("[1, 2, 3]", encoding="utf-8")
+    (arts / "execution_result_ok.json").write_text(
+        json.dumps({"run_id": "rk", "result_id": "res-k", "status": "succeeded"}),
+        encoding="utf-8",
+    )
+    (arts / "ignored.json").write_text(json.dumps({"run_id": "z"}), encoding="utf-8")
+    n = rebuild_index_from_artifacts(arts, tmp_path / "idx")
+    assert n == 1
+    recs = RunMemoryQueryService(tmp_path / "idx").all()
+    assert recs[0].run_id == "rk"
+    assert recs[0].artifact_paths == (str(arts / "execution_result_ok.json"),)
+
+
+def test_rebuild_dedupes_same_result_id(tmp_path: Path) -> None:
+    arts = tmp_path / "arts"
+    sub = arts / "sub"
+    sub.mkdir(parents=True)
+    payload = json.dumps({"run_id": "rd", "result_id": "dup"})
+    (arts / "execution_result_a.json").write_text(payload, encoding="utf-8")
+    (sub / "execution_result_b.json").write_text(payload, encoding="utf-8")
+    n = rebuild_index_from_artifacts(arts, tmp_path / "idx")
+    assert n == 1
+
+
+def test_rebuild_recurses_and_skips_pycache_and_git(tmp_path: Path) -> None:
+    arts = tmp_path / "arts"
+    (arts / "__pycache__").mkdir(parents=True)
+    (arts / ".git").mkdir()
+    deep = arts / "level1" / "level2"
+    deep.mkdir(parents=True)
+    # Files inside skipped dirs must not be indexed.
+    (arts / "__pycache__" / "execution_result_x.json").write_text(
+        json.dumps({"run_id": "px", "result_id": "px"}), encoding="utf-8"
+    )
+    (arts / ".git" / "execution_result_g.json").write_text(
+        json.dumps({"run_id": "gx", "result_id": "gx"}), encoding="utf-8"
+    )
+    (deep / "execution_result_deep.json").write_text(
+        json.dumps({"run_id": "deep", "result_id": "deep"}), encoding="utf-8"
+    )
+    n = rebuild_index_from_artifacts(arts, tmp_path / "idx")
+    assert n == 1
+    assert RunMemoryQueryService(tmp_path / "idx").all()[0].run_id == "deep"
+
+
+# ---------------------------------------------------------------------------
+# _iter_result_artifacts directly
+# ---------------------------------------------------------------------------
+
+
+def test_iter_result_artifacts_missing_dir(tmp_path: Path) -> None:
+    assert list(_iter_result_artifacts(tmp_path / "nope")) == []
+
+
+def test_iter_result_artifacts_pattern_filter(tmp_path: Path) -> None:
+    (tmp_path / "execution_result_1.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "execution_result_2.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "other.json").write_text("{}", encoding="utf-8")
+    found = [p.name for p in _iter_result_artifacts(tmp_path)]
+    assert found == ["execution_result_1.json"]

--- a/tests/unit/scheduled_tasks/__init__.py
+++ b/tests/unit/scheduled_tasks/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/scheduled_tasks/test_runner_cov.py
+++ b/tests/unit/scheduled_tasks/test_runner_cov.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.scheduled_tasks import runner as mod
+from operations_center.scheduled_tasks.runner import (
+    ScheduledTaskRunner,
+    _is_due,
+    _parse_at,
+    _parse_every,
+    _task_key,
+    due_tasks,
+)
+
+
+# ── lightweight stand-ins for pydantic models ────────────────────────────────
+
+
+@dataclass
+class FakeTask:
+    every: str = "1d"
+    title: str = "Weekly audit"
+    goal: str = "audit deps"
+    repo_key: str = "owner/repo"
+    kind: str = "goal"
+    at: str | None = None
+    on_days: list[str] | None = None
+
+
+@dataclass
+class FakeSettings:
+    scheduled_tasks: list = field(default_factory=list)
+
+
+# ── _parse_every ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("30m", 30 * 60),
+        ("6h", 6 * 3600),
+        ("1d", 86400),
+        ("1w", 604800),
+        ("  2H ", 2 * 3600),  # whitespace + case-insensitive
+        ("0m", 0),
+    ],
+)
+def test_parse_every_valid(text, expected):
+    assert _parse_every(text) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "5x", "m", "5", "-3h", "1.5h"])
+def test_parse_every_invalid(bad):
+    with pytest.raises(ValueError):
+        _parse_every(bad)
+
+
+# ── _parse_at ───────────────────────────────────────────────────────────────
+
+
+def test_parse_at_valid():
+    assert _parse_at("09:30") == (9, 30)
+    assert _parse_at(" 0:00 ") == (0, 0)
+    assert _parse_at("23:59") == (23, 59)
+
+
+@pytest.mark.parametrize("bad", ["9", "0930", "9:3", "abc"])
+def test_parse_at_malformed(bad):
+    with pytest.raises(ValueError, match="at must be HH:MM"):
+        _parse_at(bad)
+
+
+@pytest.mark.parametrize("bad", ["24:00", "12:60", "99:99"])
+def test_parse_at_out_of_range(bad):
+    with pytest.raises(ValueError, match="out of range"):
+        _parse_at(bad)
+
+
+# ── _task_key ─────────────────────────────────────────────────────────────────
+
+
+def test_task_key_stable_and_short():
+    t = FakeTask(title="T", repo_key="r")
+    k1 = _task_key(t)
+    k2 = _task_key(FakeTask(title="T", repo_key="r"))
+    assert k1 == k2
+    assert len(k1) == 16
+
+
+def test_task_key_changes_with_title_or_repo():
+    base = _task_key(FakeTask(title="A", repo_key="r"))
+    assert base != _task_key(FakeTask(title="B", repo_key="r"))
+    assert base != _task_key(FakeTask(title="A", repo_key="r2"))
+
+
+# ── _is_due ───────────────────────────────────────────────────────────────────
+
+NOW = datetime(2026, 6, 2, 9, 0, 0, tzinfo=UTC)  # 2026-06-02 is a Tuesday
+
+
+def test_is_due_malformed_every_returns_false(caplog):
+    with caplog.at_level("WARNING"):
+        assert _is_due(FakeTask(every="nope"), None, NOW) is False
+    assert "skipping malformed task" in caplog.text
+
+
+def test_is_due_first_run_no_last_run():
+    assert _is_due(FakeTask(every="1d"), None, NOW) is True
+
+
+def test_is_due_interval_not_elapsed():
+    last = NOW.replace(hour=8)  # only 1h ago, interval is 1d
+    assert _is_due(FakeTask(every="1d"), last, NOW) is False
+
+
+def test_is_due_interval_elapsed():
+    last = NOW.replace(day=1)  # >1d ago
+    assert _is_due(FakeTask(every="1d"), last, NOW) is True
+
+
+def test_is_due_weekday_match():
+    # Tuesday = "tue"
+    assert _is_due(FakeTask(every="1d", on_days=["tue"]), None, NOW) is True
+
+
+def test_is_due_weekday_no_match():
+    assert _is_due(FakeTask(every="1d", on_days=["mon"]), None, NOW) is False
+
+
+def test_is_due_weekday_unknown_name_logs_and_filtered(caplog):
+    with caplog.at_level("WARNING"):
+        # only an unknown day -> normalized&known is empty -> no match
+        result = _is_due(FakeTask(every="1d", on_days=["xyz"]), None, NOW)
+    assert result is False
+    assert "unknown day name" in caplog.text
+
+
+def test_is_due_weekday_mixed_known_unknown(caplog):
+    # "tuesday" -> "tue" matches; "xyz" unknown but logged
+    with caplog.at_level("WARNING"):
+        assert _is_due(FakeTask(every="1d", on_days=["Tuesday", "xyz", ""]), None, NOW) is True
+    assert "unknown day name" in caplog.text
+
+
+def test_is_due_at_anchor_match_within_slack():
+    # now is 09:00, anchor 09:00 -> delta 0
+    assert _is_due(FakeTask(every="1d", at="09:00"), None, NOW) is True
+
+
+def test_is_due_at_anchor_within_slack_window():
+    now = NOW.replace(minute=4)  # 09:04, anchor 09:00 -> 240s < 300 slack
+    assert _is_due(FakeTask(every="1d", at="09:00"), None, now) is True
+
+
+def test_is_due_at_anchor_outside_slack():
+    now = NOW.replace(minute=10)  # 600s > 300
+    assert _is_due(FakeTask(every="1d", at="09:00"), None, now) is False
+
+
+def test_is_due_at_custom_slack():
+    now = NOW.replace(minute=10)
+    assert _is_due(FakeTask(every="1d", at="09:00"), None, now, slack_seconds=700) is True
+
+
+def test_is_due_at_malformed_returns_false(caplog):
+    with caplog.at_level("WARNING"):
+        assert _is_due(FakeTask(every="1d", at="99:99"), None, NOW) is False
+    assert "bad `at`" in caplog.text
+
+
+# ── due_tasks ─────────────────────────────────────────────────────────────────
+
+
+def test_due_tasks_empty_settings():
+    assert due_tasks(FakeSettings(scheduled_tasks=[])) == []
+
+
+def test_due_tasks_none_scheduled():
+    s = FakeSettings()
+    s.scheduled_tasks = None
+    assert due_tasks(s) == []
+
+
+def test_due_tasks_no_state_file(tmp_path):
+    s = FakeSettings(scheduled_tasks=[FakeTask(every="1d")])
+    out = due_tasks(s, state_file=tmp_path / "missing.json", now=NOW)
+    assert len(out) == 1
+
+
+def test_due_tasks_uses_default_state_file(monkeypatch, tmp_path):
+    # Point module default at a non-existent path under tmp.
+    monkeypatch.setattr(mod, "_STATE_FILE", tmp_path / "default.json")
+    s = FakeSettings(scheduled_tasks=[FakeTask(every="1d")])
+    out = due_tasks(s, now=NOW)
+    assert len(out) == 1
+
+
+def test_due_tasks_uses_now_default(monkeypatch, tmp_path):
+    s = FakeSettings(scheduled_tasks=[FakeTask(every="1d")])
+    out = due_tasks(s, state_file=tmp_path / "x.json")
+    assert len(out) == 1  # now defaults to datetime.now(UTC); first-run fires
+
+
+def test_due_tasks_respects_last_run(tmp_path):
+    task = FakeTask(every="1d")
+    key = _task_key(task)
+    state = tmp_path / "state.json"
+    # last run was just now -> not due
+    state.write_text(json.dumps({key: NOW.isoformat()}), encoding="utf-8")
+    s = FakeSettings(scheduled_tasks=[task])
+    assert due_tasks(s, state_file=state, now=NOW) == []
+
+
+def test_due_tasks_last_run_z_suffix(tmp_path):
+    task = FakeTask(every="1d")
+    key = _task_key(task)
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({key: "2026-06-02T09:00:00Z"}), encoding="utf-8")
+    s = FakeSettings(scheduled_tasks=[task])
+    assert due_tasks(s, state_file=state, now=NOW) == []
+
+
+def test_due_tasks_bad_last_run_iso_treated_as_first_run(tmp_path):
+    task = FakeTask(every="1d")
+    key = _task_key(task)
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({key: "not-a-date"}), encoding="utf-8")
+    s = FakeSettings(scheduled_tasks=[task])
+    # unparseable -> last_run stays None -> due
+    assert len(due_tasks(s, state_file=state, now=NOW)) == 1
+
+
+def test_due_tasks_unreadable_state_file(tmp_path, caplog):
+    state = tmp_path / "state.json"
+    state.write_text("{not json", encoding="utf-8")
+    s = FakeSettings(scheduled_tasks=[FakeTask(every="1d")])
+    with caplog.at_level("WARNING"):
+        out = due_tasks(s, state_file=state, now=NOW)
+    assert len(out) == 1
+    assert "state file unreadable" in caplog.text
+
+
+def test_due_tasks_state_null_json(tmp_path):
+    # json "null" -> falls back to {} via `or {}`
+    state = tmp_path / "state.json"
+    state.write_text("null", encoding="utf-8")
+    s = FakeSettings(scheduled_tasks=[FakeTask(every="1d")])
+    assert len(due_tasks(s, state_file=state, now=NOW)) == 1
+
+
+# ── ScheduledTaskRunner.tick ─────────────────────────────────────────────────
+
+
+def _runner(client, tasks, state_file):
+    return ScheduledTaskRunner(client, FakeSettings(scheduled_tasks=tasks), state_file=state_file)
+
+
+def test_tick_no_due_returns_empty(tmp_path):
+    client = MagicMock()
+    task = FakeTask(every="1d")
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({_task_key(task): NOW.isoformat()}), encoding="utf-8")
+    r = _runner(client, [task], state)
+    assert r.tick(now=NOW) == []
+    client.create_issue.assert_not_called()
+
+
+def test_tick_creates_issue_and_persists_state(tmp_path):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": "ISSUE-1"}
+    task = FakeTask(every="1d", title="Audit", repo_key="o/r", kind="goal")
+    state = tmp_path / "sub" / "state.json"
+    r = _runner(client, [task], state)
+    ids = r.tick(now=NOW)
+    assert ids == ["ISSUE-1"]
+    # verify create_issue args
+    kwargs = client.create_issue.call_args.kwargs
+    assert kwargs["name"] == "Audit"
+    assert kwargs["state"] == "Ready for AI"
+    assert "## Goal" in kwargs["description"]
+    assert "every: 1d" in kwargs["description"]
+    assert "source: autonomy" in kwargs["label_names"]
+    # state file written
+    assert state.exists()
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert saved[_task_key(task)] == NOW.isoformat()
+    assert not state.with_suffix(".tmp").exists()
+
+
+def test_tick_empty_id_not_recorded(tmp_path):
+    client = MagicMock()
+    client.create_issue.return_value = {}  # no id
+    state = tmp_path / "state.json"
+    r = _runner(client, [FakeTask(every="1d")], state)
+    assert r.tick(now=NOW) == []
+    # nothing created -> state not written
+    assert not state.exists()
+
+
+def test_tick_create_issue_exception_logged_and_retries(tmp_path, caplog):
+    client = MagicMock()
+    client.create_issue.side_effect = RuntimeError("boom")
+    state = tmp_path / "state.json"
+    r = _runner(client, [FakeTask(every="1d", title="X")], state)
+    with caplog.at_level("WARNING"):
+        assert r.tick(now=NOW) == []
+    assert "failed to create" in caplog.text
+    assert not state.exists()
+
+
+def test_tick_partial_failure_persists_success(tmp_path):
+    client = MagicMock()
+    good = FakeTask(every="1d", title="Good", repo_key="a")
+    bad = FakeTask(every="1d", title="Bad", repo_key="b")
+
+    def side(*, name, **_):
+        if name == "Bad":
+            raise RuntimeError("nope")
+        return {"id": "GOOD-1"}
+
+    client.create_issue.side_effect = side
+    state = tmp_path / "state.json"
+    r = _runner(client, [good, bad], state)
+    ids = r.tick(now=NOW)
+    assert ids == ["GOOD-1"]
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert _task_key(good) in saved
+    assert _task_key(bad) not in saved
+
+
+def test_tick_loads_existing_state_and_merges(tmp_path):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": "NEW"}
+    new_task = FakeTask(every="1d", title="New", repo_key="n")
+    state = tmp_path / "state.json"
+    # pre-existing unrelated key should survive
+    state.write_text(json.dumps({"oldkey": "2020-01-01T00:00:00+00:00"}), encoding="utf-8")
+    r = _runner(client, [new_task], state)
+    r.tick(now=NOW)
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert "oldkey" in saved
+    assert _task_key(new_task) in saved
+
+
+def test_tick_existing_state_unreadable_resets(tmp_path):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": "NEW"}
+    task = FakeTask(every="1d")
+    state = tmp_path / "state.json"
+    # due_tasks tolerates bad json; tick re-reads and resets to {}
+    state.write_text("garbage{", encoding="utf-8")
+    r = _runner(client, [task], state)
+    assert r.tick(now=NOW) == ["NEW"]
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert _task_key(task) in saved
+
+
+def test_tick_persist_oserror_logged(tmp_path, monkeypatch, caplog):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": "ID1"}
+    state = tmp_path / "state.json"
+    r = _runner(client, [FakeTask(every="1d")], state)
+
+    real_write = Path.write_text
+
+    def boom(self, *a, **k):
+        if self.suffix == ".tmp":
+            raise OSError("disk full")
+        return real_write(self, *a, **k)
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    with caplog.at_level("WARNING"):
+        ids = r.tick(now=NOW)
+    # ids still returned even though persistence failed
+    assert ids == ["ID1"]
+    assert "failed to persist last_run state" in caplog.text
+
+
+def test_tick_default_now(tmp_path):
+    client = MagicMock()
+    client.create_issue.return_value = {"id": "ID"}
+    state = tmp_path / "state.json"
+    r = _runner(client, [FakeTask(every="1d")], state)
+    # now omitted -> defaults to datetime.now(UTC); first run fires
+    assert r.tick() == ["ID"]
+
+
+def test_runner_default_state_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(mod, "_STATE_FILE", tmp_path / "def.json")
+    client = MagicMock()
+    r = ScheduledTaskRunner(client, FakeSettings(scheduled_tasks=[]))
+    assert r._state_file == tmp_path / "def.json"

--- a/tests/unit/slice_replay/test_checks_cov.py
+++ b/tests/unit/slice_replay/test_checks_cov.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Coverage-focused unit tests for slice_replay.checks.
+
+Hermetic: models are constructed directly (no harvest pipeline, no network,
+no git). All filesystem access is confined to pytest tmp_path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from operations_center.behavior_calibration.models import ArtifactIndexSummary
+from operations_center.fixture_harvesting.models import FixtureArtifact, FixturePack
+from operations_center.slice_replay import checks
+from operations_center.slice_replay.checks import (
+    CHECK_REGISTRY,
+    _is_json_type,
+    _is_text_type,
+)
+from operations_center.slice_replay.models import (
+    SliceReplayCheck,
+    SliceReplayProfile,
+    SliceReplayRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _summary() -> ArtifactIndexSummary:
+    return ArtifactIndexSummary(
+        total_artifacts=1,
+        by_kind={},
+        by_location={},
+        by_status={},
+        singleton_count=0,
+        partial_count=0,
+        excluded_path_count=0,
+        unresolved_path_count=0,
+        missing_file_count=0,
+        machine_readable_count=0,
+        warnings_count=0,
+        errors_count=0,
+        manifest_limitations=[],
+    )
+
+
+def _check(check_type: str = "x", **kw) -> SliceReplayCheck:
+    base = {
+        "check_type": check_type,
+        "description": "desc",
+        "fixture_artifact_ids": ["aid-1"],
+    }
+    base.update(kw)
+    return SliceReplayCheck(**base)
+
+
+def _artifact(**kw) -> FixtureArtifact:
+    base = {
+        "source_artifact_id": "src:aid",
+        "artifact_kind": "stage_report",
+        "source_stage": "TopicSelectionStage",
+        "location": "run_root",
+        "path_role": "primary",
+        "source_path": "run/topic.json",
+        "fixture_relative_path": "topic.json",
+        "content_type": "application/json",
+        "copied": True,
+    }
+    base.update(kw)
+    return FixtureArtifact(**base)
+
+
+def _pack(**kw) -> FixturePack:
+    base = {
+        "fixture_pack_id": "repo__run__profile__ts",
+        "source_repo_id": "repo",
+        "source_run_id": "run",
+        "source_audit_type": "audit_type_1",
+        "source_manifest_path": "/abs/manifest.json",
+        "source_index_summary": _summary(),
+        "harvest_profile": "full_manifest_snapshot",
+    }
+    base.update(kw)
+    return FixturePack(**base)
+
+
+def _request(**kw) -> SliceReplayRequest:
+    base = {
+        "fixture_pack_path": Path("/tmp/fp.json"),
+        "replay_profile": SliceReplayProfile.FIXTURE_INTEGRITY,
+    }
+    base.update(kw)
+    return SliceReplayRequest(**base)
+
+
+def _write_artifact(pack_dir: Path, rel: str, data: bytes) -> Path:
+    f = pack_dir / "artifacts" / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(data)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# helper predicates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ct,expected",
+    [
+        ("application/json", True),
+        ("application/x-ndjson", True),
+        ("application/json; charset=utf-8", True),
+        ("APPLICATION/JSON", True),
+        ("text/plain", False),
+        ("application/octet-stream", False),
+    ],
+)
+def test_is_json_type(ct, expected):
+    assert _is_json_type(ct) is expected
+
+
+@pytest.mark.parametrize(
+    "ct,expected",
+    [
+        ("application/json", True),
+        ("text/plain", True),
+        ("text/markdown", True),  # startswith text/
+        ("text/csv; charset=utf-8", True),
+        ("application/yaml", True),
+        ("application/octet-stream", False),
+        ("image/png", False),
+    ],
+)
+def test_is_text_type(ct, expected):
+    assert _is_text_type(ct) is expected
+
+
+# ---------------------------------------------------------------------------
+# check_fixture_pack_loads
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_pack_loads_passes(tmp_path):
+    res = checks.check_fixture_pack_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "passed"
+    assert res.check_id == _check().check_id or res.check_id  # has an id
+    assert res.fixture_artifact_ids == ["aid-1"]
+
+
+# ---------------------------------------------------------------------------
+# check_copied_file_exists
+# ---------------------------------------------------------------------------
+
+
+def test_copied_file_exists_no_artifact(tmp_path):
+    res = checks.check_copied_file_exists(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_copied_file_exists_metadata_only(tmp_path):
+    art = _artifact(copied=False, copy_error="missing file")
+    res = checks.check_copied_file_exists(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+    assert "metadata-only" in res.summary
+
+
+def test_copied_file_exists_empty_relative_path(tmp_path):
+    art = _artifact(copied=True, fixture_relative_path="")
+    res = checks.check_copied_file_exists(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+
+
+def test_copied_file_exists_present(tmp_path):
+    _write_artifact(tmp_path, "topic.json", b"{}")
+    res = checks.check_copied_file_exists(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "passed"
+
+
+def test_copied_file_exists_missing(tmp_path):
+    res = checks.check_copied_file_exists(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "failed"
+    assert "missing" in res.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# check_metadata_only_reason_present
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_only_reason_no_artifact(tmp_path):
+    res = checks.check_metadata_only_reason_present(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_metadata_only_reason_copied(tmp_path):
+    res = checks.check_metadata_only_reason_present(
+        _check(), _pack(), tmp_path, _artifact(copied=True), _request()
+    )
+    assert res.status == "skipped"
+
+
+def test_metadata_only_reason_has_copy_error(tmp_path):
+    art = _artifact(copied=False, copy_error="oversized")
+    res = checks.check_metadata_only_reason_present(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+    assert "oversized" in res.summary
+
+
+def test_metadata_only_reason_has_limitations(tmp_path):
+    art = _artifact(copied=False, copy_error="", limitations=["partial_run"])
+    res = checks.check_metadata_only_reason_present(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+    assert "limitations" in res.summary
+
+
+def test_metadata_only_reason_missing(tmp_path):
+    art = _artifact(copied=False, copy_error="", limitations=[])
+    res = checks.check_metadata_only_reason_present(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# check_source_manifest_loads
+# ---------------------------------------------------------------------------
+
+
+def test_source_manifest_not_found(tmp_path):
+    res = checks.check_source_manifest_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+    assert "not found" in res.summary
+
+
+def test_source_manifest_invalid_json(tmp_path):
+    (tmp_path / "source_manifest.json").write_text("not json", encoding="utf-8")
+    res = checks.check_source_manifest_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+    assert "not valid JSON" in res.summary
+
+
+def test_source_manifest_os_error(tmp_path, monkeypatch):
+    (tmp_path / "source_manifest.json").write_text("{}", encoding="utf-8")
+
+    def boom(self, *a, **k):
+        raise OSError("io fail")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    res = checks.check_source_manifest_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "error"
+    assert "io fail" in res.error
+
+
+def test_source_manifest_missing_fields(tmp_path):
+    (tmp_path / "source_manifest.json").write_text(json.dumps({"x": 1}), encoding="utf-8")
+    res = checks.check_source_manifest_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+    assert "missing expected fields" in res.summary
+
+
+def test_source_manifest_valid(tmp_path):
+    (tmp_path / "source_manifest.json").write_text(
+        json.dumps({"repo_id": "r", "artifacts": []}), encoding="utf-8"
+    )
+    res = checks.check_source_manifest_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "passed"
+
+
+# ---------------------------------------------------------------------------
+# check_source_index_summary_loads
+# ---------------------------------------------------------------------------
+
+
+def test_source_index_summary_not_found(tmp_path):
+    res = checks.check_source_index_summary_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+
+
+def test_source_index_summary_invalid_json(tmp_path):
+    (tmp_path / "source_index_summary.json").write_text("{bad", encoding="utf-8")
+    res = checks.check_source_index_summary_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+    assert "not valid JSON" in res.summary
+
+
+def test_source_index_summary_os_error(tmp_path, monkeypatch):
+    (tmp_path / "source_index_summary.json").write_text("{}", encoding="utf-8")
+
+    def boom(self, *a, **k):
+        raise OSError("io fail")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    res = checks.check_source_index_summary_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "error"
+
+
+def test_source_index_summary_missing_field(tmp_path):
+    (tmp_path / "source_index_summary.json").write_text(json.dumps({"x": 1}), encoding="utf-8")
+    res = checks.check_source_index_summary_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "failed"
+    assert "total_artifacts" in res.summary
+
+
+def test_source_index_summary_valid(tmp_path):
+    (tmp_path / "source_index_summary.json").write_text(
+        json.dumps({"total_artifacts": 5}), encoding="utf-8"
+    )
+    res = checks.check_source_index_summary_loads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "passed"
+    assert "total_artifacts=5" in res.summary
+
+
+# ---------------------------------------------------------------------------
+# check_json_artifact_reads
+# ---------------------------------------------------------------------------
+
+
+def test_json_artifact_no_artifact(tmp_path):
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_json_artifact_not_copied(tmp_path):
+    art = _artifact(copied=False, fixture_relative_path=None)
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+
+
+def test_json_artifact_not_json_type(tmp_path):
+    art = _artifact(content_type="text/plain")
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+    assert "Not a JSON" in res.summary
+
+
+def test_json_artifact_file_missing(tmp_path):
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "failed"
+
+
+def test_json_artifact_os_error(tmp_path, monkeypatch):
+    _write_artifact(tmp_path, "topic.json", b"{}")
+
+    def boom(self, *a, **k):
+        raise OSError("read fail")
+
+    monkeypatch.setattr(Path, "read_bytes", boom)
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "error"
+
+
+def test_json_artifact_invalid_json(tmp_path):
+    _write_artifact(tmp_path, "topic.json", b"not json")
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "failed"
+    assert "not valid JSON" in res.summary
+
+
+def test_json_artifact_valid(tmp_path):
+    _write_artifact(tmp_path, "topic.json", json.dumps({"a": 1}).encode())
+    res = checks.check_json_artifact_reads(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "passed"
+
+
+def test_json_artifact_truncation_branch(tmp_path):
+    # Valid JSON larger than the limit gets truncated -> becomes invalid JSON.
+    payload = json.dumps({"key": "x" * 100}).encode()
+    _write_artifact(tmp_path, "topic.json", payload)
+    res = checks.check_json_artifact_reads(
+        _check(), _pack(), tmp_path, _artifact(), _request(max_artifact_bytes=5)
+    )
+    assert res.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# check_text_artifact_reads
+# ---------------------------------------------------------------------------
+
+
+def test_text_artifact_no_artifact(tmp_path):
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_text_artifact_not_copied(tmp_path):
+    art = _artifact(copied=False, fixture_relative_path=None, content_type="text/plain")
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+
+
+def test_text_artifact_not_text_type(tmp_path):
+    art = _artifact(content_type="application/octet-stream")
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+    assert "Not a text" in res.summary
+
+
+def test_text_artifact_file_missing(tmp_path):
+    art = _artifact(content_type="text/plain")
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+
+
+def test_text_artifact_os_error(tmp_path, monkeypatch):
+    art = _artifact(content_type="text/plain")
+    _write_artifact(tmp_path, "topic.json", b"hello")
+
+    def boom(self, *a, **k):
+        raise OSError("read fail")
+
+    monkeypatch.setattr(Path, "read_bytes", boom)
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "error"
+
+
+def test_text_artifact_invalid_utf8(tmp_path):
+    art = _artifact(content_type="text/plain")
+    _write_artifact(tmp_path, "topic.json", b"\xff\xfe\xff")
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+    assert "UTF-8" in res.summary
+
+
+def test_text_artifact_valid(tmp_path):
+    art = _artifact(content_type="text/plain")
+    _write_artifact(tmp_path, "topic.json", b"hello world")
+    res = checks.check_text_artifact_reads(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+
+
+def test_text_artifact_truncation_valid(tmp_path):
+    # Truncating multibyte sequence still valid here because ASCII payload.
+    art = _artifact(content_type="text/plain")
+    _write_artifact(tmp_path, "topic.json", b"abcdefghij")
+    res = checks.check_text_artifact_reads(
+        _check(), _pack(), tmp_path, art, _request(max_artifact_bytes=3)
+    )
+    assert res.status == "passed"
+
+
+# ---------------------------------------------------------------------------
+# check_failure_limitation_present
+# ---------------------------------------------------------------------------
+
+
+def test_failure_limitation_artifact_has_failure_lims(tmp_path):
+    art = _artifact(limitations=["partial_run", "other"])
+    res = checks.check_failure_limitation_present(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+    assert "partial_run" in res.summary
+
+
+def test_failure_limitation_artifact_not_copied(tmp_path):
+    art = _artifact(copied=False, copy_error="missing", limitations=[])
+    res = checks.check_failure_limitation_present(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+    assert "not copied" in res.summary
+
+
+def test_failure_limitation_pack_level(tmp_path):
+    # Artifact copied with no failure lims -> falls through to pack-level.
+    art = _artifact(copied=True, limitations=[])
+    pack = _pack(limitations=["failed_run"])
+    res = checks.check_failure_limitation_present(_check(), pack, tmp_path, art, _request())
+    assert res.status == "passed"
+    assert "failed_run" in res.summary
+
+
+def test_failure_limitation_none(tmp_path):
+    art = _artifact(copied=True, limitations=[])
+    pack = _pack(limitations=[])
+    res = checks.check_failure_limitation_present(_check(), pack, tmp_path, art, _request())
+    assert res.status == "failed"
+
+
+def test_failure_limitation_no_artifact_pack_has(tmp_path):
+    pack = _pack(limitations=["missing_downstream_artifacts"])
+    res = checks.check_failure_limitation_present(_check(), pack, tmp_path, None, _request())
+    assert res.status == "passed"
+
+
+# ---------------------------------------------------------------------------
+# check_checksum_matches_if_available
+# ---------------------------------------------------------------------------
+
+
+def test_checksum_no_artifact(tmp_path):
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_checksum_not_copied(tmp_path):
+    art = _artifact(copied=False, fixture_relative_path=None)
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+
+
+def test_checksum_none_recorded(tmp_path):
+    art = _artifact(checksum=None)
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "skipped"
+    assert "No checksum" in res.summary
+
+
+def test_checksum_file_missing(tmp_path):
+    art = _artifact(checksum="sha256:deadbeef")
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+    assert "not found" in res.summary
+
+
+def test_checksum_os_error(tmp_path, monkeypatch):
+    data = b"payload"
+    _write_artifact(tmp_path, "topic.json", data)
+    art = _artifact(checksum="sha256:whatever")
+
+    def boom(self, *a, **k):
+        raise OSError("open fail")
+
+    monkeypatch.setattr(Path, "open", boom)
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "error"
+
+
+def test_checksum_match(tmp_path):
+    data = b"payload-bytes"
+    _write_artifact(tmp_path, "topic.json", data)
+    digest = f"sha256:{hashlib.sha256(data).hexdigest()}"
+    art = _artifact(checksum=digest)
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "passed"
+
+
+def test_checksum_mismatch(tmp_path):
+    _write_artifact(tmp_path, "topic.json", b"payload")
+    art = _artifact(checksum="sha256:0000")
+    res = checks.check_checksum_matches_if_available(_check(), _pack(), tmp_path, art, _request())
+    assert res.status == "failed"
+    assert "mismatch" in res.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# check_artifact_kind_matches
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_kind_no_artifact(tmp_path):
+    res = checks.check_artifact_kind_matches(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_artifact_kind_no_filter(tmp_path):
+    res = checks.check_artifact_kind_matches(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "skipped"
+
+
+def test_artifact_kind_match(tmp_path):
+    res = checks.check_artifact_kind_matches(
+        _check(), _pack(), tmp_path, _artifact(), _request(artifact_kind="stage_report")
+    )
+    assert res.status == "passed"
+
+
+def test_artifact_kind_mismatch(tmp_path):
+    res = checks.check_artifact_kind_matches(
+        _check(), _pack(), tmp_path, _artifact(), _request(artifact_kind="other")
+    )
+    assert res.status == "failed"
+    assert "mismatch" in res.summary
+
+
+# ---------------------------------------------------------------------------
+# check_source_stage_matches
+# ---------------------------------------------------------------------------
+
+
+def test_source_stage_no_artifact(tmp_path):
+    res = checks.check_source_stage_matches(_check(), _pack(), tmp_path, None, _request())
+    assert res.status == "skipped"
+
+
+def test_source_stage_no_filter(tmp_path):
+    res = checks.check_source_stage_matches(_check(), _pack(), tmp_path, _artifact(), _request())
+    assert res.status == "skipped"
+
+
+def test_source_stage_match(tmp_path):
+    res = checks.check_source_stage_matches(
+        _check(),
+        _pack(),
+        tmp_path,
+        _artifact(),
+        _request(source_stage="TopicSelectionStage"),
+    )
+    assert res.status == "passed"
+
+
+def test_source_stage_mismatch(tmp_path):
+    res = checks.check_source_stage_matches(
+        _check(), _pack(), tmp_path, _artifact(), _request(source_stage="OtherStage")
+    )
+    assert res.status == "failed"
+    assert "mismatch" in res.summary
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_maps_to_callables():
+    assert set(CHECK_REGISTRY) == {
+        "fixture_pack_loads",
+        "copied_file_exists",
+        "metadata_only_reason_present",
+        "source_manifest_loads",
+        "source_index_summary_loads",
+        "json_artifact_reads",
+        "text_artifact_reads",
+        "failure_limitation_present",
+        "checksum_matches_if_available",
+        "artifact_kind_matches",
+        "source_stage_matches",
+    }
+    for fn in CHECK_REGISTRY.values():
+        assert callable(fn)
+
+
+def test_registry_entries_point_to_module_functions():
+    assert CHECK_REGISTRY["fixture_pack_loads"] is checks.check_fixture_pack_loads
+    assert CHECK_REGISTRY["source_stage_matches"] is checks.check_source_stage_matches

--- a/tests/unit/spec_author/__init__.py
+++ b/tests/unit/spec_author/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/spec_author/test_campaign_builder_cov.py
+++ b/tests/unit/spec_author/test_campaign_builder_cov.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.spec_author.campaign_builder import (
+    CampaignBuilder,
+    ChildTaskSpec,
+)
+
+SPEC_HEADER = """---
+campaign_id: camp-123
+slug: my-feature
+phases:
+  - implement
+  - test
+  - improve
+repos:
+  - acme/repo
+area_keywords:
+  - api
+---
+"""
+
+
+def _spec(body: str = "", *, phases_block: str = SPEC_HEADER) -> str:
+    return phases_block + body
+
+
+def _make_client(ids):
+    """Return a client whose create_issue yields the given ids in order."""
+    client = MagicMock()
+    client.create_issue.side_effect = [{"id": i} for i in ids]
+    return client
+
+
+# --------------------------------------------------------------------------
+# _extract_goals
+# --------------------------------------------------------------------------
+
+
+def test_extract_goals_parses_numbered_list():
+    text = """## Goals
+1. First goal
+2. Second goal
+
+## Constraints
+none
+"""
+    goals = CampaignBuilder._extract_goals(text)
+    assert goals == ["First goal", "Second goal"]
+
+
+def test_extract_goals_stops_at_next_section():
+    text = """## Goals
+1. Only goal
+## Other
+2. Not a goal
+"""
+    goals = CampaignBuilder._extract_goals(text)
+    assert goals == ["Only goal"]
+
+
+def test_extract_goals_defaults_when_absent():
+    goals = CampaignBuilder._extract_goals("no goals here")
+    assert goals == ["Implement the spec as described"]
+
+
+def test_extract_goals_ignores_non_numbered_lines_in_section():
+    text = """## Goals
+some intro prose
+1. Real goal
+- bullet not matched
+"""
+    goals = CampaignBuilder._extract_goals(text)
+    assert goals == ["Real goal"]
+
+
+def test_extract_goals_case_insensitive_header():
+    text = """## GOALS
+1. Cased goal
+"""
+    assert CampaignBuilder._extract_goals(text) == ["Cased goal"]
+
+
+# --------------------------------------------------------------------------
+# _extract_section
+# --------------------------------------------------------------------------
+
+
+def test_extract_section_returns_body():
+    text = """## Constraints
+must be fast
+must be safe
+
+## Goals
+1. g
+"""
+    out = CampaignBuilder._extract_section(text, "Constraints")
+    assert out == "must be fast\nmust be safe"
+
+
+def test_extract_section_missing_returns_empty():
+    assert CampaignBuilder._extract_section("nothing", "Constraints") == ""
+
+
+def test_extract_section_case_insensitive():
+    text = """## constraints
+lower header
+"""
+    assert CampaignBuilder._extract_section(text, "Constraints") == "lower header"
+
+
+# --------------------------------------------------------------------------
+# _build_parent_body
+# --------------------------------------------------------------------------
+
+
+def test_build_parent_body_includes_fields_and_preview():
+    from operations_center.spec_author.models import SpecFrontMatter
+
+    fm = SpecFrontMatter(campaign_id="cid", slug="my-slug")
+    spec_text = "x" * 1000
+    body = CampaignBuilder._build_parent_body(fm, spec_text)
+    assert "campaign_id: cid" in body
+    assert "spec_file: docs/specs/my-slug.md" in body
+    assert "status: active" in body
+    # Preview truncated to 800 chars + "..."
+    assert body.count("x") == 800
+    assert body.rstrip().endswith("...")
+
+
+# --------------------------------------------------------------------------
+# _create_child_task
+# --------------------------------------------------------------------------
+
+
+def _fm(phases):
+    from operations_center.spec_author.models import SpecFrontMatter
+
+    return SpecFrontMatter(campaign_id="cid", slug="slug", phases=phases)
+
+
+def test_create_child_task_implement_phase():
+    client = _make_client(["t1"])
+    cb = CampaignBuilder(client, "proj")
+    spec = ChildTaskSpec(
+        title="T",
+        goal_text="  do thing  ",
+        constraints_text="  be careful  ",
+        phase="implement",
+        spec_coverage_hint="Goal 1",
+    )
+    task_id = cb._create_child_task(
+        fm=_fm(["implement"]),
+        repo_key="acme/repo",
+        base_branch="main",
+        spec=spec,
+    )
+    assert task_id == "t1"
+    _, kwargs = client.create_issue.call_args
+    assert kwargs["name"] == "T"
+    assert kwargs["state"] == "Ready for AI"
+    body = kwargs["description"]
+    assert "mode: goal" in body
+    assert "repo: acme/repo" in body
+    assert "base_branch: main" in body
+    assert "do thing" in body
+    assert "be careful" in body
+    assert "task_phase_note" not in body
+    assert "task-kind: goal" in kwargs["label_names"]
+    assert "campaign-id: cid" in kwargs["label_names"]
+
+
+def test_create_child_task_test_phase_note():
+    client = _make_client(["t2"])
+    cb = CampaignBuilder(client, "proj")
+    spec = ChildTaskSpec(
+        title="T",
+        goal_text="g",
+        constraints_text="c",
+        phase="test_campaign",
+        spec_coverage_hint="Goal 1",
+    )
+    cb._create_child_task(
+        fm=_fm(["test_campaign"]),
+        repo_key="r",
+        base_branch="main",
+        spec=spec,
+    )
+    _, kwargs = client.create_issue.call_args
+    assert kwargs["state"] == "Backlog"
+    assert "mode: test_campaign" in kwargs["description"]
+    assert "Promoted after implement task merges" in kwargs["description"]
+    assert "task-kind: test_campaign" in kwargs["label_names"]
+
+
+def test_create_child_task_improve_phase_note():
+    client = _make_client(["t3"])
+    cb = CampaignBuilder(client, "proj")
+    spec = ChildTaskSpec(
+        title="T",
+        goal_text="g",
+        constraints_text="c",
+        phase="improve_campaign",
+        spec_coverage_hint="Goal 1",
+    )
+    cb._create_child_task(
+        fm=_fm(["improve_campaign"]),
+        repo_key="r",
+        base_branch="main",
+        spec=spec,
+    )
+    _, kwargs = client.create_issue.call_args
+    assert kwargs["state"] == "Backlog"
+    assert "Promoted after test_campaign passes clean" in kwargs["description"]
+
+
+# --------------------------------------------------------------------------
+# build (integration of the above)
+# --------------------------------------------------------------------------
+
+
+def test_build_happy_path_creates_parent_and_children():
+    spec_text = _spec("""## Goals
+1. Build the API
+2. Add docs
+
+## Constraints
+keep it simple
+""")
+    # parent + 2 goals * 3 phases = 7 issues
+    client = _make_client([f"id{i}" for i in range(7)])
+    cb = CampaignBuilder(client, "proj", max_tasks=10)
+    ids = cb.build(spec_text, repo_key="acme/repo", base_branch="main")
+
+    assert len(ids) == 7
+    assert ids[0] == "id0"
+    # First call is the parent campaign issue.
+    first_call = client.create_issue.call_args_list[0]
+    assert first_call.kwargs["name"] == "[Campaign] my-feature"
+    assert "source: spec-campaign" in first_call.kwargs["label_names"]
+    assert "campaign-id: camp-123" in first_call.kwargs["label_names"]
+
+    # Child titles use phase prefixes (phases normalised: test->test_campaign etc.)
+    child_names = [c.kwargs["name"] for c in client.create_issue.call_args_list[1:]]
+    assert "[Impl] Build the API" in child_names
+    assert "[Test] Build the API" in child_names
+    assert "[Improve] Build the API" in child_names
+
+
+def test_build_respects_max_tasks_outer_break():
+    spec_text = _spec("""## Goals
+1. Goal one
+2. Goal two
+3. Goal three
+""")
+    # max_tasks=2 means after 2 children the outer loop breaks on next goal.
+    client = _make_client([f"id{i}" for i in range(10)])
+    cb = CampaignBuilder(client, "proj", max_tasks=2)
+    ids = cb.build(spec_text, repo_key="r", base_branch="main")
+    # parent + 2 children
+    assert len(ids) == 3
+
+
+def test_build_respects_max_tasks_inner_break():
+    # Single goal, 3 phases, max_tasks=2 -> inner loop break.
+    spec_text = _spec("""## Goals
+1. Solo goal
+""")
+    client = _make_client([f"id{i}" for i in range(10)])
+    cb = CampaignBuilder(client, "proj", max_tasks=2)
+    ids = cb.build(spec_text, repo_key="r", base_branch="main")
+    assert len(ids) == 3  # parent + 2 phase children
+
+
+def test_build_unknown_phase_uses_phase_as_prefix():
+    spec_text = """---
+campaign_id: c
+slug: s
+phases:
+  - weird
+---
+## Goals
+1. A goal
+"""
+    client = _make_client(["p", "c1"])
+    cb = CampaignBuilder(client, "proj")
+    cb.build(spec_text, repo_key="r", base_branch="main")
+    child = client.create_issue.call_args_list[1]
+    assert child.kwargs["name"] == "[weird] A goal"
+
+
+def test_build_defaults_goal_when_none_present():
+    spec_text = """---
+campaign_id: c
+slug: s
+phases:
+  - implement
+---
+## Constraints
+c
+"""
+    client = _make_client(["p", "c1"])
+    cb = CampaignBuilder(client, "proj")
+    cb.build(spec_text, repo_key="r", base_branch="main")
+    child = client.create_issue.call_args_list[1]
+    assert child.kwargs["name"] == "[Impl] Implement the spec as described"
+
+
+def test_build_truncates_long_goal_title():
+    long_goal = "G" * 100
+    spec_text = f"""---
+campaign_id: c
+slug: s
+phases:
+  - implement
+---
+## Goals
+1. {long_goal}
+"""
+    client = _make_client(["p", "c1"])
+    cb = CampaignBuilder(client, "proj")
+    cb.build(spec_text, repo_key="r", base_branch="main")
+    child = client.create_issue.call_args_list[1]
+    # Title is "[Impl] " + first 60 chars of goal.
+    assert child.kwargs["name"] == "[Impl] " + "G" * 60
+
+
+def test_build_raises_on_missing_front_matter():
+    client = MagicMock()
+    cb = CampaignBuilder(client, "proj")
+    with pytest.raises(ValueError):
+        cb.build("no front matter here", repo_key="r", base_branch="main")
+    client.create_issue.assert_not_called()
+
+
+def test_build_logs_limit_warning(caplog):
+    import logging
+
+    spec_text = _spec("""## Goals
+1. one
+2. two
+""")
+    client = _make_client([f"id{i}" for i in range(10)])
+    cb = CampaignBuilder(client, "proj", max_tasks=1)
+    with caplog.at_level(logging.WARNING):
+        cb.build(spec_text, repo_key="r", base_branch="main")
+    assert any("campaign_task_limit_reached" in r.message for r in caplog.records)
+
+
+def test_build_logs_created_info(caplog):
+    import logging
+
+    spec_text = _spec("""## Goals
+1. one
+""")
+    client = _make_client([f"id{i}" for i in range(10)])
+    cb = CampaignBuilder(client, "proj")
+    with caplog.at_level(logging.INFO):
+        cb.build(spec_text, repo_key="r", base_branch="main")
+    assert any("campaign_created" in r.message for r in caplog.records)

--- a/tests/unit/spec_author/test_phase_orchestrator_cov.py
+++ b/tests/unit/spec_author/test_phase_orchestrator_cov.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from operations_center.spec_author.models import ActiveCampaigns, CampaignRecord
+from operations_center.spec_author.phase_orchestrator import (
+    PendingPhaseAdvance,
+    PhaseOrchestrationResult,
+    PhaseOrchestrator,
+    _campaign_id_from_issue,
+    _labels,
+    _status,
+    _summarize_phase_tasks,
+    _task_kind,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_status_from_dict_state():
+    assert _status({"state": {"name": "Done"}}) == "done"
+
+
+def test_status_from_string_state():
+    assert _status({"state": "Backlog"}) == "backlog"
+
+
+def test_status_missing_state_is_empty():
+    assert _status({}) == ""
+
+
+def test_status_none_state_is_empty():
+    assert _status({"state": None}) == ""
+
+
+def test_status_dict_without_name():
+    assert _status({"state": {}}) == ""
+
+
+def test_labels_with_dicts_and_strings():
+    issue = {
+        "labels": [
+            {"name": "campaign-id:abc"},
+            "task-kind:test_campaign",
+            {"name": ""},  # falsy name skipped
+            {"nope": "x"},  # no name key skipped
+            "",  # falsy string skipped
+        ]
+    }
+    assert _labels(issue) == ["campaign-id:abc", "task-kind:test_campaign"]
+
+
+def test_labels_non_list_returns_empty():
+    assert _labels({"labels": "notalist"}) == []
+
+
+def test_labels_missing_returns_empty():
+    assert _labels({}) == []
+
+
+def test_campaign_id_from_issue_found():
+    issue = {"labels": ["campaign-id:  cmp-1  "]}
+    assert _campaign_id_from_issue(issue) == "cmp-1"
+
+
+def test_campaign_id_from_issue_case_insensitive():
+    issue = {"labels": ["Campaign-ID:cmp-2"]}
+    assert _campaign_id_from_issue(issue) == "cmp-2"
+
+
+def test_campaign_id_from_issue_none():
+    assert _campaign_id_from_issue({"labels": ["other"]}) is None
+
+
+def test_task_kind_found():
+    issue = {"labels": ["task-kind: Test_Campaign "]}
+    assert _task_kind(issue) == "test_campaign"
+
+
+def test_task_kind_defaults_to_goal():
+    assert _task_kind({"labels": ["random"]}) == "goal"
+
+
+def test_summarize_phase_tasks_orders_and_filters():
+    by_phase = {
+        "goal": [{"state": "Done", "name": "  G1  "}],
+        "test_campaign": [{"state": {"name": "Backlog"}, "name": "T1"}],
+        "improve_campaign": [{"name": "I1"}],
+        "parent": [{"name": "P1"}],  # ignored
+    }
+    out = _summarize_phase_tasks(by_phase)
+    assert out == [
+        ("goal", "done", "G1"),
+        ("test_campaign", "backlog", "T1"),
+        ("improve_campaign", "", "I1"),
+    ]
+
+
+def test_summarize_phase_tasks_missing_buckets():
+    assert _summarize_phase_tasks({}) == []
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_pending_phase_advance_defaults():
+    p = PendingPhaseAdvance(
+        campaign_id="c",
+        spec_slug="s",
+        spec_file_path="/p",
+        current_phase="goal",
+        next_phase="test",
+    )
+    assert p.task_summaries == []
+
+
+def test_result_defaults():
+    r = PhaseOrchestrationResult()
+    assert r.phases_advanced == 0
+    assert r.campaigns_completed == 0
+    assert r.pending_advances == []
+    assert r.errors == []
+    assert r.tasks_unblocked == 0
+    assert r.tasks_cancelled == 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers for orchestrator tests
+# ---------------------------------------------------------------------------
+
+
+def _make_campaign(campaign_id="cmp-1", slug="myslug", spec_file="", status="active"):
+    return CampaignRecord(
+        campaign_id=campaign_id,
+        slug=slug,
+        spec_file=spec_file,
+        status=status,
+        created_at="2026-01-01",
+    )
+
+
+def _make_state_manager(campaigns):
+    sm = MagicMock()
+    sm.load.return_value = ActiveCampaigns(campaigns=campaigns)
+    return sm
+
+
+def _issue(id_, name, status, *, campaign="cmp-1", kind=None):
+    labels = [f"campaign-id:{campaign}"] if campaign else []
+    if kind:
+        labels.append(f"task-kind:{kind}")
+    return {"id": id_, "name": name, "state": {"name": status}, "labels": labels}
+
+
+# ---------------------------------------------------------------------------
+# run() / detect_pending_advances
+# ---------------------------------------------------------------------------
+
+
+def test_run_no_active_campaigns(tmp_path):
+    sm = _make_state_manager([])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    result = orch.run([])
+    assert result.phases_advanced == 0
+    assert result.pending_advances == []
+    client.transition_issue.assert_not_called()
+
+
+def test_detect_pending_advances_delegates(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    # all goal tasks terminal -> a pending advance is emitted
+    issues = [_issue("1", "goal task", "Done", kind="goal")]
+    advances = orch.detect_pending_advances(issues)
+    assert len(advances) == 1
+    assert advances[0].next_phase == "test"
+
+
+def test_run_catches_orchestrate_exception(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    # Make _orchestrate blow up
+    orch._orchestrate = MagicMock(side_effect=RuntimeError("boom"))
+    result = orch.run([])
+    assert len(result.errors) == 1
+    assert "cmp-1" in result.errors[0]
+    assert "boom" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Phase advancement
+# ---------------------------------------------------------------------------
+
+
+def test_phase_advance_goal_terminal_promotes_backlog_test(tmp_path):
+    sm = _make_state_manager([_make_campaign(spec_file="/custom/spec.md")])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("g1", "goal", "Done", kind="goal"),
+        _issue("t1", "test", "Backlog", kind="test_campaign"),
+        _issue("t2", "test in progress", "In Progress", kind="test_campaign"),
+        # parent (campaign) issue
+        {
+            "id": "p1",
+            "name": "[Campaign] my campaign",
+            "state": {"name": "In Progress"},
+            "labels": ["campaign-id:cmp-1"],
+        },
+    ]
+    result = orch.run(issues)
+    # only the backlog test task promoted
+    client.transition_issue.assert_called_once_with("t1", "Ready for AI")
+    assert result.phases_advanced == 1
+    # parent commented because backlog_next non-empty
+    client.comment_issue.assert_any_call("p1", "Advancing to test phase: 1 tasks promoted.")
+    # pending advance emitted with custom spec file
+    assert len(result.pending_advances) == 1
+    pa = result.pending_advances[0]
+    assert pa.current_phase == "goal"
+    assert pa.next_phase == "test"
+    assert pa.spec_file_path == "/custom/spec.md"
+
+
+def test_phase_advance_no_backlog_no_promotion_but_pending_emitted(tmp_path):
+    sm = _make_state_manager([_make_campaign(spec_file="")])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("g1", "goal", "Cancelled", kind="goal"),
+        _issue("t1", "test running", "In Progress", kind="test_campaign"),
+    ]
+    result = orch.run(issues)
+    # no backlog test tasks -> no transition, no comment
+    client.transition_issue.assert_not_called()
+    client.comment_issue.assert_not_called()
+    assert result.phases_advanced == 0
+    # but a pending advance is still emitted; spec_file empty -> derived path
+    assert len(result.pending_advances) == 1
+    pa = result.pending_advances[0]
+    assert pa.spec_file_path == str(tmp_path / "myslug.md")
+
+
+def test_no_advance_when_current_phase_not_terminal(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("g1", "goal", "In Progress", kind="goal"),
+        _issue("t1", "test", "Backlog", kind="test_campaign"),
+    ]
+    result = orch.run(issues)
+    client.transition_issue.assert_not_called()
+    assert result.pending_advances == []
+    assert result.phases_advanced == 0
+
+
+def test_no_advance_when_current_phase_empty(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    # no goal tasks at all -> chain skips goal->test
+    issues = [_issue("t1", "test", "Backlog", kind="test_campaign")]
+    result = orch.run(issues)
+    assert result.pending_advances == []
+    client.transition_issue.assert_not_called()
+
+
+def test_test_to_improve_advance(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("t1", "test", "Done", kind="test_campaign"),
+        _issue("i1", "improve", "Backlog", kind="improve_campaign"),
+    ]
+    result = orch.run(issues)
+    client.transition_issue.assert_called_once_with("i1", "Ready for AI")
+    assert result.phases_advanced == 1
+    pa = result.pending_advances[0]
+    assert pa.current_phase == "test_campaign"
+    assert pa.next_phase == "improve"
+
+
+def test_issue_for_other_campaign_ignored(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("g1", "goal", "Done", kind="goal"),
+        _issue("x1", "other", "Backlog", campaign="other-cmp", kind="test_campaign"),
+    ]
+    result = orch.run(issues)
+    # the other-campaign test task is not in this campaign's buckets
+    client.transition_issue.assert_not_called()
+    # goal terminal still emits pending advance
+    assert len(result.pending_advances) == 1
+
+
+def test_unknown_kind_buckets_to_goal(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [_issue("g1", "weird", "Done", kind="totally_unknown")]
+    result = orch.run(issues)
+    # bucketed into goal; goal terminal -> pending advance for goal->test
+    assert len(result.pending_advances) == 1
+    assert result.pending_advances[0].current_phase == "goal"
+
+
+# ---------------------------------------------------------------------------
+# Campaign completion
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_completion_archives_and_marks_complete(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    parent = {
+        "id": "p1",
+        "name": "[Campaign] done campaign",
+        "state": {"name": "In Progress"},
+        "labels": ["campaign-id:cmp-1", {"name": "priority:high"}],
+    }
+    issues = [
+        _issue("g1", "g", "Done", kind="goal"),
+        _issue("t1", "t", "Cancelled", kind="test_campaign"),
+        _issue("i1", "i", "Done", kind="improve_campaign"),
+        parent,
+    ]
+    result = orch.run(issues)
+    assert result.campaigns_completed == 1
+    client.transition_issue.assert_any_call("p1", "Done")
+    client.comment_issue.assert_any_call("p1", "Campaign complete. 2 tasks done, 1 cancelled.")
+    client.update_issue_labels.assert_called_once_with(
+        "p1", ["campaign-id:cmp-1", "priority:high", "lifecycle: archived"]
+    )
+    sm.mark_complete.assert_called_once_with("cmp-1")
+
+
+def test_campaign_completion_skips_archive_if_already_archived(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    parent = {
+        "id": "p1",
+        "name": "[Campaign] x",
+        "state": {"name": "In Progress"},
+        "labels": ["campaign-id:cmp-1", "lifecycle: archived"],
+    }
+    issues = [_issue("g1", "g", "Done", kind="goal"), parent]
+    orch.run(issues)
+    client.update_issue_labels.assert_not_called()
+
+
+def test_campaign_completion_label_update_exception_logged(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    client.update_issue_labels.side_effect = RuntimeError("label fail")
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    parent = {
+        "id": "p1",
+        "name": "[Campaign] x",
+        "state": {"name": "In Progress"},
+        "labels": ["campaign-id:cmp-1"],
+    }
+    issues = [_issue("g1", "g", "Done", kind="goal"), parent]
+    result = orch.run(issues)
+    # exception in archive is swallowed; completion still proceeds
+    assert result.campaigns_completed == 1
+    sm.mark_complete.assert_called_once_with("cmp-1")
+
+
+def test_no_completion_when_tasks_not_all_terminal(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    issues = [
+        _issue("g1", "g", "Done", kind="goal"),
+        _issue("i1", "i", "In Progress", kind="improve_campaign"),
+    ]
+    result = orch.run(issues)
+    assert result.campaigns_completed == 0
+    sm.mark_complete.assert_not_called()
+
+
+def test_no_completion_when_no_tasks(tmp_path):
+    sm = _make_state_manager([_make_campaign()])
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, sm, tmp_path)
+    # only a parent, no child tasks
+    parent = {
+        "id": "p1",
+        "name": "[Campaign] empty",
+        "state": {"name": "In Progress"},
+        "labels": ["campaign-id:cmp-1"],
+    }
+    result = orch.run([parent])
+    assert result.campaigns_completed == 0
+    client.transition_issue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _all_terminal / _comment_parent
+# ---------------------------------------------------------------------------
+
+
+def test_all_terminal_true(tmp_path):
+    orch = PhaseOrchestrator(MagicMock(), _make_state_manager([]), tmp_path)
+    assert orch._all_terminal([{"state": "Done"}, {"state": "Cancelled"}]) is True
+
+
+def test_all_terminal_false_with_nonterminal(tmp_path):
+    orch = PhaseOrchestrator(MagicMock(), _make_state_manager([]), tmp_path)
+    assert orch._all_terminal([{"state": "Done"}, {"state": "Backlog"}]) is False
+
+
+def test_all_terminal_empty_false(tmp_path):
+    orch = PhaseOrchestrator(MagicMock(), _make_state_manager([]), tmp_path)
+    assert orch._all_terminal([]) is False
+
+
+def test_comment_parent_handles_exception(tmp_path):
+    client = MagicMock()
+    client.comment_issue.side_effect = RuntimeError("nope")
+    orch = PhaseOrchestrator(client, _make_state_manager([]), tmp_path)
+    # should not raise
+    orch._comment_parent([{"id": "p1"}], "hello")
+    client.comment_issue.assert_called_once_with("p1", "hello")
+
+
+def test_comment_parent_success(tmp_path):
+    client = MagicMock()
+    orch = PhaseOrchestrator(client, _make_state_manager([]), tmp_path)
+    orch._comment_parent([{"id": "p1"}, {"id": "p2"}], "msg")
+    assert client.comment_issue.call_count == 2
+
+
+def test_init_accepts_max_rewrite_attempts(tmp_path):
+    # back-compat kwarg retained; should be accepted without error
+    orch = PhaseOrchestrator(MagicMock(), _make_state_manager([]), tmp_path, max_rewrite_attempts=5)
+    assert isinstance(orch._specs_dir, Path)

--- a/tests/unit/spec_author/test_state_cov.py
+++ b/tests/unit/spec_author/test_state_cov.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from operations_center.spec_author.models import ActiveCampaigns, CampaignRecord
+from operations_center.spec_author.state import (
+    CampaignStateManager,
+    _DEFAULT_STATE_PATH,
+)
+
+
+def _record(campaign_id: str = "c1", status: str = "active") -> CampaignRecord:
+    return CampaignRecord(
+        campaign_id=campaign_id,
+        slug="my-slug",
+        spec_file="specs/foo.md",
+        status=status,
+        created_at="2026-01-01T00:00:00",
+    )
+
+
+def _state_path(tmp_path: Path) -> Path:
+    return tmp_path / "state" / "campaigns" / "active.json"
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_default_path_when_none() -> None:
+    mgr = CampaignStateManager()
+    assert mgr.state_path == _DEFAULT_STATE_PATH
+
+
+def test_init_uses_provided_path(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    assert mgr.state_path == p
+
+
+# ---------------------------------------------------------------------------
+# load
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_empty_when_missing(tmp_path: Path) -> None:
+    mgr = CampaignStateManager(state_path=_state_path(tmp_path))
+    state = mgr.load()
+    assert isinstance(state, ActiveCampaigns)
+    assert state.campaigns == []
+
+
+def test_load_parses_valid_file(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        ActiveCampaigns(campaigns=[_record()]).model_dump_json(),
+        encoding="utf-8",
+    )
+    mgr = CampaignStateManager(state_path=p)
+    state = mgr.load()
+    assert len(state.campaigns) == 1
+    assert state.campaigns[0].campaign_id == "c1"
+
+
+def test_load_corrupt_invalid_json_renames_and_returns_empty(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    p = _state_path(tmp_path)
+    p.parent.mkdir(parents=True)
+    p.write_text("{ not valid json", encoding="utf-8")
+    mgr = CampaignStateManager(state_path=p)
+
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        state = mgr.load()
+
+    assert state.campaigns == []
+    # original file got renamed away
+    assert not p.exists()
+    corrupt_files = list(p.parent.glob("active.json.corrupt.*"))
+    assert len(corrupt_files) == 1
+    assert "spec_campaign_state_corrupt" in caplog.text
+
+
+def test_load_corrupt_schema_mismatch(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    p.parent.mkdir(parents=True)
+    # valid json but campaigns is wrong type -> model_validate raises
+    p.write_text(json.dumps({"campaigns": "nope"}), encoding="utf-8")
+    mgr = CampaignStateManager(state_path=p)
+    state = mgr.load()
+    assert state.campaigns == []
+    assert not p.exists()
+
+
+def test_load_corrupt_rename_oserror_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = _state_path(tmp_path)
+    p.parent.mkdir(parents=True)
+    p.write_text("garbage", encoding="utf-8")
+    mgr = CampaignStateManager(state_path=p)
+
+    orig_rename = Path.rename
+
+    def boom(self: Path, target: object) -> None:  # noqa: ANN401
+        raise OSError("cannot rename")
+
+    monkeypatch.setattr(Path, "rename", boom)
+    state = mgr.load()
+    assert state.campaigns == []
+    # rename failed so original remains
+    monkeypatch.setattr(Path, "rename", orig_rename)
+    assert p.exists()
+
+
+# ---------------------------------------------------------------------------
+# save
+# ---------------------------------------------------------------------------
+
+
+def test_save_creates_parents_and_writes(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    state = ActiveCampaigns(campaigns=[_record()])
+    mgr.save(state)
+    assert p.exists()
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert data["campaigns"][0]["campaign_id"] == "c1"
+    # tmp file should have been renamed away
+    assert not p.with_suffix(".tmp").exists()
+
+
+def test_save_roundtrip_via_load(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.save(ActiveCampaigns(campaigns=[_record("x"), _record("y", "complete")]))
+    loaded = mgr.load()
+    assert [c.campaign_id for c in loaded.campaigns] == ["x", "y"]
+    assert loaded.campaigns[1].status == "complete"
+
+
+# ---------------------------------------------------------------------------
+# add_campaign
+# ---------------------------------------------------------------------------
+
+
+def test_add_campaign_appends(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.add_campaign(_record("a"))
+    mgr.add_campaign(_record("b"))
+    loaded = mgr.load()
+    assert [c.campaign_id for c in loaded.campaigns] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# mark_complete / mark_cancelled / _update_status
+# ---------------------------------------------------------------------------
+
+
+def test_mark_complete_updates_status(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.add_campaign(_record("a"))
+    mgr.mark_complete("a")
+    assert mgr.load().campaigns[0].status == "complete"
+
+
+def test_mark_cancelled_updates_status(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.add_campaign(_record("a"))
+    mgr.mark_cancelled("a")
+    assert mgr.load().campaigns[0].status == "cancelled"
+
+
+def test_update_status_updates_all_matching(tmp_path: Path) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.add_campaign(_record("dup"))
+    mgr.add_campaign(_record("dup"))
+    mgr.add_campaign(_record("other"))
+    mgr.mark_complete("dup")
+    loaded = mgr.load()
+    statuses = {c.campaign_id: c.status for c in loaded.campaigns}
+    assert statuses["dup"] == "complete"
+    assert statuses["other"] == "active"
+
+
+def test_update_status_no_match_does_not_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    mgr.add_campaign(_record("a"))
+
+    calls: list[object] = []
+    orig_save = mgr.save
+
+    def tracking_save(state: ActiveCampaigns) -> None:
+        calls.append(state)
+        orig_save(state)
+
+    monkeypatch.setattr(mgr, "save", tracking_save)
+    mgr.mark_complete("nonexistent")
+    assert calls == []
+    assert mgr.load().campaigns[0].status == "active"
+
+
+# ---------------------------------------------------------------------------
+# rebuild_from_specs
+# ---------------------------------------------------------------------------
+
+
+SPEC_ACTIVE = """---
+campaign_id: camp-1
+slug: active-one
+status: active
+created_at: 2026-01-02T00:00:00
+phases:
+  - test
+---
+body
+"""
+
+SPEC_COMPLETE = """---
+campaign_id: camp-2
+slug: done-one
+status: complete
+created_at: 2026-01-03T00:00:00
+---
+body
+"""
+
+SPEC_BAD = "no front matter here"
+
+
+def test_rebuild_from_specs_only_active(tmp_path: Path) -> None:
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    (specs / "01_active.md").write_text(SPEC_ACTIVE, encoding="utf-8")
+    (specs / "02_complete.md").write_text(SPEC_COMPLETE, encoding="utf-8")
+
+    p = _state_path(tmp_path)
+    mgr = CampaignStateManager(state_path=p)
+    result = mgr.rebuild_from_specs(specs)
+
+    assert [c.campaign_id for c in result.campaigns] == ["camp-1"]
+    rec = result.campaigns[0]
+    assert rec.slug == "active-one"
+    assert rec.status == "active"
+    assert rec.spec_file.endswith("01_active.md")
+    # rebuilt state was persisted
+    assert mgr.load().campaigns[0].campaign_id == "camp-1"
+
+
+def test_rebuild_from_specs_skips_unparseable(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    (specs / "01_active.md").write_text(SPEC_ACTIVE, encoding="utf-8")
+    (specs / "02_bad.md").write_text(SPEC_BAD, encoding="utf-8")
+
+    import logging
+
+    mgr = CampaignStateManager(state_path=_state_path(tmp_path))
+    with caplog.at_level(logging.WARNING):
+        result = mgr.rebuild_from_specs(specs)
+
+    assert [c.campaign_id for c in result.campaigns] == ["camp-1"]
+    assert "spec_rebuild_skip" in caplog.text
+
+
+def test_rebuild_from_specs_empty_dir(tmp_path: Path) -> None:
+    specs = tmp_path / "specs"
+    specs.mkdir()
+    mgr = CampaignStateManager(state_path=_state_path(tmp_path))
+    result = mgr.rebuild_from_specs(specs)
+    assert result.campaigns == []
+    # empty state still saved
+    assert mgr.load().campaigns == []

--- a/tests/unit/test_post_merge_regression_cov.py
+++ b/tests/unit/test_post_merge_regression_cov.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from operations_center.post_merge_regression import (
+    RegressionSignal,
+    _extract_evidence_file_tokens,
+    create_revert_branch,
+    detect_post_merge_regressions,
+)
+
+
+def _now_iso(delta_hours: float = 0.0) -> str:
+    return (datetime.now(UTC) + timedelta(hours=delta_hours)).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# detect_post_merge_regressions
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_no_head_sha_returns_empty():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = None
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+    gh.get_failed_checks.assert_not_called()
+
+
+def test_detect_failed_checks_fetch_raises_returns_empty():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "abc123"
+    gh.get_failed_checks.side_effect = RuntimeError("boom")
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+
+
+def test_detect_base_green_returns_empty():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "abc123"
+    gh.get_failed_checks.return_value = []
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+
+
+def test_detect_no_list_merged_attribute_attributes_head():
+    # spec= without list_recently_merged_prs -> getattr returns None
+    gh = MagicMock(spec=["get_branch_head", "get_failed_checks"])
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build", "lint"]
+    out = detect_post_merge_regressions(gh, "o", "r", base_branch="develop")
+    assert len(out) == 1
+    sig = out[0]
+    assert sig.pr_number is None
+    assert sig.merge_commit_sha == "headsha"
+    assert sig.head_sha == "headsha"
+    assert sig.failed_checks == ("build", "lint")
+    assert sig.base_branch == "develop"
+    assert sig.merged_at  # isoformat string present
+
+
+def test_detect_list_merged_not_callable_attributes_head():
+    gh = MagicMock(spec=["get_branch_head", "get_failed_checks"])
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    # Add a non-callable attribute named list_recently_merged_prs
+    gh.list_recently_merged_prs = "not-callable"
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert len(out) == 1
+    assert out[0].pr_number is None
+
+
+def test_detect_list_merged_raises_yields_no_signals():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.side_effect = RuntimeError("api down")
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+
+
+def test_detect_pr_within_lookback_attributed():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {
+            "number": 42,
+            "merged_at": _now_iso(-1),
+            "merge_commit_sha": "mergesha42",
+        }
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r", lookback_hours=24)
+    assert len(out) == 1
+    sig = out[0]
+    assert sig.pr_number == 42
+    assert sig.merge_commit_sha == "mergesha42"
+    assert sig.head_sha == "headsha"
+    assert sig.failed_checks == ("build",)
+
+
+def test_detect_pr_older_than_cutoff_skipped():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {"number": 1, "merged_at": _now_iso(-100), "merge_commit_sha": "old"}
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r", lookback_hours=24)
+    assert out == []
+
+
+def test_detect_pr_unparseable_date_skipped():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {"number": 1, "merged_at": "not-a-date", "merge_commit_sha": "x"},
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+
+
+def test_detect_pr_none_date_skipped():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {"number": 1, "merged_at": None, "updated_at": None, "merge_commit_sha": "x"},
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out == []
+
+
+def test_detect_uses_updated_at_fallback():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {"number": 7, "updated_at": _now_iso(-1), "merge_commit_sha": "s7"},
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert len(out) == 1
+    assert out[0].pr_number == 7
+
+
+def test_detect_z_suffix_date_and_missing_fields():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    # Zulu suffix, missing number -> pr_number None, missing merge_commit_sha -> ""
+    raw = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    gh.list_recently_merged_prs.return_value = [{"merged_at": raw}]
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert len(out) == 1
+    sig = out[0]
+    assert sig.pr_number is None  # int(0) or None -> None
+    assert sig.merge_commit_sha == ""
+
+
+def test_detect_number_zero_becomes_none():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = [
+        {"number": 0, "merged_at": _now_iso(-1), "merge_commit_sha": "s"},
+    ]
+    out = detect_post_merge_regressions(gh, "o", "r")
+    assert out[0].pr_number is None
+
+
+def test_detect_ignored_checks_passed_through():
+    gh = MagicMock()
+    gh.get_branch_head.return_value = "headsha"
+    gh.get_failed_checks.return_value = ["build"]
+    gh.list_recently_merged_prs.return_value = []
+    detect_post_merge_regressions(gh, "o", "r", ignored_checks=("flaky",))
+    _, kwargs = gh.get_failed_checks.call_args
+    assert kwargs["ignored_checks"] == ["flaky"]
+
+
+# --------------------------------------------------------------------------- #
+# create_revert_branch
+# --------------------------------------------------------------------------- #
+
+
+def test_create_revert_branch_success(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    branch = create_revert_branch(tmp_path, commit_sha="abcdef1234567890")
+    assert branch == "revert/abcdef12"
+    assert len(calls) == 3
+    assert calls[0][:2] == ["git", "fetch"]
+    assert calls[2][:2] == ["git", "revert"]
+
+
+def test_create_revert_branch_custom_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MagicMock(returncode=0))
+    branch = create_revert_branch(
+        tmp_path, commit_sha="deadbeef", base_branch="develop", branch_name="my-revert"
+    )
+    assert branch == "my-revert"
+
+
+def test_create_revert_branch_empty_sha_uses_unknown(tmp_path, monkeypatch):
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MagicMock(returncode=0))
+    branch = create_revert_branch(tmp_path, commit_sha="")
+    assert branch == "revert/unknown"
+
+
+def test_create_revert_branch_called_process_error_with_stderr(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr=b"conflict happened")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert create_revert_branch(tmp_path, commit_sha="abc12345") is None
+
+
+def test_create_revert_branch_called_process_error_no_stderr(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr=None)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert create_revert_branch(tmp_path, commit_sha="abc12345") is None
+
+
+def test_create_revert_branch_timeout(tmp_path, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 60)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert create_revert_branch(tmp_path, commit_sha="abc12345") is None
+
+
+# --------------------------------------------------------------------------- #
+# _extract_evidence_file_tokens
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_tokens_empty():
+    assert _extract_evidence_file_tokens("") == ()
+
+
+def test_extract_tokens_basic():
+    diff = "+++ b/src/a.py\n+++ b/src/b.py\n--- a/src/a.py\n"
+    assert _extract_evidence_file_tokens(diff) == ("src/a.py", "src/b.py")
+
+
+def test_extract_tokens_dedup_and_devnull():
+    diff = "+++ b/src/a.py\n+++ b/src/a.py\n+++ b//dev/null\n"
+    # /dev/null appears as "/dev/null" after stripping "+++ b/" -> "/dev/null"
+    assert _extract_evidence_file_tokens(diff) == ("src/a.py",)
+
+
+def test_extract_tokens_blank_path_skipped():
+    diff = "+++ b/\n+++ b/real.py\n"
+    assert _extract_evidence_file_tokens(diff) == ("real.py",)
+
+
+def test_extract_tokens_respects_max_files():
+    lines = "\n".join(f"+++ b/f{i}.py" for i in range(20))
+    out = _extract_evidence_file_tokens(lines, max_files=3)
+    assert out == ("f0.py", "f1.py", "f2.py")
+
+
+def test_extract_tokens_ignores_non_matching_lines():
+    diff = "diff --git a/x b/x\nindex 123..456\n@@ -1 +1 @@\n+content\n"
+    assert _extract_evidence_file_tokens(diff) == ()
+
+
+# --------------------------------------------------------------------------- #
+# RegressionSignal dataclass
+# --------------------------------------------------------------------------- #
+
+
+def test_regression_signal_frozen():
+    sig = RegressionSignal(
+        pr_number=1,
+        merge_commit_sha="s",
+        head_sha="h",
+        failed_checks=("c",),
+        merged_at="2026-01-01T00:00:00+00:00",
+        base_branch="main",
+    )
+    with pytest.raises(Exception):
+        sig.pr_number = 2  # type: ignore[misc]
+    assert sig.failed_checks == ("c",)

--- a/tests/unit/test_quality_alerts_cov.py
+++ b/tests/unit/test_quality_alerts_cov.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from operations_center import quality_alerts as qa
+
+
+# ── _comment_markdown ────────────────────────────────────────────────────────
+
+
+def test_comment_markdown_headline_only():
+    out = qa._comment_markdown(headline="  Hello  ")
+    assert out == "<!-- operations-center:bot -->\n\n**Hello**"
+
+
+def test_comment_markdown_with_bullets_filters_blank():
+    out = qa._comment_markdown(
+        headline="Title",
+        bullets=["one", "  ", "", "two"],
+    )
+    lines = out.split("\n")
+    assert "- one" in lines
+    assert "- two" in lines
+    # only two bullet lines (blank/whitespace dropped)
+    assert sum(1 for ln in lines if ln.startswith("- ")) == 2
+
+
+def test_comment_markdown_with_none_bullet_entry():
+    out = qa._comment_markdown(headline="T", bullets=[None, "kept"])  # type: ignore[list-item]
+    assert "- kept" in out
+    bullet_lines = [ln for ln in out.split("\n") if ln.startswith("- ")]
+    assert bullet_lines == ["- kept"]
+
+
+def test_comment_markdown_with_code_block():
+    out = qa._comment_markdown(headline="T", code_block="  print(1)  ")
+    assert "```\nprint(1)\n```" in out
+
+
+def test_comment_markdown_custom_marker():
+    out = qa._comment_markdown(headline="T", bot_marker="<!-- x -->")
+    assert out.startswith("<!-- x -->")
+
+
+def test_comment_markdown_empty_bullets_list_no_section():
+    out = qa._comment_markdown(headline="T", bullets=[])
+    assert out == "<!-- operations-center:bot -->\n\n**T**"
+
+
+# ── _extract_rejection_patterns ──────────────────────────────────────────────
+
+
+def test_extract_rejection_empty():
+    assert qa._extract_rejection_patterns([]) == []
+
+
+def test_extract_rejection_counts_and_orders():
+    records = [
+        {"reason": "Flaky Test"},
+        {"reason": "flaky test"},
+        {"reason": "style"},
+        {"reason": "STYLE"},
+        {"reason": "style"},
+    ]
+    out = qa._extract_rejection_patterns(records)
+    # "style" appears 3x, "flaky test" 2x -> style first
+    assert out[0] == "style"
+    assert "flaky test" in out
+
+
+def test_extract_rejection_skips_non_dict_and_blank():
+    records = ["bad", 5, {}, {"reason": ""}, {"reason": "  "}, {"reason": "real"}]
+    assert qa._extract_rejection_patterns(records) == ["real"]
+
+
+def test_extract_rejection_top5_cap():
+    records = [{"reason": f"r{i}"} for i in range(8)]
+    out = qa._extract_rejection_patterns(records)
+    assert len(out) == 5
+
+
+def test_extract_rejection_missing_reason_key():
+    assert qa._extract_rejection_patterns([{"other": "x"}]) == []
+
+
+# ── _load_rejection_patterns_for_proposal ────────────────────────────────────
+
+
+def _chdir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+
+def test_load_rejection_missing_catalog(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    assert qa._load_rejection_patterns_for_proposal() == []
+
+
+def test_load_rejection_unreadable_json(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text("{ not json", encoding="utf-8")
+    assert qa._load_rejection_patterns_for_proposal() == []
+
+
+def test_load_rejection_dict_with_records(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text(
+        json.dumps({"records": [{"reason": "x"}, {"reason": "x"}, {"reason": "y"}]}),
+        encoding="utf-8",
+    )
+    out = qa._load_rejection_patterns_for_proposal()
+    assert out[0] == "x"
+
+
+def test_load_rejection_bare_list(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text(json.dumps([{"reason": "z"}]), encoding="utf-8")
+    assert qa._load_rejection_patterns_for_proposal() == ["z"]
+
+
+def test_load_rejection_records_not_list(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text(json.dumps({"records": "nope"}), encoding="utf-8")
+    assert qa._load_rejection_patterns_for_proposal() == []
+
+
+def test_load_rejection_top_level_not_dict_or_list(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text(json.dumps("scalar"), encoding="utf-8")
+    assert qa._load_rejection_patterns_for_proposal() == []
+
+
+def test_load_rejection_filters_by_repo_key(monkeypatch, tmp_path):
+    _chdir(monkeypatch, tmp_path)
+    cat = tmp_path / "state" / "proposal_rejections.json"
+    cat.parent.mkdir(parents=True)
+    cat.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {"reason": "a", "repo_key": "r1"},
+                    {"reason": "b", "repo_key": "r2"},
+                    "junk",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = qa._load_rejection_patterns_for_proposal(repo_key="r1")
+    assert out == ["a"]
+
+
+# ── _escalate_to_human ────────────────────────────────────────────────────────
+
+
+def test_escalate_writes_jsonl(monkeypatch, tmp_path):
+    log = tmp_path / "state" / "escalations.jsonl"
+    monkeypatch.setattr(qa, "_ESCALATION_LOG", log)
+    ok = qa._escalate_to_human(task_id="T1", reason="bad", detail="d", severity="crit")
+    assert ok is True
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert rec["task_id"] == "T1"
+    assert rec["reason"] == "bad"
+    assert rec["detail"] == "d"
+    assert rec["severity"] == "crit"
+    assert "ts" in rec
+
+
+def test_escalate_appends_multiple(monkeypatch, tmp_path):
+    log = tmp_path / "state" / "escalations.jsonl"
+    monkeypatch.setattr(qa, "_ESCALATION_LOG", log)
+    qa._escalate_to_human(task_id="A", reason="r")
+    qa._escalate_to_human(task_id="B", reason="r")
+    lines = log.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+
+
+def test_escalate_truncates_detail(monkeypatch, tmp_path):
+    log = tmp_path / "state" / "escalations.jsonl"
+    monkeypatch.setattr(qa, "_ESCALATION_LOG", log)
+    qa._escalate_to_human(task_id="T", reason="r", detail="x" * 5000)
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert len(rec["detail"]) == 1000
+
+
+def test_escalate_defaults(monkeypatch, tmp_path):
+    log = tmp_path / "state" / "escalations.jsonl"
+    monkeypatch.setattr(qa, "_ESCALATION_LOG", log)
+    qa._escalate_to_human(task_id="T", reason="r")
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert rec["detail"] == ""
+    assert rec["severity"] == "warn"
+
+
+def test_escalate_write_failure_returns_false(monkeypatch, tmp_path):
+    log = tmp_path / "state" / "escalations.jsonl"
+    monkeypatch.setattr(qa, "_ESCALATION_LOG", log)
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    # mkdir succeeds, open raises OSError
+    monkeypatch.setattr(type(log), "open", boom)
+    assert qa._escalate_to_human(task_id="T", reason="r") is False
+
+
+# ── _process_self_review ──────────────────────────────────────────────────────
+
+
+def test_process_self_review_none():
+    res, summ = qa._process_self_review(None)
+    assert res == "CONCERNS"
+    assert summ == "(verdict missing or malformed)"
+
+
+def test_process_self_review_not_dict():
+    res, summ = qa._process_self_review("nope")  # type: ignore[arg-type]
+    assert res == "CONCERNS"
+
+
+def test_process_self_review_lgtm():
+    res, summ = qa._process_self_review({"result": " lgtm ", "summary": "ok"})
+    assert res == "LGTM"
+    assert summ == "ok"
+
+
+def test_process_self_review_concerns_explicit():
+    res, summ = qa._process_self_review({"result": "concerns", "summary": "issues"})
+    assert res == "CONCERNS"
+    assert summ == "issues"
+
+
+def test_process_self_review_unknown_result_fails_closed():
+    res, _ = qa._process_self_review({"result": "maybe", "summary": "x"})
+    assert res == "CONCERNS"
+
+
+def test_process_self_review_missing_summary():
+    res, summ = qa._process_self_review({"result": "LGTM"})
+    assert summ == "(no summary provided)"
+
+
+def test_process_self_review_truncates_summary():
+    res, summ = qa._process_self_review({"result": "LGTM", "summary": "y" * 500}, max_summary=400)
+    assert len(summ) == 400
+    assert summ.endswith("...")
+
+
+def test_process_self_review_non_string_fields():
+    res, summ = qa._process_self_review({"result": 123, "summary": 456})
+    assert res == "CONCERNS"
+    assert summ == "456"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/unit/tuning/test_models_and_loader.py
+++ b/tests/unit/tuning/test_models_and_loader.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for tuning/models.py and tuning/loader.py.
+
+Covers the TuningConfig.get_int override lookup, model defaults/round-trip,
+and TuningArtifactLoader.load_recent (ordering, limit, missing dir, skipping
+dirs without artifacts, and tolerating malformed JSON)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from operations_center.tuning.loader import TuningArtifactLoader
+from operations_center.tuning.models import (
+    FamilyMetrics,
+    TuningConfig,
+    TuningRunArtifact,
+)
+
+_NOW = datetime(2026, 6, 1, 12, tzinfo=UTC)
+
+
+# ── TuningConfig.get_int ──────────────────────────────────────────────────────
+
+
+def test_get_int_returns_override_when_int() -> None:
+    cfg = TuningConfig(updated_at=_NOW, overrides={"fam": {"min_runs": 1}})
+    assert cfg.get_int("fam", "min_runs", default=5) == 1
+
+
+def test_get_int_returns_default_when_family_absent() -> None:
+    cfg = TuningConfig(updated_at=_NOW, overrides={})
+    assert cfg.get_int("missing", "min_runs", default=5) == 5
+
+
+def test_get_int_returns_default_when_key_absent() -> None:
+    cfg = TuningConfig(updated_at=_NOW, overrides={"fam": {"other": 2}})
+    assert cfg.get_int("fam", "min_runs", default=7) == 7
+
+
+def test_get_int_returns_default_when_value_not_int() -> None:
+    # A non-int override (e.g. a float or string) must fall back to the default.
+    cfg = TuningConfig(updated_at=_NOW, overrides={"fam": {"min_runs": "nope"}})
+    assert cfg.get_int("fam", "min_runs", default=3) == 3
+    cfg2 = TuningConfig(updated_at=_NOW, overrides={"fam": {"min_runs": 1.5}})
+    assert cfg2.get_int("fam", "min_runs", default=3) == 3
+
+
+def test_config_version_defaults_to_1() -> None:
+    assert TuningConfig(updated_at=_NOW).version == 1
+
+
+# ── model defaults / round-trip ───────────────────────────────────────────────
+
+
+def test_family_metrics_defaults() -> None:
+    fm = FamilyMetrics(family="obs", sample_runs=4)
+    assert fm.candidates_emitted == 0
+    assert fm.suppression_rate == 0.0
+    assert fm.top_suppression_reasons == {}
+
+
+def test_run_artifact_round_trip() -> None:
+    art = TuningRunArtifact(
+        run_id="r1",
+        generated_at=_NOW,
+        source_command="tune",
+        window_runs=10,
+        family_metrics=[FamilyMetrics(family="obs", sample_runs=4)],
+    )
+    restored = TuningRunArtifact.model_validate(json.loads(art.model_dump_json()))
+    assert restored.run_id == "r1"
+    assert restored.dry_run is True
+    assert restored.family_metrics[0].family == "obs"
+
+
+# ── TuningArtifactLoader.load_recent ──────────────────────────────────────────
+
+
+def _write_run(root: Path, name: str, run_id: str) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    art = TuningRunArtifact(run_id=run_id, generated_at=_NOW, source_command="tune", window_runs=1)
+    (d / "tuning_run.json").write_text(art.model_dump_json(), encoding="utf-8")
+
+
+def test_load_recent_missing_root_returns_empty(tmp_path: Path) -> None:
+    loader = TuningArtifactLoader(tuning_root=tmp_path / "nope")
+    assert loader.load_recent() == []
+
+
+def test_load_recent_orders_newest_first_and_respects_limit(tmp_path: Path) -> None:
+    # Dir names sort descending → newest first; limit caps the count.
+    for name in ("2026-06-01", "2026-06-02", "2026-06-03"):
+        _write_run(tmp_path, name, run_id=name)
+    loader = TuningArtifactLoader(tuning_root=tmp_path)
+
+    recent = loader.load_recent(limit=2)
+    assert [a.run_id for a in recent] == ["2026-06-03", "2026-06-02"]
+
+
+def test_load_recent_skips_dirs_without_artifact(tmp_path: Path) -> None:
+    _write_run(tmp_path, "has-run", run_id="good")
+    (tmp_path / "empty-dir").mkdir()
+    loader = TuningArtifactLoader(tuning_root=tmp_path)
+    assert [a.run_id for a in loader.load_recent()] == ["good"]
+
+
+def test_load_recent_tolerates_malformed_json(tmp_path: Path) -> None:
+    _write_run(tmp_path, "good", run_id="good")
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "tuning_run.json").write_text("{not json", encoding="utf-8")
+    loader = TuningArtifactLoader(tuning_root=tmp_path)
+    # Malformed entry is skipped, valid one still returned.
+    assert [a.run_id for a in loader.load_recent()] == ["good"]


### PR DESCRIPTION
## Why
The #215 CI coverage gate (`pytest tests/unit -m "not slow" --cov=src --cov-fail-under=85`) had **never passed** — unit coverage was ~61.5%, so "Test (pytest)" was red on every PR. With the new CI-green merge precondition, that kept OC autonomy PRs escalated to needs-human (couldn't self-merge). Per the decision to **keep 85% and reach it with real tests**, this adds hermetic unit tests across the highest-gap modules until the gate genuinely passes.

## What
**~49 new `*_cov.py` test files (~2,300 tests)** covering the biggest coverage gaps: the `tuning/` package, `observer` (validation/metrics/exporters), `decision/service`, `policy/engine`, `run_memory/index`, `slice_replay/checks`, `worker_backend_selector`, `artifact_index`, `audit_governance/models`, `audit_dispatch/lock_store`, `execution` (usage_store, workspace, coordinator, campaign_store, ci_evaluator, ci_coordinator, validation), the `board_worker` entrypoints (outcomes, dispatch, spec_author, _text), the plane/git/github adapters, `proposer/*`, `spec_author/*`, `scheduled_tasks/runner`, maintenance (triage_scan, board_unblock, registry), `application/task_parser`, `quality_alerts`, `post_merge_regression`.

Also makes all `tests/unit/` subdirectories proper packages (adds missing `__init__.py`) so duplicate test-file basenames across packages no longer collide during collection.

All tests are hermetic (no network/CLI/git/HTTP — `tmp_path` + mocks). Authored and hygiene-cleaned (meaningful asserts, `_`-prefixed helpers, no ungated skips) via parallel agent workflows.

## Result
```
pytest tests/unit -m "not slow" --cov=src --cov-fail-under=85
→ 4561 passed, 3 skipped, coverage 86.9%
```
ruff clean; Custodian audit 0 findings. CI "Test (pytest)" goes green — restoring OC autonomy self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)