### PR TITLE
feat(maintenance): orphan-branch detector (WO-4)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,7 @@
+## 2026-06-08 — WO-4: orphan-branch detector implemented (ensure_ascii fix)
+
+Custodian C? finding: json.dumps without ensure_ascii=False. Fixed.
+
 ## 2026-06-08 — WO-4: orphan-branch detector implemented
 
 `operations-center-orphan-branch-check` CLI added. Detects remote branches with

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,10 @@
+## 2026-06-08 — WO-4: orphan-branch detector implemented
+
+`operations-center-orphan-branch-check` CLI added. Detects remote branches with
+commits ahead of default branch + no open PR + older than 24h. Protected set:
+main, master, gh-pages, prod, staging, operations-center-testing-branch, and
+per-repo sandbox_base_branch. First sweep clean (0 orphans). 17 unit tests.
+
 ## 2026-06-08 — fix(review-watcher): clear escalation deadlock when escalated_head_sha is null
 
 `_phase1` null SHA deadlock: when `escalated_needs_human: true` AND `escalated_head_sha: null`,

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,7 @@
+## 2026-06-08 — WO-4: fix PlaneClient args in orphan_branch_check (_emit_plane_task)
+
+token→api_token, added project_id, title→name, labels→label_names. CI was failing ty check.
+
 ## 2026-06-08 — WO-4: orphan-branch detector implemented (ensure_ascii fix)
 
 Custodian C? finding: json.dumps without ensure_ascii=False. Fixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ operations-center-worker-backend-probe = "operations_center.entrypoints.worker_b
 # projection rebuild extracted from spec_director. Single writer of
 # state/campaigns/active.json.
 operations-center-spec-hygiene      = "operations_center.entrypoints.spec_hygiene.main:main"
+# WO-4 orphan-branch detector — remote branches with commits ahead of main,
+# no open PR, older than 24 h. Run in watchdog STEP-2 or as a one-shot sweep.
+operations-center-orphan-branch-check = "operations_center.entrypoints.maintenance.orphan_branch_check:main"
 
 [project.entry-points."pytest11"]
 flaky-detection = "operations_center.observer.pytest_flaky_plugin"

--- a/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
+++ b/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
@@ -237,8 +237,9 @@ def _emit_plane_task(settings: Any, orphan: OrphanBranch) -> None:
 
     plane = PlaneClient(
         base_url=settings.plane.base_url,
-        token=settings.plane.token,
+        api_token=settings.plane_token(),
         workspace_slug=settings.plane.workspace_slug,
+        project_id=settings.plane.project_id,
     )
     title = f"Orphan branch: {orphan.repo_key}/{orphan.branch} ({orphan.commits_ahead} commits ahead)"
     body = (
@@ -248,12 +249,10 @@ def _emit_plane_task(settings: Any, orphan: OrphanBranch) -> None:
         "Action: open a PR, merge the commits, or delete the branch after confirming "
         "no salvage value per the WO-1 close-with-receipt invariant."
     )
-    project_id = settings.plane.project_id
     plane.create_issue(
-        project_id=project_id,
-        title=title,
+        name=title,
         description=body,
-        labels=["orphan-branch", f"repo:{orphan.repo_key}"],
+        label_names=["orphan-branch", f"repo:{orphan.repo_key}"],
     )
     logger.info("created Plane task for %s/%s", orphan.repo_key, orphan.branch)
 

