### PR TITLE
feat(spec-author): PR title + dedup hygiene (WO-5)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,5 @@
+## 2026-06-08 — WO-5: spec-author PR title + dedup gate implemented
+
 ## 2026-06-08 — WO-3: self-retracting reviewer verdicts implemented
 
 Added `_retract_flag()` to the review watcher: when a PR merges, is closed with receipt,

--- a/src/operations_center/entrypoints/board_worker/_text.py
+++ b/src/operations_center/entrypoints/board_worker/_text.py
@@ -239,7 +239,7 @@ def build_spec_author_goal_text(payload: dict, run_id_placeholder: str) -> str:
 
     parts: list[str] = []
     parts.append(
-        f"# Spec authoring task\n\n"
+        f"# Spec: {spec_slug}\n\n"
         f"Write a focused improvement-campaign spec at `{target_path}` in this "
         f"repository (`OperationsCenter`). The spec drives a multi-task Plane "
         f"campaign; keep its goals concrete and bounded."

--- a/src/operations_center/entrypoints/spec_trigger/main.py
+++ b/src/operations_center/entrypoints/spec_trigger/main.py
@@ -21,7 +21,7 @@ import logging
 import re
 import subprocess
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -127,6 +127,42 @@ def _any_queued_spec_author(issues: list[dict[str, Any]]) -> str | None:
         if src in names and kind in names:
             return str(issue.get("id", ""))
     return None
+
+
+_SPEC_AUTHOR_TERMINAL_STATES = frozenset({"done", "cancelled"})
+_QUEUE_DRAIN_COOLDOWN_HOURS = 6
+
+
+def _spec_author_recently_completed(
+    issues: list[dict[str, Any]],
+    cooldown_hours: int = _QUEUE_DRAIN_COOLDOWN_HOURS,
+) -> bool:
+    """Return True if a spec-author task completed within the cooldown window.
+
+    Prevents the queue-drain trigger from re-firing immediately after a
+    spec-author task finishes, which caused 7+ specs to be minted in one day.
+    Drop-file triggers bypass this check (operator intent wins).
+    """
+    src = _LABEL_SOURCE.lower()
+    kind = _LABEL_TASK_KIND.lower()
+    cutoff = datetime.now(UTC) - timedelta(hours=cooldown_hours)
+    for issue in issues:
+        state_name = str((issue.get("state") or {}).get("name", "")).lower()
+        if state_name not in _SPEC_AUTHOR_TERMINAL_STATES:
+            continue
+        names = _spec_author_label_names(issue)
+        if src not in names or kind not in names:
+            continue
+        raw_ts = issue.get("updated_at") or issue.get("created_at") or ""
+        if not raw_ts:
+            continue
+        try:
+            ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+            if ts > cutoff:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 def _slugify(text: str, fallback: str) -> str:
@@ -258,6 +294,19 @@ def run_once(settings: Any, client: PlaneClient) -> None:
             logger.info(
                 json.dumps(
                     {"event": "spec_trigger_skip_queued", "issue_id": queued},
+                    ensure_ascii=False,
+                )
+            )
+            return
+        # Cooldown: suppress if a spec-author task completed recently to prevent
+        # re-triggering immediately after each completion (root cause: 7 specs/day).
+        if _spec_author_recently_completed(all_issues):
+            logger.info(
+                json.dumps(
+                    {
+                        "event": "spec_trigger_skip_cooldown",
+                        "cooldown_hours": _QUEUE_DRAIN_COOLDOWN_HOURS,
+                    },
                     ensure_ascii=False,
                 )
             )

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -437,6 +437,7 @@ class WorkspaceManager:
 
         text = (request.goal_text or "").strip()
         first_line = text.splitlines()[0].strip() if text else ""
+        first_line = re.sub(r"^#+\s*", "", first_line)  # strip markdown heading markers
         first_line = re.sub(r"^\[\w+\]\s*", "", first_line)  # strip [Impl]/[Test]/[Improve]
         first_line = re.sub(r"\*\*([^*]+)\*\*", r"\1", first_line)  # **bold** → bold
         first_line = re.sub(r"`([^`]+)`", r"\1", first_line)  # `code` → code

--- a/tests/spec_author/test_spec_trigger.py
+++ b/tests/spec_author/test_spec_trigger.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -14,13 +15,17 @@ def _make_issue(
     state_name: str,
     labels: list[str],
     title: str = "Test",
+    updated_at: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    issue: dict[str, Any] = {
         "id": issue_id,
         "name": title,
         "state": {"name": state_name},
         "labels": [{"name": lbl} for lbl in labels],
     }
+    if updated_at is not None:
+        issue["updated_at"] = updated_at
+    return issue
 
 
 _SPEC_LABELS = ["source: spec-director", "task-kind: spec-author"]
@@ -174,6 +179,119 @@ def test_run_once_drop_file_fires_even_with_queued_spec_tasks(tmp_path):
         patch(
             "operations_center.entrypoints.spec_trigger.main.create_spec_author_task",
             return_value="new-issue-id",
+        ) as mock_create,
+    ):
+        run_once(mock_settings, mock_client)
+
+    mock_create.assert_called_once()
+
+
+# ── _spec_author_recently_completed cooldown tests ────────────────────────────
+
+
+def test_recently_completed_detects_done_within_window():
+    from operations_center.entrypoints.spec_trigger.main import _spec_author_recently_completed
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    issue = _make_issue("d1", "Done", _SPEC_LABELS, updated_at=recent_ts)
+    assert _spec_author_recently_completed([issue], cooldown_hours=6) is True
+
+
+def test_recently_completed_detects_cancelled_within_window():
+    from operations_center.entrypoints.spec_trigger.main import _spec_author_recently_completed
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    issue = _make_issue("c1", "Cancelled", _SPEC_LABELS, updated_at=recent_ts)
+    assert _spec_author_recently_completed([issue], cooldown_hours=6) is True
+
+
+def test_recently_completed_ignores_old_terminal_task():
+    from operations_center.entrypoints.spec_trigger.main import _spec_author_recently_completed
+
+    old_ts = (datetime.now(UTC) - timedelta(hours=10)).isoformat()
+    issue = _make_issue("d2", "Done", _SPEC_LABELS, updated_at=old_ts)
+    assert _spec_author_recently_completed([issue], cooldown_hours=6) is False
+
+
+def test_recently_completed_ignores_non_spec_author_labels():
+    from operations_center.entrypoints.spec_trigger.main import _spec_author_recently_completed
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    issue = _make_issue("g1", "Done", ["task-kind: goal"], updated_at=recent_ts)
+    assert _spec_author_recently_completed([issue], cooldown_hours=6) is False
+
+
+def test_recently_completed_ignores_active_states():
+    from operations_center.entrypoints.spec_trigger.main import _spec_author_recently_completed
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    issue = _make_issue("r1", "Ready for AI", _SPEC_LABELS, updated_at=recent_ts)
+    assert _spec_author_recently_completed([issue], cooldown_hours=6) is False
+
+
+def test_run_once_suppresses_queue_drain_within_cooldown(tmp_path):
+    """run_once must not create a new task when a spec-author finished recently."""
+    from operations_center.entrypoints.spec_trigger.main import run_once
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    done_issue = _make_issue("done-spec", "Done", _SPEC_LABELS, updated_at=recent_ts)
+
+    mock_client = MagicMock()
+    mock_client.list_issues.return_value = [done_issue]
+
+    mock_sd = MagicMock()
+    mock_sd.enabled = True
+    mock_sd.drop_file_path = str(tmp_path / "nonexistent.md")
+    mock_sd.poll_interval_seconds = 60
+
+    mock_settings = MagicMock()
+    mock_settings.spec_author = mock_sd
+    mock_settings.repos = {}
+
+    with (
+        patch(
+            "operations_center.entrypoints.spec_trigger.main._has_active_campaign",
+            return_value=False,
+        ),
+        patch(
+            "operations_center.entrypoints.spec_trigger.main.create_spec_author_task",
+        ) as mock_create,
+    ):
+        run_once(mock_settings, mock_client)
+
+    mock_create.assert_not_called()
+
+
+def test_run_once_drop_file_bypasses_cooldown(tmp_path):
+    """Drop-file triggers bypass the cooldown — operator intent wins."""
+    from operations_center.entrypoints.spec_trigger.main import run_once
+
+    drop_file = tmp_path / "spec_direction.md"
+    drop_file.write_text("override idea")
+
+    recent_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    done_issue = _make_issue("done-spec", "Done", _SPEC_LABELS, updated_at=recent_ts)
+
+    mock_client = MagicMock()
+    mock_client.list_issues.return_value = [done_issue]
+
+    mock_sd = MagicMock()
+    mock_sd.enabled = True
+    mock_sd.drop_file_path = str(drop_file)
+    mock_sd.poll_interval_seconds = 60
+
+    mock_settings = MagicMock()
+    mock_settings.spec_author = mock_sd
+    mock_settings.repos = {}
+
+    with (
+        patch(
+            "operations_center.entrypoints.spec_trigger.main._has_active_campaign",
+            return_value=False,
+        ),
+        patch(
+            "operations_center.entrypoints.spec_trigger.main.create_spec_author_task",
+            return_value="new-id",
         ) as mock_create,
     ):
         run_once(mock_settings, mock_client)

--- a/tests/unit/entrypoints/board_worker/test__text_cov.py
+++ b/tests/unit/entrypoints/board_worker/test__text_cov.py
@@ -298,7 +298,7 @@ def test_build_spec_author_full_authoring():
         },
     }
     out = _text.build_spec_author_goal_text(payload, "RUN9")
