### PR TITLE
fix(reviewer): prioritize merge-ready PRs over slow fix loops

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-06-07 — Reviewer proactivity: prioritize merge-ready PRs over slow fix loops
+
+**Decision**: the pr_review_watcher sweep now builds its worklist and sorts by
+_review_priority before processing — quick-merge candidates (fresh self_review,
+CI-green) run before PRs sunk into multi-pass fix battles. Previously PRs were
+processed in GitHub discovery order (descending number), so a slow PR could
+starve a merge-ready one each cycle, or drop it entirely on a mid-sweep restart.
+
+Live trigger: #247 (green, mergeable) was starved behind #250 (resurrected #235,
+in a legitimate multi-pass fix loop over a spec-overdelivery CONCERNS). Tiers:
+0 fresh self_review, 1 ci_fix, 2 self_review-in-fix-loop; within tier by
+fix_attempts then PR number. 4 new tests. Part of WO-6 (proactivity).
+
+---
+
 ## 2026-06-07 — Reviewer hardening: refuse to review against an unclean OC source tree
 
 **Decision**: the pr_review_watcher planning subprocess now pre-flights the OC

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.console/log.md merge=union

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1333,6 +1333,29 @@ def _write_heartbeat(status_dir: Path) -> None:
 # ── Poll cycle ────────────────────────────────────────────────────────────────
 
 
+def _review_priority(state: dict) -> tuple[int, int, int]:
+    """Sort key for the per-repo review worklist — lower sorts (and runs) first.
+
+    Proactive ordering: a PR that may reach a terminal decision on this pass —
+    a fresh self-review that could merge — must not be starved behind a PR
+    already sunk into a multi-pass fix battle (each fix pass is a slow LLM run).
+    Tiers:
+      0  self_review, no fix attempts yet  — the quick-merge candidates
+      1  ci_fix                            — bounded automated CI repair
+      2  self_review already iterating     — slow fix loops, run last
+    Within a tier: fewer consumed fix passes first, then PR number for a
+    stable, deterministic order."""
+    phase = state.get("phase", "ci_fix")
+    fix_attempts = int(state.get("fix_attempts", 0))
+    if phase == "self_review" and fix_attempts == 0:
+        tier = 0
+    elif phase == "ci_fix":
+        tier = 1
+    else:
+        tier = 2
+    return (tier, fix_attempts, int(state.get("pr_number", 0)))
+
+
 def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
     gh_client = _github_client(settings)
 
@@ -1355,6 +1378,11 @@ def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
             logger.warning("pr_review_watcher: failed to list PRs %s/%s — %s", owner, repo, exc)
             continue
 
+        # Build the worklist (discover + load state) before processing, so the
+        # sweep can be ordered. A single slow PR (a multi-pass fix battle) must
+        # not push a merge-ready PR to the back of the sweep — or off it entirely
+        # if the watcher restarts mid-cycle.
+        worklist: list[tuple[dict, dict, Path]] = []
         for pr_data in open_prs:
             if pr_data.get("draft"):
                 continue
@@ -1371,7 +1399,12 @@ def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
             state = _load_state(sp)
             if not state:
                 continue
+            worklist.append((pr_data, state, sp))
 
+        # Proactive ordering: quick-merge candidates before slow fix loops.
+        worklist.sort(key=lambda item: _review_priority(item[1]))
+
+        for pr_data, state, sp in worklist:
             phase = state.get("phase", "ci_fix")
 
             # human_review is removed — any state files left over from the old

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -787,3 +787,37 @@ def test_unclean_tree_escalates_with_specific_reason_after_budget(tmp_path: Path
     esc.assert_called_once()
     assert esc.call_args.kwargs.get("reason") == "oc_source_tree_unclean"
     assert state["no_verdict_passes"] == 0
+
+
+# ── proactive review-queue ordering (2026-06-07 starvation fix) ───────────────
+
+
+def test_review_priority_tiers() -> None:
+    # Fresh self_review (tier 0) < ci_fix (tier 1) < self_review-in-fix-loop (tier 2)
+    fresh = {"phase": "self_review", "fix_attempts": 0, "pr_number": 100}
+    ci = {"phase": "ci_fix", "fix_attempts": 0, "pr_number": 100}
+    battling = {"phase": "self_review", "fix_attempts": 3, "pr_number": 100}
+    assert watcher._review_priority(fresh) < watcher._review_priority(ci)
+    assert watcher._review_priority(ci) < watcher._review_priority(battling)
+
+
+def test_review_priority_merge_ready_beats_higher_numbered_fix_battle() -> None:
+    # The live case: #247 (green, fresh self_review) must sort before #250
+    # (self_review sunk into a fix loop) even though 250 > 247.
+    pr247 = {"phase": "self_review", "fix_attempts": 0, "pr_number": 247}
+    pr250 = {"phase": "self_review", "fix_attempts": 2, "pr_number": 250}
+    assert watcher._review_priority(pr247) < watcher._review_priority(pr250)
+
+
+def test_review_priority_within_tier_orders_by_attempts_then_number() -> None:
+    a = {"phase": "self_review", "fix_attempts": 1, "pr_number": 300}
+    b = {"phase": "self_review", "fix_attempts": 2, "pr_number": 200}
+    c = {"phase": "self_review", "fix_attempts": 1, "pr_number": 400}
+    ordered = sorted([b, c, a], key=watcher._review_priority)
+    assert ordered == [a, c, b]  # fix_attempts asc, then pr_number asc
+
+
+def test_review_priority_defaults_safe_on_empty_state() -> None:
+    # Missing keys must not crash; defaults to ci_fix tier.
+    key = watcher._review_priority({})
+    assert key == (1, 0, 0)


### PR DESCRIPTION
## Problem (observed live)

The review sweep processed open PRs in GitHub discovery order (descending PR number) and ran each to completion before the next. Each fix pass is a slow multi-stage LLM run, so a PR sunk into a fix battle starved merge-ready PRs behind it every cycle — and dropped them entirely if the watcher restarted mid-sweep.

Live case this session: **#247** (green, mergeable) sat behind **#250** (resurrected #235, legitimately iterating on a spec-overdelivery CONCERNS) — so the quick win waited on the slow battle.

## Fix

Build the per-repo worklist first, then sort by `_review_priority` before processing:

| Tier | State | Rationale |
|------|-------|-----------|
| 0 | `self_review`, `fix_attempts==0` | quick-merge candidates — may merge this pass |
| 1 | `ci_fix` | bounded automated CI repair |
| 2 | `self_review` with fix attempts | slow fix loops — run last |

Within a tier: fewer fix attempts first, then PR number (stable, deterministic). A quick LGTM-merge now runs before minutes are sunk into a slow PR.

Pure ordering change — no behavioral change to any individual PR's processing. Part of WO-6 (reviewer proactivity).

## Verification
- `pytest tests/test_pr_review_watcher.py` → 46 passed (4 new)
- ruff + ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)