--- a/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
+++ b/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Orphan-branch detector — WO-4 of the 2026-06-07 flow-hygiene work order.
+
+An orphan branch is a remote branch that:
+  (a) has at least one commit ahead of the default branch, AND
+  (b) has no open pull request, AND
+  (c) is older than --min-age-hours (default 24 h).
+
+These are branches whose work has been abandoned, forgotten, or silently lost.
+The close-with-receipt invariant (WO-1) covers PRs that get closed; this scanner
+covers branches that were never promoted to a PR in the first place.
+
+Protected branches are never reported as orphans:
+  main, master, HEAD, operations-center-testing-branch
+  plus any branch whose name matches the repo's sandbox_base_branch.
+
+Run (read-only — never mutates repos or Plane):
+  python -m operations_center.entrypoints.maintenance.orphan_branch_check \\
+      --config config/operations_center.local.yaml
+
+Run and emit Plane tasks (one task per orphan):
+  python -m operations_center.entrypoints.maintenance.orphan_branch_check \\
+      --config config/operations_center.local.yaml --emit
+
+Exit code: 0 always (orphans are findings, not fatal errors).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from operations_center.adapters.github_pr import GitHubPRClient
+from operations_center.config import load_settings
+
+logger = logging.getLogger(__name__)
+
+# Never flag these as orphans regardless of commits-ahead.
+_ALWAYS_PROTECTED = frozenset(
+    {
+        "main",
+        "master",
+        "HEAD",
+        "operations-center-testing-branch",
+        "gh-pages",  # GitHub Pages deployment branch
+        "prod",      # Production deployment branch
+        "staging",   # Staging deployment branch
+    }
+)
+
+
+@dataclass(frozen=True)
+class OrphanBranch:
+    repo_key: str
+    branch: str
+    commits_ahead: int
+    last_commit_at: datetime
+    age_hours: float
+
+
+@dataclass
+class RepoOrphanResult:
+    repo_key: str
+    local_path: Path
+    orphans: list[OrphanBranch] = field(default_factory=list)
+    error: str | None = None
+    skipped: bool = False
+
+
+def _git(args: list[str], cwd: Path) -> tuple[str, int]:
+    """Run a git command, return (stdout, returncode)."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def _open_pr_head_branches(github_client: GitHubPRClient, clone_url: str) -> set[str]:
+    """Return the set of head branch names for all open PRs in the repo."""
+    try:
+        owner, repo = GitHubPRClient.owner_repo_from_clone_url(clone_url)
+        prs = github_client.list_open_prs(owner, repo)
+        return {str(pr.get("head", {}).get("ref", "")) for pr in prs if pr.get("head", {}).get("ref")}
+    except Exception as exc:
+        logger.warning("could not list open PRs for %s: %s", clone_url, exc)
+        return set()
+
+
+def _scan_repo(
+    repo_key: str,
+    local_path: Path,
+    clone_url: str,
+    sandbox_base_branch: str | None,
+    github_client: GitHubPRClient,
+    min_age_hours: float,
+    default_branch: str,
+) -> RepoOrphanResult:
+    result = RepoOrphanResult(repo_key=repo_key, local_path=local_path)
+
+    if not (local_path / ".git").exists():
+        result.skipped = True
+        return result
+
+    # Fetch to sync remote refs (quiet; non-fatal on error).
+    _, rc = _git(["fetch", "origin", "--prune", "--quiet"], local_path)
+    if rc != 0:
+        logger.warning("%s: git fetch failed (rc=%d); using cached refs", repo_key, rc)
+
+    # List all remote branches.
+    raw, rc = _git(
+        ["branch", "-r", "--format=%(refname:short)"],
+        local_path,
+    )
+    if rc != 0:
+        result.error = f"git branch -r failed (rc={rc})"
+        return result
+
+    remote_branches = [
+        b.removeprefix("origin/")
+        for b in raw.splitlines()
+        if b.startswith("origin/") and not b.endswith("/HEAD")
+    ]
+
+    # Branches that are never orphans.
+    protected = set(_ALWAYS_PROTECTED)
+    if sandbox_base_branch:
+        protected.add(sandbox_base_branch)
+    protected.add(default_branch)
+
+    # Open-PR head branches — skip fetching if nothing to check.
+    candidate_branches = [b for b in remote_branches if b not in protected]
+    if not candidate_branches:
+        return result
+
+    open_pr_branches = _open_pr_head_branches(github_client, clone_url)
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(hours=min_age_hours)
+
+    for branch in candidate_branches:
+        if branch in open_pr_branches:
+            continue
+
+        # Commits ahead of default branch.
+        ahead_raw, rc = _git(
+            ["rev-list", "--count", f"origin/{default_branch}..origin/{branch}"],
+            local_path,
+        )
+        if rc != 0:
+            logger.debug("%s:%s — rev-list failed, skipping", repo_key, branch)
+            continue
+        try:
+            commits_ahead = int(ahead_raw)
+        except ValueError:
+            continue
+        if commits_ahead == 0:
+            continue
+
+        # Last commit timestamp on the branch.
+        ts_raw, rc = _git(
+            ["log", "-1", "--format=%cI", f"origin/{branch}"],
+            local_path,
+        )
+        if rc != 0 or not ts_raw:
+            continue
+        try:
+            last_commit_at = datetime.fromisoformat(ts_raw)
+            if last_commit_at.tzinfo is None:
+                last_commit_at = last_commit_at.replace(tzinfo=UTC)
+        except ValueError:
+            continue
+
+        if last_commit_at > cutoff:
+            continue  # too recent — not yet an orphan
+
+        age_hours = (now - last_commit_at).total_seconds() / 3600.0
+        result.orphans.append(
+            OrphanBranch(
+                repo_key=repo_key,
+                branch=branch,
+                commits_ahead=commits_ahead,
+                last_commit_at=last_commit_at,
+                age_hours=age_hours,
+            )
+        )
+
+    return result
+
+
+def scan(settings: Any, min_age_hours: float = 24.0) -> list[RepoOrphanResult]:
+    """Scan all configured repos and return orphan findings per repo."""
+    token = ""
+    for env_var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        import os
+
+        token = os.environ.get(env_var, "")
+        if token:
+            break
+
+    github_client = GitHubPRClient(token=token)
+    results: list[RepoOrphanResult] = []
+
+    for repo_key, repo_cfg in settings.repos.items():
+        local_path_str = repo_cfg.local_path
+        if not local_path_str:
+            continue
+        local_path = Path(local_path_str)
+
+        results.append(
+            _scan_repo(
+                repo_key=repo_key,
+                local_path=local_path,
+                clone_url=repo_cfg.clone_url,
+                sandbox_base_branch=repo_cfg.sandbox_base_branch,
+                github_client=github_client,
+                min_age_hours=min_age_hours,
+                default_branch=repo_cfg.default_branch,
+            )
+        )
+
+    return results
+
+
+def _emit_plane_task(settings: Any, orphan: OrphanBranch) -> None:
+    from operations_center.adapters.plane import PlaneClient
+
+    plane = PlaneClient(
+        base_url=settings.plane.base_url,
+        token=settings.plane.token,
+        workspace_slug=settings.plane.workspace_slug,
+    )
+    title = f"Orphan branch: {orphan.repo_key}/{orphan.branch} ({orphan.commits_ahead} commits ahead)"
+    body = (
+        f"Branch `{orphan.branch}` in **{orphan.repo_key}** has {orphan.commits_ahead} "
+        f"commit(s) ahead of main with no open PR, last committed "
+        f"{orphan.age_hours:.1f}h ago.\n\n"
+        "Action: open a PR, merge the commits, or delete the branch after confirming "
+        "no salvage value per the WO-1 close-with-receipt invariant."
+    )
+    project_id = settings.plane.project_id
+    plane.create_issue(
+        project_id=project_id,
+        title=title,
+        description=body,
+        labels=["orphan-branch", f"repo:{orphan.repo_key}"],
+    )
+    logger.info("created Plane task for %s/%s", orphan.repo_key, orphan.branch)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Orphan-branch detector")
+    parser.add_argument("--config", required=True, help="Path to operations_center.local.yaml")
+    parser.add_argument(
+        "--min-age-hours",
+        type=float,
+        default=24.0,
+        help="Minimum branch age in hours to report (default: 24)",
+    )
+    parser.add_argument(
+        "--emit",
+        action="store_true",
+        help="Create Plane tasks for each orphan found",
+    )
+    parser.add_argument(
+        "--json",
+        dest="output_json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    settings = load_settings(args.config)
+    results = scan(settings, min_age_hours=args.min_age_hours)
+
+    all_orphans = [o for r in results for o in r.orphans]
+    errors = [r for r in results if r.error]
+
+    if args.output_json:
+        out: dict[str, Any] = {
+            "scanned_at": datetime.now(UTC).isoformat(),
+            "min_age_hours": args.min_age_hours,
+            "orphans": [
+                {
+                    "repo_key": o.repo_key,
+                    "branch": o.branch,
+                    "commits_ahead": o.commits_ahead,
+                    "last_commit_at": o.last_commit_at.isoformat(),
+                    "age_hours": round(o.age_hours, 1),
+                }
+                for o in all_orphans
+            ],
+            "errors": [{"repo_key": r.repo_key, "error": r.error} for r in errors],
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        if all_orphans:
+            print(f"ORPHAN BRANCHES ({len(all_orphans)}):")
+            for o in all_orphans:
+                print(
+                    f"  {o.repo_key}/{o.branch}: {o.commits_ahead} commits ahead, "
+                    f"age={o.age_hours:.1f}h"
+                )
+        else:
+            print("No orphan branches found.")
+        if errors:
+            print(f"\nERRORS ({len(errors)}):")
+            for r in errors:
+                print(f"  {r.repo_key}: {r.error}")
+
+    if args.emit and all_orphans:
+        for orphan in all_orphans:
+            try:
+                _emit_plane_task(settings, orphan)
+            except Exception as exc:
+                logger.warning("failed to emit Plane task for %s/%s: %s", orphan.repo_key, orphan.branch, exc)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
+++ b/src/operations_center/entrypoints/maintenance/orphan_branch_check.py
@@ -304,7 +304,7 @@ def main(argv: list[str] | None = None) -> int:
             ],
             "errors": [{"repo_key": r.repo_key, "error": r.error} for r in errors],
         }
-        print(json.dumps(out, indent=2))
+        print(json.dumps(out, indent=2, ensure_ascii=False))
     else:
         if all_orphans:
             print(f"ORPHAN BRANCHES ({len(all_orphans)}):")

--- a/tests/maintenance/test_orphan_branch_check.py
+++ b/tests/maintenance/test_orphan_branch_check.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for the orphan-branch detector (WO-4)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from operations_center.entrypoints.maintenance.orphan_branch_check import (
+    OrphanBranch,
+    RepoOrphanResult,
+    _ALWAYS_PROTECTED,
+    _open_pr_head_branches,
+    _scan_repo,
+    main,
+    scan,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_settings(repos: dict | None = None) -> MagicMock:
+    s = MagicMock()
+    s.repos = repos or {}
+    return s
+
+
+def _make_repo_cfg(
+    local_path: str = "/tmp/fake_repo",
+    clone_url: str = "https://github.com/owner/repo.git",
+    default_branch: str = "main",
+    sandbox_base_branch: str | None = None,
+) -> MagicMock:
+    cfg = MagicMock()
+    cfg.local_path = local_path
+    cfg.clone_url = clone_url
+    cfg.default_branch = default_branch
+    cfg.sandbox_base_branch = sandbox_base_branch
+    return cfg
+
+
+_NOW = datetime(2026, 6, 8, 10, 0, 0, tzinfo=UTC)
+_OLD = _NOW - timedelta(hours=48)  # 48h ago — definitely an orphan
+_RECENT = _NOW - timedelta(hours=6)  # 6h ago — too new
+
+
+# ── Protected branch set ──────────────────────────────────────────────────────
+
+
+def test_always_protected_contains_expected_names() -> None:
+    assert "main" in _ALWAYS_PROTECTED
+    assert "master" in _ALWAYS_PROTECTED
+    assert "HEAD" in _ALWAYS_PROTECTED
+    assert "operations-center-testing-branch" in _ALWAYS_PROTECTED
+    assert "gh-pages" in _ALWAYS_PROTECTED
+    assert "prod" in _ALWAYS_PROTECTED
+    assert "staging" in _ALWAYS_PROTECTED
+
+
+# ── _open_pr_head_branches ────────────────────────────────────────────────────
+
+
+def test_open_pr_head_branches_returns_branch_names() -> None:
+    client = MagicMock()
+    client.list_open_prs.return_value = [
+        {"head": {"ref": "feat/foo"}},
+        {"head": {"ref": "fix/bar"}},
+    ]
+    client.owner_repo_from_clone_url = MagicMock(return_value=("owner", "repo"))
+    with patch(
+        "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+        return_value=("owner", "repo"),
+    ):
+        result = _open_pr_head_branches(client, "https://github.com/owner/repo.git")
+    assert "feat/foo" in result
+    assert "fix/bar" in result
+
+
+def test_open_pr_head_branches_handles_api_error() -> None:
+    client = MagicMock()
+    client.list_open_prs.side_effect = Exception("network error")
+    with patch(
+        "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+        return_value=("owner", "repo"),
+    ):
+        result = _open_pr_head_branches(client, "https://github.com/owner/repo.git")
+    assert result == set()
+
+
+def test_open_pr_head_branches_skips_prs_without_ref() -> None:
+    client = MagicMock()
+    client.list_open_prs.return_value = [
+        {"head": {}},
+        {"head": {"ref": ""}},
+        {"head": {"ref": "valid-branch"}},
+    ]
+    with patch(
+        "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+        return_value=("owner", "repo"),
+    ):
+        result = _open_pr_head_branches(client, "https://github.com/owner/repo.git")
+    assert "valid-branch" in result
+    assert "" not in result
+
+
+# ── _scan_repo ────────────────────────────────────────────────────────────────
+
+
+def _make_git_mock(responses: dict[tuple, tuple[str, int]]) -> MagicMock:
+    """Return a mock for _git that returns (stdout, rc) based on args tuple."""
+
+    def _git(args: list[str], cwd: Path) -> tuple[str, int]:
+        key = tuple(args)
+        return responses.get(key, ("", 0))
+
+    return _git
+
+
+def test_scan_repo_skips_if_no_dot_git(tmp_path: Path) -> None:
+    client = MagicMock()
+    result = _scan_repo(
+        repo_key="test",
+        local_path=tmp_path,
+        clone_url="https://github.com/o/r.git",
+        sandbox_base_branch=None,
+        github_client=client,
+        min_age_hours=24.0,
+        default_branch="main",
+    )
+    assert result.skipped is True
+    assert result.orphans == []
+
+
+def test_scan_repo_detects_orphan(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    git_responses = {
+        ("fetch", "origin", "--prune", "--quiet"): ("", 0),
+        ("branch", "-r", "--format=%(refname:short)"): (
+            "origin/main\norigin/HEAD -> origin/main\norigin/feature/orphan",
+            0,
+        ),
+        ("rev-list", "--count", "origin/main..origin/feature/orphan"): ("3", 0),
+        ("log", "-1", "--format=%cI", "origin/feature/orphan"): (
+            _OLD.isoformat(),
+            0,
+        ),
+    }
+    client = MagicMock()
+    client.list_open_prs.return_value = []
+
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._git",
+            side_effect=lambda args, cwd: git_responses.get(tuple(args), ("", 0)),
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+            return_value=("owner", "repo"),
+        ),
+    ):
+        result = _scan_repo(
+            repo_key="test",
+            local_path=tmp_path,
+            clone_url="https://github.com/owner/repo.git",
+            sandbox_base_branch=None,
+            github_client=client,
+            min_age_hours=24.0,
+            default_branch="main",
+        )
+
+    assert len(result.orphans) == 1
+    assert result.orphans[0].branch == "feature/orphan"
+    assert result.orphans[0].commits_ahead == 3
+
+
+def test_scan_repo_skips_branch_with_open_pr(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    git_responses = {
+        ("fetch", "origin", "--prune", "--quiet"): ("", 0),
+        ("branch", "-r", "--format=%(refname:short)"): (
+            "origin/main\norigin/feat/has-pr",
+            0,
+        ),
+    }
+    client = MagicMock()
+    client.list_open_prs.return_value = [{"head": {"ref": "feat/has-pr"}}]
+
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._git",
+            side_effect=lambda args, cwd: git_responses.get(tuple(args), ("", 0)),
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+            return_value=("owner", "repo"),
+        ),
+    ):
+        result = _scan_repo(
+            repo_key="test",
+            local_path=tmp_path,
+            clone_url="https://github.com/owner/repo.git",
+            sandbox_base_branch=None,
+            github_client=client,
+            min_age_hours=24.0,
+            default_branch="main",
+        )
+
+    assert result.orphans == []
+
+
+def test_scan_repo_skips_branch_with_zero_commits_ahead(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    git_responses = {
+        ("fetch", "origin", "--prune", "--quiet"): ("", 0),
+        ("branch", "-r", "--format=%(refname:short)"): (
+            "origin/main\norigin/feat/merged",
+            0,
+        ),
+        ("rev-list", "--count", "origin/main..origin/feat/merged"): ("0", 0),
+    }
+    client = MagicMock()
+    client.list_open_prs.return_value = []
+
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._git",
+            side_effect=lambda args, cwd: git_responses.get(tuple(args), ("", 0)),
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+            return_value=("owner", "repo"),
+        ),
+    ):
+        result = _scan_repo(
+            repo_key="test",
+            local_path=tmp_path,
+            clone_url="https://github.com/owner/repo.git",
+            sandbox_base_branch=None,
+            github_client=client,
+            min_age_hours=24.0,
+            default_branch="main",
+        )
+
+    assert result.orphans == []
+
+
+def test_scan_repo_skips_recent_branch(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    git_responses = {
+        ("fetch", "origin", "--prune", "--quiet"): ("", 0),
+        ("branch", "-r", "--format=%(refname:short)"): (
+            "origin/main\norigin/feat/new",
+            0,
+        ),
+        ("rev-list", "--count", "origin/main..origin/feat/new"): ("5", 0),
+        ("log", "-1", "--format=%cI", "origin/feat/new"): (
+            _RECENT.isoformat(),
+            0,
+        ),
+    }
+    client = MagicMock()
+    client.list_open_prs.return_value = []
+
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._git",
+            side_effect=lambda args, cwd: git_responses.get(tuple(args), ("", 0)),
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+            return_value=("owner", "repo"),
+        ),
+    ):
+        result = _scan_repo(
+            repo_key="test",
+            local_path=tmp_path,
+            clone_url="https://github.com/owner/repo.git",
+            sandbox_base_branch=None,
+            github_client=client,
+            min_age_hours=24.0,
+            default_branch="main",
+        )
+
+    assert result.orphans == []
+
+
+def test_scan_repo_skips_protected_branches(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    git_responses = {
+        ("fetch", "origin", "--prune", "--quiet"): ("", 0),
+        ("branch", "-r", "--format=%(refname:short)"): (
+            "origin/main\norigin/master\norigin/operations-center-testing-branch\norigin/sandbox-branch",
+            0,
+        ),
+    }
+    client = MagicMock()
+    client.list_open_prs.return_value = []
+
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._git",
+            side_effect=lambda args, cwd: git_responses.get(tuple(args), ("", 0)),
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient.owner_repo_from_clone_url",
+            return_value=("owner", "repo"),
+        ),
+    ):
+        result = _scan_repo(
+            repo_key="test",
+            local_path=tmp_path,
+            clone_url="https://github.com/owner/repo.git",
+            sandbox_base_branch="sandbox-branch",
+            github_client=client,
+            min_age_hours=24.0,
+            default_branch="main",
+        )
+
+    assert result.orphans == []
+
+
+def test_scan_repo_no_local_path_skipped() -> None:
+    client = MagicMock()
+    result = _scan_repo(
+        repo_key="test",
+        local_path=Path("/nonexistent/path"),
+        clone_url="https://github.com/o/r.git",
+        sandbox_base_branch=None,
+        github_client=client,
+        min_age_hours=24.0,
+        default_branch="main",
+    )
+    assert result.skipped is True
+
+
+# ── main() CLI ────────────────────────────────────────────────────────────────
+
+
+def test_main_returns_zero_on_no_orphans(tmp_path: Path) -> None:
+    settings = _make_settings(repos={})
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.load_settings",
+            return_value=settings,
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.scan",
+            return_value=[],
+        ),
+    ):
+        rc = main(["--config", "fake.yaml", "--json"])
+    assert rc == 0
+
+
+def test_main_json_output_structure(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    orphan = OrphanBranch(
+        repo_key="MyRepo",
+        branch="feat/abandoned",
+        commits_ahead=7,
+        last_commit_at=_OLD,
+        age_hours=48.0,
+    )
+    repo_result = RepoOrphanResult(repo_key="MyRepo", local_path=tmp_path, orphans=[orphan])
+
+    settings = _make_settings()
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.load_settings",
+            return_value=settings,
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.scan",
+            return_value=[repo_result],
+        ),
+    ):
+        rc = main(["--config", "fake.yaml", "--json"])
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert len(out["orphans"]) == 1
+    assert out["orphans"][0]["branch"] == "feat/abandoned"
+    assert out["orphans"][0]["commits_ahead"] == 7
+
+
+def test_main_text_output_lists_orphan(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    orphan = OrphanBranch(
+        repo_key="MyRepo",
+        branch="feat/lost",
+        commits_ahead=2,
+        last_commit_at=_OLD,
+        age_hours=48.0,
+    )
+    repo_result = RepoOrphanResult(repo_key="MyRepo", local_path=tmp_path, orphans=[orphan])
+
+    settings = _make_settings()
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.load_settings",
+            return_value=settings,
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.scan",
+            return_value=[repo_result],
+        ),
+    ):
+        rc = main(["--config", "fake.yaml"])
+
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "feat/lost" in captured
+    assert "2 commits" in captured
+
+
+def test_main_emit_calls_plane_task_creation(tmp_path: Path) -> None:
+    orphan = OrphanBranch(
+        repo_key="MyRepo",
+        branch="feat/old",
+        commits_ahead=3,
+        last_commit_at=_OLD,
+        age_hours=50.0,
+    )
+    repo_result = RepoOrphanResult(repo_key="MyRepo", local_path=tmp_path, orphans=[orphan])
+
+    settings = _make_settings()
+    with (
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.load_settings",
+            return_value=settings,
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check.scan",
+            return_value=[repo_result],
+        ),
+        patch(
+            "operations_center.entrypoints.maintenance.orphan_branch_check._emit_plane_task",
+        ) as mock_emit,
+    ):
+        rc = main(["--config", "fake.yaml", "--emit"])
+
+    assert rc == 0
+    mock_emit.assert_called_once_with(settings, orphan)
+
+
+# ── scan() integration-level ──────────────────────────────────────────────────
+
+
+def test_scan_skips_repos_without_local_path() -> None:
+    repo_cfg = _make_repo_cfg(local_path="")
+    settings = _make_settings(repos={"orphan_repo": repo_cfg})
+    repo_cfg.local_path = None  # no local path
+
+    with patch(
+        "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient",
+    ):
+        results = scan(settings, min_age_hours=24.0)
+
+    assert results == []
+
+
+def test_scan_returns_list_of_results() -> None:
+    repo_cfg = _make_repo_cfg(local_path="/nonexistent")
+    settings = _make_settings(repos={"repo_a": repo_cfg})
+
+    with patch(
+        "operations_center.entrypoints.maintenance.orphan_branch_check.GitHubPRClient",
+    ):
+        results = scan(settings, min_age_hours=24.0)
+
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert results[0].repo_key == "repo_a"
+    assert results[0].skipped is True


### PR DESCRIPTION
## Summary

- Adds `operations-center-orphan-branch-check` CLI: detects remote branches with commits ahead of the default branch, no open PR, and older than 24 h (WO-4 of the 2026-06-07 flow-hygiene work order)
- Protected set: `main`, `master`, `gh-pages`, `prod`, `staging`, `HEAD`, `operations-center-testing-branch`, and per-repo `sandbox_base_branch`
- First sweep result: **0 orphan branches** across all managed repos (VideoFoundry/prod and SwitchBoard/gh-pages are deployment branches, correctly excluded)
- 17 new unit tests; 7319 existing tests still passing; custodian clean

## Test plan

- [ ] `pytest tests/maintenance/test_orphan_branch_check.py` — 17 tests pass
- [ ] `operations-center-orphan-branch-check --config config/operations_center.local.yaml --json` — runs clean, 0 orphans
- [ ] `pytest tests/unit/er000_phase0_golden/` — 15 golden tests pass
- [ ] CI green on all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)