### PR TITLE
feat(reviewer): backend-crash budget separation + stuck-green escalation (WO-6 items 2+3)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,7 @@
+## 2026-06-08 — WO-6 (items 2+3): backend-crash budget separation + stuck-green escalation
+
+## 2026-06-08 — WO-1 backfill: all 20 closed-unmerged PRs audited; 14 historical close-receipts posted
+
 ## 2026-06-08 — WO-5: spec-author PR title + dedup gate implemented
 
 ## 2026-06-08 — WO-3: self-retracting reviewer verdicts implemented

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -171,6 +171,16 @@ class OCSourceTreeUncleanError(RuntimeError):
     burns a PR's review budget or reads as "no verdict"."""
 
 
+class ReviewerBackendError(RuntimeError):
+    """The reviewer backend (``claude`` CLI) crashed, was killed, or timed out.
+
+    This is an INFRA failure, not a PR-quality failure.  The PR may be perfectly
+    good; the backend just can't review it right now (e.g. a transient rate-limit,
+    OOM kill, or process timeout).  Surfaced distinctly so crashes never burn the
+    PR's ``no_verdict_passes`` budget — only a clean exit with no verdict.json
+    written counts against that budget."""
+
+
 def _oc_source_conflict_markers(oc_root: Path) -> list[str]:
     """Tracked ``src/`` Python files containing git conflict markers.
 
@@ -306,10 +316,9 @@ def _run_direct_review(
                 timeout=300,
             )
         except subprocess.TimeoutExpired:
-            logger.warning(
-                "pr_review_watcher: direct review timed out for state_key=%s", state_key
+            raise ReviewerBackendError(
+                f"direct review timed out (300s) for state_key={state_key}"
             )
-            return None
         if verdict_path.exists():
             try:
                 return json.loads(verdict_path.read_text(encoding="utf-8"))
@@ -318,17 +327,25 @@ def _run_direct_review(
                     "pr_review_watcher: malformed verdict.json from direct review for %s",
                     state_key,
                 )
-        else:
-            # Log stdout tail — helps diagnose if Claude is writing to stdout
-            # instead of disk when --output-format json was previously set.
+                return None  # clean exit, bad JSON — genuine no-verdict
+        # No verdict.json written.
+        if proc.returncode != 0:
+            # Non-zero exit = crash, signal kill, or rate-limit — infra failure,
+            # not a PR quality problem.  Don't charge the no_verdict budget.
             stdout_tail = (proc.stdout or "").strip()[-500:]
-            logger.warning(
-                "pr_review_watcher: no verdict.json from direct review for %s "
-                "(rc=%d, stdout_tail=%r)",
-                state_key,
-                proc.returncode,
-                stdout_tail,
+            raise ReviewerBackendError(
+                f"reviewer process exited with rc={proc.returncode} "
+                f"for state_key={state_key} (stdout_tail={stdout_tail!r})"
             )
+        # returncode == 0, no verdict.json — the reviewer ran cleanly but chose
+        # not to write a file.  Genuine no-verdict; charge the budget.
+        stdout_tail = (proc.stdout or "").strip()[-500:]
+        logger.warning(
+            "pr_review_watcher: no verdict.json from direct review for %s "
+            "(rc=0, stdout_tail=%r)",
+            state_key,
+            stdout_tail,
+        )
         return None
 
 
@@ -1567,6 +1584,8 @@ def _phase1(
     state.setdefault("fix_attempts", 0)
     state.setdefault("no_verdict_passes", 0)
     state.setdefault("env_unclean_passes", 0)
+    state.setdefault("backend_error_passes", 0)
+    state.setdefault("no_verdict_escalation_count", 0)
 
     try:
         verdict = _run_direct_review(oc_root, goal_text, state_key)
@@ -1599,32 +1618,78 @@ def _phase1(
             state["env_unclean_passes"] = 0
         _save_state(state_path, state)
         return
+    except ReviewerBackendError as exc:
+        # The claude backend crashed, was killed, or timed out — INFRA failure,
+        # not a PR quality problem.  Do NOT charge no_verdict_passes (that budget
+        # measures genuine "reviewer ran but emitted no verdict", not crashes).
+        state["backend_error_passes"] += 1
+        logger.warning(
+            "pr_review_watcher: PR #%d review SKIPPED (not budget-charged) — backend error: %s "
+            "(backend_error_pass=%d/%d)",
+            pr_number,
+            exc,
+            state["backend_error_passes"],
+            reviewer.max_self_review_loops,
+        )
+        if state["backend_error_passes"] >= reviewer.max_self_review_loops:
+            _escalate_needs_human(
+                state,
+                state_path,
+                gh_client,
+                owner,
+                repo,
+                settings,
+                reason="reviewer_backend_unavailable",
+                detail=str(exc),
+            )
+            state["backend_error_passes"] = 0
+        _save_state(state_path, state)
+        return
 
     state["self_review_loops"] += 1
     state["env_unclean_passes"] = 0  # a pipeline ran — tree is clean
+    state["backend_error_passes"] = 0  # backend is reachable
 
     if verdict is None:
-        # Pipeline produced no verdict (crash/timeout/rate-limit). This is a
-        # REVIEWER failure, not a PR-quality failure — the PR may be perfectly
-        # good, we just can't review it right now (often a transient backend
-        # rate-limit). Never merge blind; but also never close/destroy a good
-        # PR over infra flakiness. Retry a few times, then leave the PR open and
-        # escalate for a human, and keep polling (a recovered backend will
-        # review it next cycle).
+        # Reviewer ran cleanly (exit 0) but did not write verdict.json — a genuine
+        # no-verdict (prompt or model failure).  Count against the budget.
         state["no_verdict_passes"] += 1
         if state["no_verdict_passes"] >= reviewer.max_self_review_loops:
+            state["no_verdict_escalation_count"] += 1
+            escalation_count = state["no_verdict_escalation_count"]
             logger.warning(
                 "pr_review_watcher: PR #%d produced no verdict after %d passes — "
-                "escalating (leaving open; reviewer unavailable, work preserved)",
+                "escalating (leaving open; reviewer unavailable, work preserved) "
+                "[no_verdict_escalation_count=%d]",
                 pr_number,
                 state["no_verdict_passes"],
+                escalation_count,
             )
+            # Stuck-green detection: a PR that repeatedly reaches the no-verdict
+            # escalation threshold without ever merging is likely stuck.  Emit a
+            # distinct alarm so the operator (and watchdog) can see it clearly.
+            _STUCK_GREEN_ESCALATION_THRESHOLD = 3
+            if escalation_count >= _STUCK_GREEN_ESCALATION_THRESHOLD:
+                logger.error(
+                    "pr_review_watcher: STUCK-GREEN PR #%d repo=%s — green on CI but "
+                    "unmerged after %d no-verdict escalation cycles "
+                    "(reason=stuck_green_repeated_failures); human review required",
+                    pr_number,
+                    repo_key,
+                    escalation_count,
+                )
             detail = (
                 "Self-review produced no parseable verdict after repeated passes "
-                "(likely a transient backend/rate-limit issue, or a diff too large "
-                "to review). The PR is left open for human attention; automated "
+                "(reviewer ran but emitted no verdict.json — possible prompt or model "
+                "issue). The PR is left open for human attention; automated "
                 "review will retry."
             )
+            if escalation_count >= _STUCK_GREEN_ESCALATION_THRESHOLD:
+                detail += (
+                    f" WARNING: this is the {escalation_count}th no-verdict escalation "
+                    f"for this PR (stuck-green — green on CI but review never converges). "
+                    f"Reason code: stuck_green_repeated_failures."
+                )
             record_escalation(
                 pr_number=pr_number,
                 repo_key=repo_key,

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -1020,6 +1020,182 @@ def test_unclean_tree_escalates_with_specific_reason_after_budget(tmp_path: Path
     assert state["no_verdict_passes"] == 0
 
 
+# ── WO-6 item 2: backend crash vs genuine no-verdict budget separation ────────
+
+
+def test_run_direct_review_raises_backend_error_on_nonzero_exit(tmp_path: Path) -> None:
+    # Non-zero exit code = backend crash/rate-limit → ReviewerBackendError, not None.
+    import subprocess as _sp
+
+    def _fake_run(cmd, cwd, capture_output, text, timeout):
+        return _sp.CompletedProcess(cmd, returncode=1, stdout="rate limit exceeded", stderr="")
+
+    with (
+        patch.object(watcher, "_oc_source_conflict_markers", return_value=[]),
+        patch("operations_center.entrypoints.pr_review_watcher.main.subprocess.run", side_effect=_fake_run),
+    ):
+        with pytest.raises(watcher.ReviewerBackendError) as ei:
+            watcher._run_direct_review(tmp_path, "review this diff", STATE_KEY)
+    assert "rc=1" in str(ei.value)
+
+
+def test_run_direct_review_raises_backend_error_on_timeout(tmp_path: Path) -> None:
+    import subprocess as _sp
+
+    def _fake_run(cmd, cwd, capture_output, text, timeout):
+        raise _sp.TimeoutExpired(cmd, timeout)
+
+    with (
+        patch.object(watcher, "_oc_source_conflict_markers", return_value=[]),
+        patch("operations_center.entrypoints.pr_review_watcher.main.subprocess.run", side_effect=_fake_run),
+    ):
+        with pytest.raises(watcher.ReviewerBackendError) as ei:
+            watcher._run_direct_review(tmp_path, "review this diff", STATE_KEY)
+    assert "timed out" in str(ei.value)
+
+
+def test_run_direct_review_returns_none_on_clean_exit_no_verdict(tmp_path: Path) -> None:
+    # Exit 0 + no verdict.json = genuine no-verdict (charged to budget), not a crash.
+    import subprocess as _sp
+
+    def _fake_run(cmd, cwd, capture_output, text, timeout):
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch.object(watcher, "_oc_source_conflict_markers", return_value=[]),
+        patch("operations_center.entrypoints.pr_review_watcher.main.subprocess.run", side_effect=_fake_run),
+    ):
+        result = watcher._run_direct_review(tmp_path, "review this diff", STATE_KEY)
+    assert result is None  # charged against no_verdict budget
+
+
+def test_backend_crash_does_not_burn_no_verdict_budget(tmp_path: Path) -> None:
+    # ReviewerBackendError must increment backend_error_passes, NOT no_verdict_passes,
+    # and must not escalate on the first pass (max_self_review_loops=2).
+    state, sp = _make_state(tmp_path, phase="self_review", no_verdict_passes=0)
+    gh = _make_gh()
+    with (
+        patch.object(watcher, "_run_direct_review", side_effect=watcher.ReviewerBackendError("rc=1")),
+        patch.object(watcher, "_escalate_needs_human") as esc,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+    assert state["no_verdict_passes"] == 0
+    assert state["backend_error_passes"] == 1
+    esc.assert_not_called()
+
+
+def test_backend_crash_escalates_with_specific_reason_after_budget(tmp_path: Path) -> None:
+    # After max_self_review_loops backend errors, escalate with reviewer_backend_unavailable.
+    state, sp = _make_state(tmp_path, phase="self_review", backend_error_passes=1)  # max=2
+    gh = _make_gh()
+    with (
+        patch.object(watcher, "_run_direct_review", side_effect=watcher.ReviewerBackendError("timeout")),
+        patch.object(watcher, "_escalate_needs_human") as esc,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+    esc.assert_called_once()
+    assert esc.call_args.kwargs.get("reason") == "reviewer_backend_unavailable"
+    assert state["no_verdict_passes"] == 0
+    assert state["backend_error_passes"] == 0  # reset after escalation
+
+
+def test_clean_exit_no_verdict_charges_budget(tmp_path: Path) -> None:
+    # returncode=0 but no verdict.json = genuine no-verdict, must charge no_verdict_passes.
+    state, sp = _make_state(tmp_path, phase="self_review", no_verdict_passes=0)
+    gh = _make_gh()
+    with patch.object(watcher, "_run_direct_review", return_value=None):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+    assert state["no_verdict_passes"] == 1
+    assert state["backend_error_passes"] == 0
+
+
+# ── WO-6 item 3: stuck-green escalation ──────────────────────────────────────
+
+
+def test_stuck_green_escalation_fires_after_repeated_no_verdict_cycles(tmp_path: Path) -> None:
+    # After 3 no-verdict escalation cycles (no_verdict_escalation_count >= 3),
+    # the detail message must include the stuck-green warning.
+    # Seed state at the threshold: 2 escalations already, about to trigger the 3rd.
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        no_verdict_passes=1,  # one more will hit max=2
+        no_verdict_escalation_count=2,  # 3rd escalation → stuck-green
+    )
+    gh = _make_gh()
+    captured_detail: list[str] = []
+
+    def _esc(s, sp, gh, o, r, settings, *, reason, detail):
+        captured_detail.append(detail)
+        s["escalated_needs_human"] = True
+
+    with (
+        patch.object(watcher, "_run_direct_review", return_value=None),
+        patch.object(watcher, "_escalate_needs_human", side_effect=_esc),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    assert len(captured_detail) == 1
+    assert "stuck_green_repeated_failures" in captured_detail[0]
+    assert state["no_verdict_escalation_count"] == 3
+
+
+def test_stuck_green_not_triggered_on_first_two_escalations(tmp_path: Path) -> None:
+    # Stuck-green alarm must NOT fire before the 3rd escalation.
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        no_verdict_passes=1,  # hits max=2
+        no_verdict_escalation_count=0,  # 1st escalation — not stuck yet
+    )
+    gh = _make_gh()
+    captured_detail: list[str] = []
+
+    def _esc(s, sp, gh, o, r, settings, *, reason, detail):
+        captured_detail.append(detail)
+        s["escalated_needs_human"] = True
+
+    with (
+        patch.object(watcher, "_run_direct_review", return_value=None),
+        patch.object(watcher, "_escalate_needs_human", side_effect=_esc),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    assert len(captured_detail) == 1
+    assert "stuck_green_repeated_failures" not in captured_detail[0]
+    assert state["no_verdict_escalation_count"] == 1
+
+
+def test_no_verdict_escalation_count_persisted(tmp_path: Path) -> None:
+    # no_verdict_escalation_count must survive save/load cycles.
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        no_verdict_passes=1,
+        no_verdict_escalation_count=1,
+    )
+    gh = _make_gh()
+    with (
+        patch.object(watcher, "_run_direct_review", return_value=None),
+        patch.object(watcher, "_escalate_needs_human"),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+    loaded = watcher._load_state(sp)
+    assert loaded["no_verdict_escalation_count"] == 2
+
+
 # ── proactive review-queue ordering (2026-06-07 starvation fix) ───────────────
 
 


### PR DESCRIPTION
## Summary

- **WO-6 item 2 — Backend-crash budget separation**: adds `ReviewerBackendError`. When the `claude` process exits non-zero or times out (crash / OOM / rate-limit), `_run_direct_review` now raises `ReviewerBackendError` instead of returning `None`. `_phase1` handles it as an infra failure via a new `backend_error_passes` counter, separate from `no_verdict_passes`. A flaky backend can no longer exhaust a good PR's review budget. Only a clean exit (rc=0) with no `verdict.json` written counts as a genuine no-verdict against the budget.

- **WO-6 item 3 — Stuck-green escalation**: adds `no_verdict_escalation_count`, a per-PR cumulative counter of no-verdict escalation cycles (never reset, survives state reloads). After ≥ 3 escalation cycles the PR is flagged `stuck_green_repeated_failures` via `logger.error` and the escalation detail includes an explicit warning. The operator and watchdog can detect it in structured log output without manual inspection.

## Test plan

- [ ] `tests/test_pr_review_watcher.py` — 82/82 pass (9 new: 6 for item 2, 3 for item 3)
- [ ] `tests/unit/er000_phase0_golden/` — 15/15 pass
- [ ] `ruff check` clean, `ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)