### PR TITLE
fix(loop): reselect across full backend priority after a global limit

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-06-07 — Loop controller: global-limit fallback reselects across full backend priority
+
+**Decision**: After a backend limit, `_fallback_backend_after_limit()` re-runs
+`_select_backend()` over the full priority list instead of checking only the
+immediate alternate.
+
+Root cause: a global Claude limit cools both `claude` and `opus`, but the old
+fallback checked only `_alternate_backend("claude")` → `opus` → cooled → slept
+until Claude reset instead of falling through to `codex`. Observed live
+2026-06-07 15:56Z: controller logged "using codex" then slept 125m with codex
+cooldown null. Regression test covers global-limit → codex selection.
+
+Branch: `fix/controller-global-limit-fallback` (fix authored by Codex session,
+verified + landed via worktree off main; live checkout on goal/3476567d untouched)
+
+---
+
 ## 2026-06-07 — Watchdog: Fix custodian-audit CI failure (R1 detector ID collision)
 
 **Decision**: Set `audit.r1_enabled: false` in `.custodian/config.yaml`.

--- a/tests/test_loop_controller.py
+++ b/tests/test_loop_controller.py
@@ -369,6 +369,32 @@ def test_handle_backend_limit_global_claude_limit_cools_opus_too(
     assert cooldowns["opus"] == reset
 
 
+def test_global_claude_limit_fallback_selects_codex(monkeypatch, tmp_path: Path) -> None:
+    frozen_now = datetime(2026, 5, 25, 15, 0, tzinfo=timezone.utc)
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is None:
+                return frozen_now.replace(tzinfo=None)
+            return frozen_now.astimezone(tz)
+
+    monkeypatch.setattr(controller, "datetime", FrozenDateTime)
+    monkeypatch.setattr(controller, "_log", lambda *a, **k: None)
+    monkeypatch.setattr(
+        controller,
+        "_command_available",
+        lambda command: command in {"claude", "codex"},
+    )
+
+    log_path = tmp_path / "session.log"
+    log_path.write_text("You've reached your 5-hour session limit; resets 5:15pm (UTC)\n")
+    cooldowns: dict = {"claude": None, "opus": None, "codex": None}
+
+    assert controller._handle_backend_limit("claude", log_path, cooldowns) is True
+    assert controller._fallback_backend_after_limit(cooldowns) == "codex"
+
+
 def test_classify_limit_kind_model_weekly_for_sonnet() -> None:
     kind, model = controller._classify_limit_kind(
         "claude", "You've hit your Sonnet limit · resets Jun 3, 9am (America/New_York)"

--- a/tools/loop/controller.py
+++ b/tools/loop/controller.py
@@ -425,6 +425,16 @@ def _alternate_backend(backend: str) -> str:
         return _BACKEND_PRIORITY[0]
 
 
+def _fallback_backend_after_limit(cooldowns: dict[str, datetime | None]) -> str | None:
+    """Return the next runnable backend after applying new cooldown state.
+
+    This intentionally re-runs the full selector instead of only checking the
+    immediate alternate. A global Claude limit cools both sonnet and opus, so
+    the next valid backend is codex.
+    """
+    return _select_backend(cooldowns)
+
+
 def handle_signal(signum, frame) -> None:
     global _stop
     _stop = True
@@ -956,16 +966,16 @@ def main() -> None:
             if rc != 0:
                 if _handle_backend_limit(backend, session_log, cooldowns, cooldown_meta):
                     write_runtime_state(cooldowns, None, limit_meta=cooldown_meta)
-                    alternate = _alternate_backend(backend)
-                    if _backend_available(alternate, cooldowns):
+                    fallback = _fallback_backend_after_limit(cooldowns)
+                    if fallback is not None:
                         _log(
                             f"{backend.capitalize()} is cooling down; "
-                            f"running immediate {alternate.capitalize()} fallback."
+                            f"running immediate {fallback.capitalize()} fallback."
                         )
-                        write_runtime_state(cooldowns, alternate, limit_meta=cooldown_meta)
-                        rc, session_log = run_session(iteration, alternate, anchor_vars)
-                        backend = alternate
-                        _log(f"{alternate.capitalize()} fallback session exited rc={rc}")
+                        write_runtime_state(cooldowns, fallback, limit_meta=cooldown_meta)
+                        rc, session_log = run_session(iteration, fallback, anchor_vars)
+                        backend = fallback
+                        _log(f"{fallback.capitalize()} fallback session exited rc={rc}")
                         if _stop or STOP_FLAG.exists():
                             break
                         if rc != 0 and _handle_backend_limit(


### PR DESCRIPTION
## Problem

A global Claude limit (5h session / account cap) cools both `claude` and `opus`, but the post-limit fallback path only checked the immediate alternate backend (`opus`). Seeing it cooled, the controller slept until Claude reset instead of falling through to `codex` — observed live 2026-06-07T15:56Z: log said "using codex", then slept 125m with codex cooldown null.

## Fix

After applying cooldown state, re-run the full backend selector (`claude → opus → codex`) via `_fallback_backend_after_limit()` instead of checking only `_alternate_backend()`. Regression test covers the global-limit → codex path.

## Verification

- `pytest -q tests/test_loop_controller.py` → 24 passed
- `ruff check` clean

Fix authored in a Codex session; verified and landed via worktree off main (live checkout on `goal/3476567d` untouched). Running controller needs a restart to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)