### PR TITLE
feat(reviewer): auto-rebase CONFLICTING PRs (lazy, CI-backstopped)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-06-08 — Reviewer auto-rebase (WO-6): LAZY, CI-backstopped, adversarially designed
+
+**Decision**: when an LGTM PR is CONFLICTING, the reviewer now auto-rebases the
+base into the PR branch (in the repo's persistent clone, never oc_root) and
+pushes — instead of parking. Design settled by 3 adversarial critics:
+
+- **LAZY, not eager**: fires only in _merge_and_done when verdict is already
+  LGTM + mergeable=False — never per-poll on every conflicting PR (which storms
+  CI / thrashes priority / starves the queue when main moves).
+- **CI is the backstop**: after a clean rebase, DON'T merge that cycle — push
+  the merge commit, let CI re-run + next review re-validate. Catches the
+  textually-clean-but-wrong merge (broken import, budget overflow like the live
+  #249 C29, silent hunk loss) the bot's ephemeral clone won't catch locally.
+- **Never force-push**: merge commit only (branch moves forward); rejected push
+  → reset, retry. Real (non-log) conflict → escalate rebase_conflict, never auto-resolved.
+- **rebase_attempts orthogonal to fix_attempts** (never closes a good PR);
+  bounded (3) → escalate; 120s grace so a fast-moving base can't thrash.
+- log.md union via .git/info/attributes (works even when the PR branch predates
+  the committed .gitattributes). 11 new tests incl. real-git union + conflict.
+
+Closes the last autonomous-landing gap: the loop can now clear CONFLICTING PRs
+itself (the treadmill that made me hand-merge #247/#249 today).
+
+---
+
 ## 2026-06-07 — PR #249 CI fixes (orphan-recovery branch)
 
 **Decision**: cleared the 6 ruff + 2 ty failures blocking #249 (the recovered

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -362,6 +362,93 @@ def _run_pipeline(
 # ── Merge + Plane done ────────────────────────────────────────────────────────
 
 
+# How many auto-rebase attempts before a CONFLICTING PR is escalated for a human.
+# Orthogonal to fix_attempts — a rebase is infrastructure work, not a fix, and must
+# never consume the fix budget (that would wrongly close a good PR).
+_MAX_REBASE_ATTEMPTS = 3
+# Grace window after a rebase push: main moves constantly, so re-rebasing within
+# this window would thrash (rebase → push → main moves → rebase …). Defer instead.
+_REBASE_GRACE_SECONDS = 120
+
+
+def _attempt_auto_rebase(repo_cfg, head_ref: str, settings, pr_number: int) -> str:
+    """Merge the base branch into a CONFLICTING PR's branch and push, in the
+    repo's persistent clone (never oc_root).
+
+    Returns one of:
+      "clean"         — base merged with no real conflict; merge commit pushed.
+      "conflict"      — real (non-log) conflict remained; merge aborted, nothing pushed.
+      "push_rejected" — push lost a race (branch moved); reset, nothing landed.
+      "noop"          — branch already current with base; nothing to do.
+      "unavailable"   — no local clone / token configured; cannot rebase here.
+      "error"         — anything else; defensive, never raises.
+
+    Safety: only ever creates a *merge commit* (branch moves forward only — no
+    force-push, no history rewrite). `.console/log.md` auto-resolves via a
+    union driver injected through .git/info/attributes (works even when the PR
+    branch predates the committed .gitattributes). A textually-clean-but-wrong
+    merge is NOT trusted here — the caller does not merge the result this cycle;
+    CI re-runs on the pushed commit and the next review re-validates it."""
+    local_path = getattr(repo_cfg, "local_path", None) if repo_cfg else None
+    if not local_path or not Path(local_path).exists():
+        return "unavailable"
+    local_path = Path(local_path)
+    default_branch = getattr(repo_cfg, "default_branch", "main") or "main"
+
+    git_env = dict(os.environ)
+    git_token = settings.git_token()
+    author_name = getattr(settings.git, "author_name", "Operations Center Bot")
+    author_email = getattr(settings.git, "author_email", "operations-center-bot@example.com")
+    git_env["GIT_AUTHOR_NAME"] = author_name
+    git_env["GIT_AUTHOR_EMAIL"] = author_email
+    git_env["GIT_COMMITTER_NAME"] = author_name
+    git_env["GIT_COMMITTER_EMAIL"] = author_email
+    if git_token:
+        git_env["GH_TOKEN"] = git_token
+
+    def _git(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args], cwd=local_path, env=git_env, capture_output=True, text=True
+        )
+
+    try:
+        # Inject the union driver for the append-only journal so concurrent log
+        # entries auto-keep-both instead of conflicting. .git/info/attributes is
+        # local and always applied — no dependency on the branch's committed copy.
+        info_dir = local_path / ".git" / "info"
+        info_dir.mkdir(parents=True, exist_ok=True)
+        (info_dir / "attributes").write_text(".console/log.md merge=union\n", encoding="utf-8")
+
+        _git("stash", "--include-untracked")
+        _git("fetch", "origin", head_ref, default_branch)
+        if _git("checkout", "-B", head_ref, f"origin/{head_ref}").returncode != 0:
+            return "error"
+
+        merge = _git("merge", "--no-edit", f"origin/{default_branch}")
+        if merge.returncode == 0:
+            if "Already up to date" in (merge.stdout or ""):
+                return "noop"
+            # Merged cleanly per git — but a real (non-log) conflict path would
+            # have left the merge unfinished; double-check there are none.
+            if _git("diff", "--diff-filter=U", "--name-only").stdout.strip():
+                _git("merge", "--abort")
+                return "conflict"
+            push = _git("push", "origin", f"HEAD:{head_ref}")
+            if push.returncode == 0:
+                return "clean"
+            _git("reset", "--hard", f"origin/{head_ref}")
+            return "push_rejected"
+
+        # Non-zero merge: conflicts. If every unmerged path is the log (union
+        # should have handled it but be defensive), there are none here → real
+        # conflict. Abort; never force a resolution.
+        _git("merge", "--abort")
+        return "conflict"
+    except Exception as exc:  # noqa: BLE001 — rebase must never crash the watcher
+        logger.warning("pr_review_watcher: auto-rebase PR #%d errored — %s", pr_number, exc)
+        return "error"
+
+
 def _merge_and_done(
     state: dict,
     state_path: Path,
@@ -374,17 +461,15 @@ def _merge_and_done(
     reason: str,
 ) -> None:
     pr_number = state["pr_number"]
-    # Guard: skip merge when GitHub reports a conflict — avoids 405 spam every cycle.
     # get_mergeable() returns None while GitHub is still computing; treat that as
     # "unknown, try anyway" so we don't hold up clean PRs during GitHub's lazy eval.
+    # False means a real conflict with the base — LAZY auto-rebase fires here, and
+    # ONLY here (verdict is already LGTM): never eagerly per-poll, which would storm
+    # every conflicting PR each time main moves.
     if gh_client.get_mergeable(owner, repo, pr_number) is False:
-        logger.warning(
-            "pr_review_watcher: PR #%d has merge conflicts — skipping merge (reason=%s); "
-            "branch must be rebased before auto-merge will proceed",
-            pr_number,
-            reason,
-        )
+        _auto_rebase_or_escalate(state, state_path, gh_client, owner, repo, settings, reason)
         return
+    state["rebase_attempts"] = 0  # mergeable — clear any rebase bookkeeping
     try:
         gh_client.merge_pr(owner, repo, pr_number, merge_method="squash")
         logger.info(
@@ -412,6 +497,99 @@ def _merge_and_done(
             )
 
     state_path.unlink(missing_ok=True)
+
+
+def _auto_rebase_or_escalate(
+    state: dict,
+    state_path: Path,
+    gh_client,
+    owner: str,
+    repo: str,
+    settings,
+    reason: str,
+) -> None:
+    """LGTM PR is CONFLICTING — try one bounded, grace-gated auto-rebase.
+
+    On a clean rebase we push the merge commit and STOP for this cycle: CI
+    re-runs on the merged tree and the next review re-validates it before any
+    merge to main. This is the backstop for a textually-clean-but-semantically
+    -wrong merge (broken import, budget overflow, silent hunk loss) that the
+    bot's ephemeral clone would not catch via local pre-push hooks. A real
+    conflict escalates for a human; we never force a resolution."""
+    pr_number = state["pr_number"]
+    state.setdefault("rebase_attempts", 0)
+
+    # Grace: main moves constantly; re-rebasing within the window thrashes.
+    last = state.get("last_rebase_at")
+    if last:
+        try:
+            elapsed = (datetime.now(UTC) - datetime.fromisoformat(last)).total_seconds()
+            if elapsed < _REBASE_GRACE_SECONDS:
+                logger.info(
+                    "pr_review_watcher: PR #%d CONFLICTING but rebased %ds ago — "
+                    "deferring (main may be moving)",
+                    pr_number,
+                    int(elapsed),
+                )
+                return
+        except ValueError:
+            pass
+
+    if state["rebase_attempts"] >= _MAX_REBASE_ATTEMPTS:
+        _escalate_needs_human(
+            state, state_path, gh_client, owner, repo, settings,
+            reason="rebase_attempts_exhausted",
+            detail=(
+                f"PR is CONFLICTING and {_MAX_REBASE_ATTEMPTS} auto-rebase attempts did "
+                "not yield a mergeable branch (base may be moving faster than CI/review, "
+                "or the conflict recurs). Needs a manual rebase."
+            ),
+        )
+        return
+
+    head_ref = (state.get("head_ref") or "").strip()
+    if not head_ref:
+        logger.warning(
+            "pr_review_watcher: PR #%d CONFLICTING but no head_ref recorded — cannot rebase",
+            pr_number,
+        )
+        return
+
+    repo_cfg = settings.repos.get(state["repo_key"])
+    outcome = _attempt_auto_rebase(repo_cfg, head_ref, settings, pr_number)
+    # last_rebase_at gates the grace window on every *attempt* (success or not),
+    # so a fast-moving base cannot trigger back-to-back rebases.
+    state["last_rebase_at"] = datetime.now(UTC).isoformat()
+
+    if outcome == "clean":
+        state["rebase_attempts"] += 1
+        logger.info(
+            "pr_review_watcher: PR #%d auto-rebased onto base (attempt %d/%d) — pushed; "
+            "CI will re-run and review re-validates next cycle before merge",
+            pr_number,
+            state["rebase_attempts"],
+            _MAX_REBASE_ATTEMPTS,
+        )
+        _save_state(state_path, state)
+    elif outcome == "conflict":
+        _escalate_needs_human(
+            state, state_path, gh_client, owner, repo, settings,
+            reason="rebase_conflict",
+            detail=(
+                "Auto-rebase onto the base branch hit a real code conflict "
+                "(beyond the union-merged journal). Manual rebase required."
+            ),
+        )
+    else:
+        # noop / push_rejected / unavailable / error — log and retry next cycle
+        # (grace window throttles). Not charged against rebase_attempts: no merge
+        # commit landed, so it is not a consumed attempt.
+        logger.info(
+            "pr_review_watcher: PR #%d auto-rebase outcome=%s — will retry next cycle",
+            pr_number,
+            outcome,
+        )
+        _save_state(state_path, state)
 
 
 # ── Fix pass + close/re-queue ─────────────────────────────────────────────────
@@ -1429,6 +1607,11 @@ def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
             state = _load_state(sp)
             if not state:
                 continue
+            # Record the live head ref each poll (it changes across pushes) so the
+            # auto-rebase path knows which branch to merge the base into.
+            head_ref = (pr_data.get("head") or {}).get("ref")
+            if head_ref:
+                state["head_ref"] = head_ref
             worklist.append((pr_data, state, sp))
 
         # Proactive ordering: quick-merge candidates before slow fix loops.

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -864,3 +864,196 @@ def test_review_priority_defaults_safe_on_empty_state() -> None:
     # Missing keys must not crash; defaults to ci_fix tier.
     key = watcher._review_priority({})
     assert key == (1, 0, 0)
+
+
+# ── auto-rebase: real-git conflict classification (2026-06-08 WO-6) ────────────
+
+
+def _make_repo_with_pr_branch(tmp_path: Path):
+    """Build origin + a clone with a PR branch behind main. Returns (clone, repo_cfg)."""
+    import subprocess as sp
+
+    origin = tmp_path / "origin.git"
+    sp.run(["git", "init", "--bare", "-q", str(origin)], check=True)
+    seed = tmp_path / "seed"
+    sp.run(["git", "clone", "-q", str(origin), str(seed)], check=True)
+    sp.run(["git", "-C", str(seed), "config", "user.email", "t@t"], check=True)
+    sp.run(["git", "-C", str(seed), "config", "user.name", "t"], check=True)
+    (seed / "app.py").write_text("VALUE = 1\n")
+    (seed / ".console").mkdir()
+    (seed / ".console" / "log.md").write_text("## base\n")
+    sp.run(["git", "-C", str(seed), "add", "-A"], check=True)
+    sp.run(["git", "-C", str(seed), "commit", "-qm", "base"], check=True)
+    sp.run(["git", "-C", str(seed), "branch", "-M", "main"], check=True)
+    sp.run(["git", "-C", str(seed), "push", "-q", "origin", "main"], check=True)
+    # PR branch off this base
+    sp.run(["git", "-C", str(seed), "checkout", "-qb", "pr"], check=True)
+    (seed / "feature.py").write_text("FEATURE = True\n")
+    (seed / ".console" / "log.md").write_text("## pr entry\n## base\n")
+    sp.run(["git", "-C", str(seed), "add", "-A"], check=True)
+    sp.run(["git", "-C", str(seed), "commit", "-qm", "pr work"], check=True)
+    sp.run(["git", "-C", str(seed), "push", "-q", "origin", "pr"], check=True)
+    # main moves forward (sibling merge) — appends to log.md (the conflict magnet)
+    sp.run(["git", "-C", str(seed), "checkout", "-q", "main"], check=True)
+    (seed / ".console" / "log.md").write_text("## main entry\n## base\n")
+    sp.run(["git", "-C", str(seed), "add", "-A"], check=True)
+    sp.run(["git", "-C", str(seed), "commit", "-qm", "main moves"], check=True)
+    sp.run(["git", "-C", str(seed), "push", "-q", "origin", "main"], check=True)
+
+    clone = tmp_path / "clone"
+    sp.run(["git", "clone", "-q", str(origin), str(clone)], check=True)
+    sp.run(["git", "-C", str(clone), "config", "user.email", "t@t"], check=True)
+    sp.run(["git", "-C", str(clone), "config", "user.name", "t"], check=True)
+    repo_cfg = MagicMock(local_path=str(clone), default_branch="main")
+    return clone, repo_cfg, origin
+
+
+def _rebase_settings():
+    s = MagicMock()
+    s.git_token.return_value = ""
+    s.git = MagicMock(author_name="t", author_email="t@t")
+    return s
+
+
+def test_auto_rebase_clean_resolves_log_via_union_and_pushes(tmp_path: Path) -> None:
+    import subprocess as sp
+
+    clone, repo_cfg, origin = _make_repo_with_pr_branch(tmp_path)
+    # log.md conflicts (both edited line 1) but union must auto-resolve → clean.
+    outcome = watcher._attempt_auto_rebase(repo_cfg, "pr", _rebase_settings(), 1)
+    assert outcome == "clean"
+    # origin/pr now contains main's commit (merged) and both log entries survive.
+    merged_log = sp.run(
+        ["git", "-C", str(clone), "show", "origin/pr:.console/log.md"],
+        capture_output=True, text=True,
+    ).stdout
+    assert "main entry" in merged_log and "pr entry" in merged_log
+
+
+def test_auto_rebase_real_code_conflict_aborts(tmp_path: Path) -> None:
+    import subprocess as sp
+
+    clone, repo_cfg, origin = _make_repo_with_pr_branch(tmp_path)
+    # Introduce a REAL conflict: main and pr both change app.py's VALUE line.
+    work = tmp_path / "work"
+    sp.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+    sp.run(["git", "-C", str(work), "config", "user.email", "t@t"], check=True)
+    sp.run(["git", "-C", str(work), "config", "user.name", "t"], check=True)
+    sp.run(["git", "-C", str(work), "checkout", "-q", "pr"], check=True)
+    (work / "app.py").write_text("VALUE = 999\n")
+    sp.run(["git", "-C", str(work), "commit", "-qam", "pr edits app"], check=True)
+    sp.run(["git", "-C", str(work), "push", "-q", "origin", "pr"], check=True)
+    sp.run(["git", "-C", str(work), "checkout", "-q", "main"], check=True)
+    (work / "app.py").write_text("VALUE = 2\n")
+    sp.run(["git", "-C", str(work), "commit", "-qam", "main edits app"], check=True)
+    sp.run(["git", "-C", str(work), "push", "-q", "origin", "main"], check=True)
+
+    outcome = watcher._attempt_auto_rebase(repo_cfg, "pr", _rebase_settings(), 1)
+    assert outcome == "conflict"
+    # The conflicting merge must NOT have been pushed — origin/pr is unchanged.
+    head = sp.run(
+        ["git", "-C", str(clone), "ls-remote", str(origin), "refs/heads/pr"],
+        capture_output=True, text=True,
+    ).stdout
+    assert head.strip()  # branch still exists, not corrupted
+
+
+def test_auto_rebase_unavailable_without_clone() -> None:
+    repo_cfg = MagicMock(local_path=None, default_branch="main")
+    assert watcher._attempt_auto_rebase(repo_cfg, "pr", _rebase_settings(), 1) == "unavailable"
+
+
+# ── auto-rebase orchestration: grace, bounding, budget orthogonality ──────────
+
+
+def _conflicting_gh() -> MagicMock:
+    gh = _make_gh()
+    gh.get_mergeable.return_value = False  # CONFLICTING
+    return gh
+
+
+def test_merge_and_done_conflicting_triggers_lazy_rebase(tmp_path: Path) -> None:
+    state, sp_ = _make_state(tmp_path, phase="self_review", head_ref="pr", fix_attempts=2)
+    gh = _conflicting_gh()
+    with (
+        patch.object(watcher, "_attempt_auto_rebase", return_value="clean") as reb,
+        patch.object(watcher, "_escalate_needs_human") as esc,
+    ):
+        watcher._merge_and_done(
+            state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+        )
+    reb.assert_called_once()
+    gh.merge_pr.assert_not_called()  # do NOT merge the freshly-rebased tree this cycle
+    esc.assert_not_called()
+    loaded = watcher._load_state(sp_)
+    assert loaded["rebase_attempts"] == 1
+    assert loaded["fix_attempts"] == 2  # rebase MUST NOT touch the fix budget
+    assert loaded.get("last_rebase_at")
+
+
+def test_rebase_real_conflict_escalates(tmp_path: Path) -> None:
+    state, sp_ = _make_state(tmp_path, phase="self_review", head_ref="pr")
+    gh = _conflicting_gh()
+    with (
+        patch.object(watcher, "_attempt_auto_rebase", return_value="conflict"),
+        patch.object(watcher, "_escalate_needs_human") as esc,
+    ):
+        watcher._merge_and_done(
+            state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+        )
+    esc.assert_called_once()
+    assert esc.call_args.kwargs.get("reason") == "rebase_conflict"
+
+
+def test_rebase_grace_window_defers(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    recent = datetime.now(UTC).isoformat()
+    state, sp_ = _make_state(
+        tmp_path, phase="self_review", head_ref="pr", last_rebase_at=recent, rebase_attempts=1
+    )
+    gh = _conflicting_gh()
+    with patch.object(watcher, "_attempt_auto_rebase") as reb:
+        watcher._merge_and_done(
+            state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+        )
+    reb.assert_not_called()  # within grace window → no rebase, just defer
+
+
+def test_rebase_attempts_exhausted_escalates(tmp_path: Path) -> None:
+    state, sp_ = _make_state(
+        tmp_path, phase="self_review", head_ref="pr", rebase_attempts=watcher._MAX_REBASE_ATTEMPTS
+    )
+    gh = _conflicting_gh()
+    with (
+        patch.object(watcher, "_attempt_auto_rebase") as reb,
+        patch.object(watcher, "_escalate_needs_human") as esc,
+    ):
+        watcher._merge_and_done(
+            state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+        )
+    reb.assert_not_called()
+    esc.assert_called_once()
+    assert esc.call_args.kwargs.get("reason") == "rebase_attempts_exhausted"
+
+
+def test_rebase_transient_outcome_not_charged(tmp_path: Path) -> None:
+    # push_rejected/noop/error: no merge commit landed → must NOT consume an attempt.
+    state, sp_ = _make_state(tmp_path, phase="self_review", head_ref="pr", rebase_attempts=0)
+    gh = _conflicting_gh()
+    with patch.object(watcher, "_attempt_auto_rebase", return_value="push_rejected"):
+        watcher._merge_and_done(
+            state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+        )
+    assert watcher._load_state(sp_)["rebase_attempts"] == 0
+
+
+def test_mergeable_clears_rebase_attempts(tmp_path: Path) -> None:
+    state, sp_ = _make_state(tmp_path, phase="self_review", head_ref="pr", rebase_attempts=2)
+    gh = _make_gh()
+    gh.get_mergeable.return_value = True  # now mergeable
+    watcher._merge_and_done(
+        state, sp_, _pr_data(), gh, "owner", "repo", SETTINGS, reason="self_review_lgtm"
+    )
+    gh.merge_pr.assert_called_once()
+    assert not sp_.exists()  # merged, state cleaned


### PR DESCRIPTION
## What & why

Closes the last gap blocking **autonomous landing**: when an LGTM PR is CONFLICTING, the reviewer previously just parked ("branch must be rebased") forever. Today that forced me to hand-merge #247 and #249 — every sibling merge re-conflicts open PRs on `.console/log.md` (the treadmill). Now the reviewer merges the base into the PR branch itself and pushes.

## Design — settled by 3 adversarial critics

I had three independent critics attack the design (concurrency races, silent-wrong-merges, loop liveness). They converged on:

- **LAZY, not eager.** Rebase fires *only* in `_merge_and_done` when the verdict is already LGTM and `mergeable==False` — never per-poll on every conflicting PR. Eager rebase storms CI (N PRs × main-moves), thrashes `_review_priority`, and starves the queue.
- **CI is the backstop for clean-but-wrong merges.** After a clean rebase we push the merge commit and **stop for the cycle** — CI re-runs and the next review re-validates before any merge to main. This catches the textually-clean-but-semantically-wrong merge (broken import, budget overflow — exactly the live #249 C29 I hit, silent hunk loss) that `diff --filter=U` can't see and the bot's ephemeral clone won't catch via local pre-push hooks.
- **Never force-push** — merge commit only (branch moves forward); a rejected push resets and retries next cycle.
- **Real (non-log) conflict → escalate** `rebase_conflict`, never auto-resolved.
- **`rebase_attempts` orthogonal to `fix_attempts`** — a rebase is infra, not a fix; it must never consume the fix budget and wrongly close a good PR. Bounded at 3 → escalate; 120s grace window so a fast-moving base can't thrash.
- `.console/log.md` auto-resolves via a union driver injected through `.git/info/attributes` (works even when the PR branch predates the committed `.gitattributes`).

## Verification

- 57 tests pass (11 new), including **real-git** tests: union auto-resolves the log.md conflict (both entries survive) while a real `app.py` conflict aborts cleanly with nothing pushed; plus orchestration (grace, bounding, escalation routing, budget orthogonality).
- ruff + ty + custodian clean.

The actual clone/merge/push against live GitHub is the one part not exercisable offline — the running loop will validate it on the next real CONFLICTING PR. Logic is defensive (never raises, never force-pushes, never merges an unvalidated tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)