### PR TITLE
fix(reviewer): reapply OC-venv ruff fallback lost in coverage merge

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,14 @@
+## 2026-06-03 — Reapply OC-venv ruff fallback lost in PR #236 merge
+
+Root cause: PR #236 (coverage 95.75% → 90% gate) overwrote commit 554b55bd which
+added the three-tier ruff lookup (target venv → system PATH → OC root .venv/bin/ruff).
+Without it, _phase0_ci_fix falls back to bare "ruff" causing FileNotFoundError for
+repos without their own ruff binary (e.g. PlatformManifest). Re-applied on
+oc-watchdog/20260603-0647-reapply-ruff-fallback.
+
+Also this cycle: resolved PR #235 merge conflict + custodian T4/T8 violations
+(goal/ba5d9a46) to unblock OPEN_PR_GATE holding task #192.
+
 ## 2026-06-02 — Raise unit coverage past the 85% gate (operator-directed)
 
 **Status**: ✅ On `test/coverage-climb-1`. The #215 `--cov-fail-under=85` gate had

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -815,7 +815,12 @@ def _phase0_ci_fix(
     venv_bin = local_path / (getattr(repo_cfg, "venv_dir", ".venv") or ".venv") / "bin"
     ruff_bin = venv_bin / "ruff"
     if not ruff_bin.exists():
-        ruff_bin = Path(shutil.which("ruff") or "ruff")
+        system_ruff = shutil.which("ruff")
+        if system_ruff:
+            ruff_bin = Path(system_ruff)
+        else:
+            oc_ruff = oc_root / ".venv" / "bin" / "ruff"
+            ruff_bin = oc_ruff if oc_ruff.exists() else Path("ruff")
 
     git_env = dict(os.environ)
     git_token = settings.git_token()


### PR DESCRIPTION
## Summary
- PR #236 (coverage climb to 95.75%) merged from branch `test/coverage-climb-2` which overwrote commit `554b55bd` that added the OC-venv ruff fallback for repos without their own `.venv/bin/ruff`
- Without the fallback, `_phase0_ci_fix` resolves `ruff_bin` to bare `"ruff"`, causing `FileNotFoundError` when ruff is not on system PATH
- This PR re-applies the three-tier lookup: target venv → system PATH → OC root `.venv/bin/ruff` → bare `"ruff"`

## Test plan
- [x] All CI checks green on this branch (Lint, Test, Type check, Performance regression, Custodian doctor, License headers)
- [x] Golden invariant tests pass (15/15)
- [x] Ruff fallback confirmed present in `src/operations_center/entrypoints/pr_review_watcher/main.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)