### PR TITLE
fix(reviewer): make no-progress detection reliable and preserve external escalation

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -320,3 +320,9 @@ both Claude controller lanes so status surfaces do not leave Haiku looking runna
 
 Controller startup also normalizes matching persisted Sonnet+Opus weekly resets
 to account-wide metadata so `loop_controller_state.json` reports the same scope.
+
+## 2026-06-10 — fix(reviewer): make no-progress detection reliable + preserve external escalation
+
+Root cause: no-progress check required AI concern summaries to match exactly (text comparison),
+but LLM output varies. Also: TOCTOU race where reviewer overwrote watchdog's escalation after
+fix pass. Fixed both; 88 reviewer tests pass.

--- a/.console/log.md
+++ b/.console/log.md
@@ -326,3 +326,7 @@ to account-wide metadata so `loop_controller_state.json` reports the same scope.
 Root cause: no-progress check required AI concern summaries to match exactly (text comparison),
 but LLM output varies. Also: TOCTOU race where reviewer overwrote watchdog's escalation after
 fix pass. Fixed both; 88 reviewer tests pass.
+
+## 2026-06-10 — fix(tests): use dynamic dates in flaky storage cleanup tests
+
+Hardcoded 2026-06-07 "recent" date fell behind the 3-day retention window causing CI failures.

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1785,17 +1785,21 @@ def _phase1(
         )
         return
 
+    # Trigger on the second no-change pass at the same head — no text comparison
+    # needed.  LLM-generated summaries are not bit-identical across loops even
+    # when the root issue is unchanged, so requiring text equality was
+    # unreliable and caused the reviewer to spin through all max_fix_attempts
+    # before escalating.
     repeated_no_progress = (
         state.get("fix_attempts", 0) > 0
         and state.get("last_fix_pass_pushed") is False
         and current_head_sha
         and current_head_sha == str(state.get("last_concerns_head_sha") or "").strip()
-        and normalized_summary == str(state.get("last_concerns_summary") or "").strip()
     )
     if repeated_no_progress:
         detail = (
-            "The previous automated fix pass pushed no changes, and a fresh self-review on the "
-            "same PR head produced the same concerns. Further autonomous retries would repeat "
+            "The previous automated fix pass pushed no changes; a fresh self-review on the "
+            "same PR head still finds concerns. Further autonomous retries would repeat "
             "without changing the branch.\n\nLatest concerns:\n\n"
             f"{summary}"
         )
@@ -1924,6 +1928,23 @@ def _phase1(
             state["fix_attempts"],
             reviewer.max_fix_attempts,
         )
+    # The fix pass executor can run for minutes.  An external process (e.g. the
+    # watchdog) may have updated escalated_needs_human on disk while we waited.
+    # Re-read the escalation flag so we don't overwrite it on save.
+    try:
+        disk = _load_state(state_path)
+        if disk.get("escalated_needs_human") and not state.get("escalated_needs_human"):
+            state["escalated_needs_human"] = True
+            state["escalated_head_sha"] = disk.get("escalated_head_sha") or state.get(
+                "escalated_head_sha"
+            )
+            logger.info(
+                "pr_review_watcher: PR #%d external escalation detected after fix pass; "
+                "preserving escalated_needs_human=True",
+                pr_number,
+            )
+    except Exception:
+        pass
     _save_state(state_path, state)
 
 

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -257,6 +257,74 @@ def test_phase1_repeated_concerns_after_noop_fix_escalates(tmp_path: Path) -> No
     assert state["escalated_head_sha"] == "abc123"
 
 
