### PR TITLE
fix(ci): green main — register reconcile_enforce key + drop unused import

### DIFF
--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -682,6 +682,7 @@ audit:
     - known_values
     - oc1_exempt
     - oc7_exempt
+    - reconcile_enforce
 
   # Additional well-known string values for OC9 to recognise without
   # requiring a string-literal anchor in src/.

--- a/tests/test_check_signal_collector.py
+++ b/tests/test_check_signal_collector.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from operations_center.observer.collectors.check_signal import CheckSignalCollector
 from operations_center.observer.service import ObserverContext


### PR DESCRIPTION
Two pre-existing CI failures on main:

- Custodian doctor (--strict): the audit key `reconcile_enforce`
  (added in #238) was never registered in `plugin_audit_keys`, so
  doctor flagged it as an "unknown audit key (typo?)" and --strict
  turned the warning into a non-zero exit. It is a legitimate
  OC plugin config flag — add it to plugin_audit_keys (matching the
  existing oc1_exempt/oc7_exempt/known_values registrations).

- Lint (ruff): `unittest.mock.call` was imported but unused in
  tests/test_check_signal_collector.py (F401). Removed via
  `ruff check --fix`; `call` is not referenced elsewhere in the file.

Verified locally with the repo's .venv:
  ruff check .                       -> All checks passed!
  custodian-doctor --strict --repo . -> OK
  pytest tests/test_check_signal_collector.py -> 16 passed

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
