### PR TITLE
fix(review-watcher): clear escalation deadlock when escalated_head_sha is null

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,11 @@
+## 2026-06-08 — fix(review-watcher): clear escalation deadlock when escalated_head_sha is null
+
+`_phase1` null SHA deadlock: when `escalated_needs_human: true` AND `escalated_head_sha: null`,
+the three-way `and` condition always evaluated falsy → PR permanently skipped. New branch: if
+`escalated_head_sha` is null, clear escalation and retry instead of skipping. Test added:
+`test_phase1_resumes_escalated_pr_with_null_sha`. Separate root cause from the `--output-format
+json` fix (which prevented verdict.json from being written to disk).
+
 ## 2026-06-08 — fix(review-watcher): bypass TeamExecutor for self-review (_run_direct_review)
 
 Root cause of persistent no_verdict for PR #253 (10+ consecutive failures): _run_pipeline

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1341,7 +1341,17 @@ def _phase1(
     # new push changes the PR head SHA.
     if state.get("escalated_needs_human"):
         escalated_head_sha = str(state.get("escalated_head_sha") or "").strip()
-        if current_head_sha and escalated_head_sha and current_head_sha != escalated_head_sha:
+        if not escalated_head_sha:
+            # Escalated with no recorded SHA (e.g. state was reset after a
+            # rebase or manual clear). Can't compare — clear and retry.
+            state["escalated_needs_human"] = False
+            state["no_verdict_passes"] = 0
+            logger.info(
+                "pr_review_watcher: PR #%d escalated with no recorded SHA; clearing for retry",
+                pr_number,
+            )
+            _save_state(state_path, state)
+        elif current_head_sha and current_head_sha != escalated_head_sha:
             state["escalated_needs_human"] = False
             state.pop("escalated_head_sha", None)
             state["no_verdict_passes"] = 0

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -302,6 +302,31 @@ def test_phase1_skips_escalated_pr_without_new_head(tmp_path: Path) -> None:
     assert loaded["escalated_head_sha"] == "abc123"
 
 
+def test_phase1_resumes_escalated_pr_with_null_sha(tmp_path: Path) -> None:
+    # When escalated with escalated_head_sha=None (e.g. after a manual state
+    # reset or rebase), the watcher must clear the escalation and retry rather
+    # than deadlocking in a permanent skip.
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha=None,
+        no_verdict_passes=0,
+    )
+    gh = _make_gh()
+
+    with patch.object(
+        watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+    ) as mock_review, patch.object(watcher, "_merge_and_done"):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc123"), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    mock_review.assert_called_once()
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is False
+
+
 def test_phase1_resumes_escalated_pr_after_new_head(tmp_path: Path) -> None:
     state, sp = _make_state(
         tmp_path,


### PR DESCRIPTION
## Summary

- When `escalated_needs_human: true` AND `escalated_head_sha: null`, the three-way `and` guard `if current_head_sha and escalated_head_sha and current_head_sha != escalated_head_sha` always evaluates falsy — PR is permanently skipped every cycle with no way to recover.
- New branch: if `escalated_head_sha` is null, clear escalation flag and retry instead of silently skipping.
- Adds `test_phase1_resumes_escalated_pr_with_null_sha` covering the null-SHA clear path.

**Root cause context:** This deadlock manifests after manual state surgery (e.g. clearing `escalated_head_sha` to None while `escalated_needs_human` stays true). PR #253 hit this after 31 no-verdict loops; the null SHA fix was the final unblocking piece.

## Test plan

- [x] `test_phase1_resumes_escalated_pr_with_null_sha` — null SHA → escalation cleared, `_run_direct_review` called
- [x] `test_phase1_skips_escalated_pr_without_new_head` — existing: non-null SHA match → still skips
- [x] `test_phase1_resumes_escalated_pr_after_new_head` — existing: SHA changed → resumes
- [x] Full `tests/test_pr_review_watcher.py` + `tests/unit/` (6524 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)