+def test_phase1_repeated_concerns_different_text_still_escalates(tmp_path: Path) -> None:
+    """No-progress escalation fires even when LLM produces different concern text."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=1,
+        fix_attempts=1,
+        last_fix_pass_pushed=False,
+        last_concerns_head_sha="abc123",
+        last_concerns_summary="old concern wording from prior loop",
+    )
+    gh = _make_gh()
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "slightly different wording same issue"},
+        ),
+        patch.object(watcher, "_run_fix_pass") as mock_fix,
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc123"), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    mock_fix.assert_not_called()
+    mock_escalate.assert_called_once()
+
+
+def test_phase1_fix_pass_preserves_external_escalation(tmp_path: Path) -> None:
+    """External escalation written to disk during fix pass is not overwritten on save."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=0,
+        fix_attempts=0,
+    )
+    gh = _make_gh()
+
+    def _fix_pass_writes_escalation(*_args, **_kwargs):
+        # Simulate watchdog writing escalated_needs_human=True while fix pass runs
+        import json
+        disk = json.loads(sp.read_text())
+        disk["escalated_needs_human"] = True
+        disk["escalated_head_sha"] = "headsha"
+        sp.write_text(json.dumps(disk))
+        return False  # pushed=False
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "some concerns"},
+        ),
+        patch.object(watcher, "_run_fix_pass", side_effect=_fix_pass_writes_escalation),
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="headsha"), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    import json
+    saved = json.loads(sp.read_text())
+    assert saved["escalated_needs_human"] is True, "external escalation must survive save"
+    mock_escalate.assert_not_called()
+
+
 def test_phase1_concerns_closes_and_requeues_at_fix_cap(tmp_path: Path) -> None:
     # max_fix_attempts=2, already at 2 — CONCERNS must close+requeue, NOT merge.
     state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1, fix_attempts=2)

--- a/tests/unit/observer/test_flaky_test_storage.py
+++ b/tests/unit/observer/test_flaky_test_storage.py
@@ -3,6 +3,7 @@
 """Unit tests for flaky test storage manager."""
 
 import json
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -133,14 +134,18 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old session reports."""
         storage = FlakyTestStorageManager(tmp_path, session_retention_days=3)
 
+        today = datetime.now(UTC)
+        old_date = (today - timedelta(days=10)).strftime("%Y-%m-%d")
+        recent_date = today.strftime("%Y-%m-%d")
+
         # Manually create old session files
-        old_date_dir = storage.session_dir / "2026-06-01"
+        old_date_dir = storage.session_dir / old_date
         old_date_dir.mkdir(parents=True, exist_ok=True)
         old_file = old_date_dir / "10-00-00-session.json"
         old_file.write_text("{}")
 
         # Create recent session file
-        today_date_dir = storage.session_dir / "2026-06-07"
+        today_date_dir = storage.session_dir / recent_date
         today_date_dir.mkdir(parents=True, exist_ok=True)
         today_file = today_date_dir / "10-00-00-session.json"
         today_file.write_text("{}")
@@ -157,12 +162,16 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old aggregation reports."""
         storage = FlakyTestStorageManager(tmp_path, aggregation_retention_days=30)
 
+        today = datetime.now(UTC)
+        old_date = (today - timedelta(days=60)).strftime("%Y-%m-%d")
+        recent_date = today.strftime("%Y-%m-%d")
+
         # Manually create old aggregation file
-        old_agg = storage.aggregation_dir / "2026-05-01-aggregation.json"
+        old_agg = storage.aggregation_dir / f"{old_date}-aggregation.json"
         old_agg.write_text("{}")
 
         # Create recent aggregation file
-        recent_agg = storage.aggregation_dir / "2026-06-07-aggregation.json"
+        recent_agg = storage.aggregation_dir / f"{recent_date}-aggregation.json"
         recent_agg.write_text("{}")
 
         # Run cleanup


### PR DESCRIPTION
## Summary

Two bugs causing PR #260 to loop through all 6 fix passes before escalating:

- **No-progress text comparison was unreliable**: The check required AI-generated concern summaries to match exactly across consecutive loops. LLM output varies even for the same root issue, so the check never fired. Removed the text-equality condition — only the prior-fix-pushed-nothing signal and same-SHA guard are needed.
- **TOCTOU race on state save**: After `_run_fix_pass()` returns (~10-minute subprocess), the reviewer saved its in-memory state (loaded before the fix pass started), overwriting external escalation written to disk during the wait (e.g. by the watchdog). Now re-reads `escalated_needs_human` from disk after the fix pass and preserves it.

## Test plan

- [x] `test_phase1_repeated_concerns_after_noop_fix_escalates` — still passes (same text still escalates)
- [x] `test_phase1_repeated_concerns_different_text_still_escalates` — new: escalation fires despite different concern text
- [x] `test_phase1_fix_pass_preserves_external_escalation` — new: external escalation survives post-fix-pass save
- [x] Full reviewer test suite: 88 passed
- [x] Golden gate: 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)