### PR TITLE
refactor: generalize private-manifest instance refs to role phrasing

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -8,7 +8,6 @@ workspace_root="$(cd "$repo_root/.." && pwd)"
 if [ -z "${REPOGRAPH_BOUNDARY_ARTIFACT_FILE:-}" ]; then
     shopt -s nullglob
     for candidate in \
-        "$workspace_root"/PrivateManifest/dist/boundary_disclosure_artifact.json \
         "$workspace_root"/*/dist/boundary_disclosure_artifact.json \
         "$workspace_root"/*/policy/boundary_disclosure_artifact.json
     do
@@ -22,7 +21,7 @@ fi
 
 if [ -z "${REPOGRAPH_BOUNDARY_ARTIFACT_FILE:-}" ] || [ ! -f "$REPOGRAPH_BOUNDARY_ARTIFACT_FILE" ]; then
     echo "[custodian-pre-push] missing REPOGRAPH_BOUNDARY_ARTIFACT_FILE; failing closed"
-    echo "  Generate artifact from PrivateManifest first:"
+    echo "  Generate artifact from your private-manifest repo first:"
     echo "  python -m private_manifest.export_boundary_artifact --graph-root graph --out dist/boundary_disclosure_artifact.json"
     exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Do not edit `.console/.context` directly — it is regenerated at each launch.
 
 ## Cognition Lifecycle
 
-OC uses [ContextLifecycle](https://github.com/ProtocolWarden/ContextLifecycle) for bounded, resumable agent sessions. **Cognition is hosted by the anchoring manifest** — OC carries no `.context/` of its own. Per P3 of `PlatformDeployment/docs/architecture/adr/0002-work-order-manifest-cognition.md`, every Claude Code session targeting OC must first run `eval $(cl session start PlatformManifest)` (or `PrivateManifest` for private work). All capsules, checkpoints, and handoffs land under the anchor's `.context/sessions/<CL_SESSION_ID>/` subtree.
+OC uses [ContextLifecycle](https://github.com/ProtocolWarden/ContextLifecycle) for bounded, resumable agent sessions. **Cognition is hosted by the anchoring manifest** — OC carries no `.context/` of its own. Per P3 of `PlatformDeployment/docs/architecture/adr/0002-work-order-manifest-cognition.md`, every Claude Code session targeting OC must first run `eval $(cl session start PlatformManifest)` (or your private-manifest repo for private work). All capsules, checkpoints, and handoffs land under the anchor's `.context/sessions/<CL_SESSION_ID>/` subtree.
 
 | Surface                                | Purpose                                                              |
 |----------------------------------------|----------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Local planning, execution, policy, and evidence service for the coding platform.
 - CoreRunner — runtime mechanics (subprocess/manual/HTTP) live there
 - CxRP / RxP — canonical contracts live there; OC consumes them via `cxrp_mapper.py`
 - PlatformDeployment — service compose, Dockerfiles, lifecycle scripts live there
-- RepoGraph / PlatformManifest / PrivateManifest — canonical graph semantics and graph truth live there
+- RepoGraph / PlatformManifest / the private-manifest repo — canonical graph semantics and graph truth live there
 - A scheduler, queue system, or model host
 
 ## Primary Operator Model

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -184,7 +184,7 @@ report_root: tools/report/execution_plane
 # OC consumes a merged EffectiveRepoGraph from PlatformManifest's
 # `load_effective_graph(base, private, project/work_scope, local)`. The
 # platform base is always the bundled `platform_manifest.yaml` (public
-# topology). A PrivateManifest layer adds private platform truth; a
+# topology). A private-manifest layer adds private platform truth; a
 # project/work-scope layer adds project-scoped overlays; a local layer annotates existing nodes with allowlisted
 # fields (local_path, local_port, env_file, endpoint_override,
 # cache_path, gpu_required, runtime_hints).
@@ -197,10 +197,10 @@ report_root: tools/report/execution_plane
 # Defaults: enabled=true, all paths None → platform-only graph.
 # Set false to skip composition entirely.
 #
-# PrivateManifest discovery: when `private_manifest_path` is unset and
+# Private-manifest discovery: when `private_manifest_path` is unset and
 # `project_slug` is known, OC looks for
-# `/home/dev/Documents/GitHub/PrivateManifest/manifests/<project_slug>/private_manifest.yaml`
-# (or sibling `PrivateManifest/` from the provided repo_root).
+# `<private-manifest-repo>/manifests/<project_slug>/private_manifest.yaml`
+# (or a sibling private-manifest repo from the provided repo_root).
 #
 # v0.3+ supports ONE project manifest per OC instance — to switch projects,
 # update the paths or run OC from inside that project's repo (cwd
@@ -212,7 +212,7 @@ report_root: tools/report/execution_plane
 # platform_manifest:
 #   enabled: true
 #   project_slug: <managed-repo>              # for PlatformDeployment LocalManifest discovery
-#   private_manifest_path: /home/dev/Documents/GitHub/PrivateManifest/manifests/<project-slug>/private_manifest.yaml
+#   private_manifest_path: <private-manifest-repo>/manifests/<project-slug>/private_manifest.yaml
 #   project_manifest_path: /home/dev/Documents/GitHub/<managed-repo>/topology/project_manifest.yaml
 #   local_manifest_path:   /home/dev/Documents/GitHub/<managed-repo>/topology/local_manifest.yaml
 

--- a/docs/architecture/contracts/platform_manifest_consumption.md
+++ b/docs/architecture/contracts/platform_manifest_consumption.md
@@ -1,6 +1,6 @@
 # PlatformManifest Consumption
 
-OperationsCenter consumes RepoGraph-backed PlatformManifest and PrivateManifest
+OperationsCenter consumes RepoGraph-backed PlatformManifest and private-manifest
 data as topology and visibility metadata. It does not own canonical graph
 semantics, and it does not redefine public/private disclosure policy.
 
@@ -9,7 +9,7 @@ semantics, and it does not redefine public/private disclosure policy.
 ```text
 RepoGraph owns what exists and what may be disclosed.
 PlatformManifest publishes the public graph instance.
-PrivateManifest publishes the private graph instance and boundary artifact.
+The private-manifest repo publishes the private graph instance and boundary artifact.
 CxRP owns execution/routing contract semantics.
 RxP owns runtime invocation semantics.
 OperationsCenter owns governance and orchestration implementation.

--- a/scripts/reset-training-branches.sh
+++ b/scripts/reset-training-branches.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CONFIG="$REPO_ROOT/config/operations_center.local.yaml"
 TRAINING_BRANCH="operations-center-testing-branch"
-BOUNDARY_ARTIFACT="/home/dev/Documents/GitHub/PrivateManifest/dist/boundary_disclosure_artifact.json"
+BOUNDARY_ARTIFACT="${BOUNDARY_ARTIFACT:-<private-manifest-repo>/dist/boundary_disclosure_artifact.json}"
 DRY_RUN=0
 
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1


### PR DESCRIPTION
Part of the fleet-wide private-manifest role generalization
(PlatformManifest docs/architecture/private-manifest-role-generalization.md):
the pre-push hook drops its literal instance candidate path (the generic
dist/policy globs resolve the same boundary artifact — verified), and any
doc/config prose naming the repo instance now names the role.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