-    assert "Spec authoring task" in out
+    assert "Spec: newslug" in out
     assert "specs/new.md" in out
     assert "RUN9" in out
     assert "slug: newslug" in out
@@ -317,7 +317,7 @@ def test_build_spec_author_full_authoring():
 def test_build_spec_author_minimal_no_optionals():
     payload = {"spec_slug": "s", "target_path": "t.md"}
     out = _text.build_spec_author_goal_text(payload, "R")
-    assert "Spec authoring task" in out
+    assert "Spec: s" in out
     assert "## Available Repos" not in out
     assert "## Operator Direction" not in out
     assert "Existing Specs" not in out
@@ -360,4 +360,4 @@ def test_build_spec_author_board_snapshot_missing_keys():
 def test_build_spec_author_context_bundle_missing_uses_empty():
     payload = {"spec_slug": "s", "target_path": "t.md", "context_bundle": None}
     out = _text.build_spec_author_goal_text(payload, "R")
-    assert "Spec authoring task" in out
+    assert "Spec: s" in out

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -500,6 +500,18 @@ def test_commit_message_truncates_to_72(tmp_path):
     assert mgr._commit_message(req) == "x" * 72
 
 
+def test_commit_message_strips_heading_marker(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws", goal_text="# Spec: queue-drain-20260602\nmore lines")
+    assert mgr._commit_message(req) == "Spec: queue-drain-20260602"
+
+
+def test_commit_message_strips_multi_hash_heading(tmp_path):
+    mgr = WorkspaceManager()
+    req = _make_request(tmp_path / "ws", goal_text="## Some heading\ndetails")
+    assert mgr._commit_message(req) == "Some heading"
+
+
 # ── _maybe_create_pr ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **PR title fix**: `build_spec_author_goal_text` used `"# Spec authoring task"` as the first line of `goal_text`, which propagated verbatim as the PR title for every spec-author execution (16 merged PRs with that literal heading). Changed to `f"# Spec: {spec_slug}"`. Also added `#` heading-marker stripping in `_commit_message` so goal_text starting with `#`/`##` always yields a clean PR title.
- **Dedup gate**: `spec_trigger` only suppressed re-firing when a spec-author task was in-flight (R4AI/Running). A completed or cancelled task immediately re-enabled the trigger, causing 7 specs to be minted in one day. Added a 6h cooldown (`_spec_author_recently_completed`) that suppresses `queue_drain` triggers after a spec-author task terminates. Drop-file triggers bypass the cooldown (operator intent wins).

## Test plan

- [x] 5 new unit tests for `_spec_author_recently_completed` (recent Done, recent Cancelled, old terminal, wrong labels, active state)
- [x] 2 new `run_once` integration tests (cooldown suppresses queue_drain; drop-file bypasses cooldown)
- [x] 2 new `_commit_message` tests (strips `#`, strips `##`)
- [x] 3 existing `_text_cov` assertions updated to match new `"Spec: <slug>"` heading
- [x] 7897/7897 full suite pass; golden 15/15; ruff + ty clean; custodian 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)