### PR TITLE
feat(reviewer): WO-3 CI-green escalation retraction

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -320,3 +320,9 @@ both Claude controller lanes so status surfaces do not leave Haiku looking runna
 
 Controller startup also normalizes matching persisted Sonnet+Opus weekly resets
 to account-wide metadata so `loop_controller_state.json` reports the same scope.
+
+## 2026-06-10 — fix(reviewer): make no-progress detection reliable + preserve external escalation
+
+Root cause: no-progress check required AI concern summaries to match exactly (text comparison),
+but LLM output varies. Also: TOCTOU race where reviewer overwrote watchdog's escalation after
+fix pass. Fixed both; 88 reviewer tests pass.

--- a/.console/log.md
+++ b/.console/log.md
@@ -326,3 +326,7 @@ to account-wide metadata so `loop_controller_state.json` reports the same scope.
 Root cause: no-progress check required AI concern summaries to match exactly (text comparison),
 but LLM output varies. Also: TOCTOU race where reviewer overwrote watchdog's escalation after
 fix pass. Fixed both; 88 reviewer tests pass.
+
+## 2026-06-10 — fix(tests): use dynamic dates in flaky storage cleanup tests
+
+Hardcoded 2026-06-07 "recent" date fell behind the 3-day retention window causing CI failures.

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,11 @@
+## 2026-06-10 — WO-3 extension: CI-green escalation retraction
+
+Added `_MAX_CI_GREEN_RETRACTIONS` guard and CI-green retraction path to `_phase1`.
+When a PR is escalated (same head, no new push) but CI is fully green, the reviewer
+now retracts the escalation once and resumes automated review — prevents diff-truncation
+false positives from permanently blocking autonomy PRs. Bounded by 1 retraction to
+prevent loops. 3 new unit tests; 91/91 reviewer tests pass.
+
 ## 2026-06-08 — WO-6 (items 2+3): backend-crash budget separation + stuck-green escalation
 
 ## 2026-06-08 — WO-1 backfill: all 20 closed-unmerged PRs audited; 14 historical close-receipts posted

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1785,17 +1785,21 @@ def _phase1(
         )
         return
 
+    # Trigger on the second no-change pass at the same head — no text comparison
+    # needed.  LLM-generated summaries are not bit-identical across loops even
+    # when the root issue is unchanged, so requiring text equality was
+    # unreliable and caused the reviewer to spin through all max_fix_attempts
+    # before escalating.
     repeated_no_progress = (
         state.get("fix_attempts", 0) > 0
         and state.get("last_fix_pass_pushed") is False
         and current_head_sha
         and current_head_sha == str(state.get("last_concerns_head_sha") or "").strip()
-        and normalized_summary == str(state.get("last_concerns_summary") or "").strip()
     )
     if repeated_no_progress:
         detail = (
-            "The previous automated fix pass pushed no changes, and a fresh self-review on the "
-            "same PR head produced the same concerns. Further autonomous retries would repeat "
+            "The previous automated fix pass pushed no changes; a fresh self-review on the "
+            "same PR head still finds concerns. Further autonomous retries would repeat "
             "without changing the branch.\n\nLatest concerns:\n\n"
             f"{summary}"
         )
@@ -1924,6 +1928,23 @@ def _phase1(
             state["fix_attempts"],
             reviewer.max_fix_attempts,
         )
+    # The fix pass executor can run for minutes.  An external process (e.g. the
+    # watchdog) may have updated escalated_needs_human on disk while we waited.
+    # Re-read the escalation flag so we don't overwrite it on save.
+    try:
+        disk = _load_state(state_path)
+        if disk.get("escalated_needs_human") and not state.get("escalated_needs_human"):
+            state["escalated_needs_human"] = True
+            state["escalated_head_sha"] = disk.get("escalated_head_sha") or state.get(
+                "escalated_head_sha"
+            )
+            logger.info(
+                "pr_review_watcher: PR #%d external escalation detected after fix pass; "
+                "preserving escalated_needs_human=True",
+                pr_number,
+            )
+    except Exception:
+        pass
     _save_state(state_path, state)
 
 

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -768,6 +768,12 @@ _MAX_REQUEUES = 3
 # must not silently stall the loop, nor merge on red).
 _MAX_CI_WAIT_CYCLES = 20
 
+# WO-3: when a PR is escalated (same head, no new push) but CI is fully green,
+# retract the escalation once and allow the reviewer to re-evaluate. Bounded to
+# prevent infinite escalation→retraction loops on PRs whose concerns cannot be
+# resolved by automation alone (e.g. diff-truncation false positives).
+_MAX_CI_GREEN_RETRACTIONS = 1
+
 
 def _run_fix_pass(
     oc_root: Path,
@@ -1474,12 +1480,58 @@ def _phase1(
             )
             _save_state(state_path, state)
         else:
-            logger.info(
-                "pr_review_watcher: PR #%d awaiting human attention or new push; "
-                "skipping automated self-review",
-                pr_number,
-            )
-            return
+            # WO-3: if CI is green on the escalated head, the test suite has
+            # validated the implementation. Retract the escalation once so the
+            # reviewer can re-evaluate without a diff-truncation blind spot.
+            # Bounded by _MAX_CI_GREEN_RETRACTIONS to prevent loops.
+            _ci_green_retracted = state.get("ci_green_retraction_count", 0)
+            _did_ci_green_retract = False
+            if _ci_green_retracted < _MAX_CI_GREEN_RETRACTIONS:
+                _rcfg = settings.repos.get(repo_key)
+                if _rcfg and getattr(_rcfg, "auto_merge_on_ci_green", False):
+                    _rhead = ((pr_data.get("head") or {}).get("ref") or "").lower()
+                    if _rhead.startswith(("goal/", "test/", "improve/", "spec-author/")):
+                        _rignored = list(getattr(_rcfg, "ci_ignored_checks", []) or [])
+                        try:
+                            _rfailed = gh_client.get_failed_checks(
+                                owner, repo, pr_number, pr_data=pr_data,
+                                ignored_checks=_rignored,
+                            )
+                            if not _rfailed:
+                                _retract_flag(
+                                    state, gh_client, owner, repo,
+                                    resolution=(
+                                        "CI green on unchanged head — test suite validates "
+                                        "implementation; automated review resumed"
+                                    ),
+                                )
+                                state["escalated_needs_human"] = False
+                                state.pop("escalated_head_sha", None)
+                                state["no_verdict_passes"] = 0
+                                state["fix_attempts"] = 0
+                                state.pop("last_concerns_summary", None)
+                                state.pop("last_concerns_head_sha", None)
+                                state.pop("last_fix_pass_pushed", None)
+                                state["ci_green_retraction_count"] = _ci_green_retracted + 1
+                                logger.info(
+                                    "pr_review_watcher: PR #%d CI green on escalated head; "
+                                    "retracting escalation for automated review retry "
+                                    "(retraction %d/%d)",
+                                    pr_number,
+                                    _ci_green_retracted + 1,
+                                    _MAX_CI_GREEN_RETRACTIONS,
+                                )
+                                _save_state(state_path, state)
+                                _did_ci_green_retract = True
+                        except Exception:
+                            pass  # CI check failed — fall through to skip
+            if not _did_ci_green_retract:
+                logger.info(
+                    "pr_review_watcher: PR #%d awaiting human attention or new push; "
+                    "skipping automated self-review",
+                    pr_number,
+                )
+                return
 
     # ── CI-green precondition ────────────────────────────────────────────────
     # For autonomy PRs on repos that opt in, green CI is a PRECONDITION for

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -1778,3 +1778,106 @@ def test_new_push_retracts_stale_concerns_and_reposts_for_new_head(tmp_path: Pat
     assert loaded["last_concerns_head_sha"] == "new_sha"
     assert loaded["last_concerns_summary"] == "new concerns"
     assert loaded["last_fix_pass_pushed"] is True
+
+
+# ── WO-3: CI-green retraction ─────────────────────────────────────────────────
+
+
+def _ci_green_settings() -> MagicMock:
+    """Settings with auto_merge_on_ci_green=True for WO-3 tests."""
+    repo_cfg = MagicMock(
+        auto_merge_on_ci_green=True,
+        ci_ignored_checks=[],
+    )
+    return MagicMock(
+        reviewer=REVIEWER_CFG,
+        repos={REPO_KEY: repo_cfg},
+        plane=MagicMock(base_url="http://plane.local", project_id="proj", workspace_slug="ws"),
+    )
+
+
+def test_wo3_ci_green_retracts_escalation_and_resumes(tmp_path: Path) -> None:
+    """WO-3: CI green on escalated head retracts escalation and resumes review (→ LGTM)."""
+    state, sp_ = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="same_sha",
+        escalation_comment_id=9001,
+        no_verdict_passes=2,
+        ci_green_retraction_count=0,
+        plane_task_id=None,
+    )
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = []  # CI green
+    gh.list_pr_comments.return_value = [
+        {"id": 9001, "body": "<!-- bot -->\n**Needs human attention** (reason=`concerns`)."},
+    ]
+
+    with (
+        patch.object(watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._phase1(
+            state, sp_, _pr_data(head_sha="same_sha"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", _ci_green_settings(),
+        )
+
+    loaded = watcher._load_state(sp_)
+    assert loaded.get("ci_green_retraction_count") == 1
+    assert not loaded.get("escalated_needs_human")
+    gh.update_comment.assert_called_once()
+    retracted = gh.update_comment.call_args[0][3]
+    assert "CI green on unchanged head" in retracted
+
+
+def test_wo3_ci_green_retraction_bounded_by_max(tmp_path: Path) -> None:
+    """WO-3: once retraction count hits _MAX_CI_GREEN_RETRACTIONS, skip still applies."""
+    state, sp_ = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="same_sha",
+        escalation_comment_id=9002,
+        ci_green_retraction_count=watcher._MAX_CI_GREEN_RETRACTIONS,  # already exhausted
+        plane_task_id=None,
+    )
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = []  # CI green — but retraction budget exhausted
+
+    with patch.object(watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}):
+        watcher._phase1(
+            state, sp_, _pr_data(head_sha="same_sha"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", _ci_green_settings(),
+        )
+
+    loaded = watcher._load_state(sp_)
+    assert loaded.get("escalated_needs_human") is True
+    assert loaded.get("ci_green_retraction_count") == watcher._MAX_CI_GREEN_RETRACTIONS
+    gh.update_comment.assert_not_called()
+
+
+def test_wo3_ci_red_does_not_retract(tmp_path: Path) -> None:
+    """WO-3: CI failures prevent retraction; PR stays escalated."""
+    state, sp_ = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="same_sha",
+        escalation_comment_id=9003,
+        ci_green_retraction_count=0,
+        plane_task_id=None,
+    )
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = [{"name": "Tests", "conclusion": "FAILURE"}]  # CI red
+
+    with patch.object(watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}):
+        watcher._phase1(
+            state, sp_, _pr_data(head_sha="same_sha"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", _ci_green_settings(),
+        )
+
+    loaded = watcher._load_state(sp_)
+    assert loaded.get("escalated_needs_human") is True
+    assert loaded.get("ci_green_retraction_count", 0) == 0
+    gh.update_comment.assert_not_called()

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -257,6 +257,74 @@ def test_phase1_repeated_concerns_after_noop_fix_escalates(tmp_path: Path) -> No
     assert state["escalated_head_sha"] == "abc123"
 
 
+def test_phase1_repeated_concerns_different_text_still_escalates(tmp_path: Path) -> None:
+    """No-progress escalation fires even when LLM produces different concern text."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=1,
+        fix_attempts=1,
+        last_fix_pass_pushed=False,
+        last_concerns_head_sha="abc123",
+        last_concerns_summary="old concern wording from prior loop",
+    )
+    gh = _make_gh()
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "slightly different wording same issue"},
+        ),
+        patch.object(watcher, "_run_fix_pass") as mock_fix,
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc123"), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    mock_fix.assert_not_called()
+    mock_escalate.assert_called_once()
+
+
+def test_phase1_fix_pass_preserves_external_escalation(tmp_path: Path) -> None:
+    """External escalation written to disk during fix pass is not overwritten on save."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=0,
+        fix_attempts=0,
+    )
+    gh = _make_gh()
+
+    def _fix_pass_writes_escalation(*_args, **_kwargs):
+        # Simulate watchdog writing escalated_needs_human=True while fix pass runs
+        import json
+        disk = json.loads(sp.read_text())
+        disk["escalated_needs_human"] = True
+        disk["escalated_head_sha"] = "headsha"
+        sp.write_text(json.dumps(disk))
+        return False  # pushed=False
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "some concerns"},
+        ),
+        patch.object(watcher, "_run_fix_pass", side_effect=_fix_pass_writes_escalation),
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="headsha"), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    import json
+    saved = json.loads(sp.read_text())
+    assert saved["escalated_needs_human"] is True, "external escalation must survive save"
+    mock_escalate.assert_not_called()
+
+
 def test_phase1_concerns_closes_and_requeues_at_fix_cap(tmp_path: Path) -> None:
     # max_fix_attempts=2, already at 2 — CONCERNS must close+requeue, NOT merge.
     state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=1, fix_attempts=2)

--- a/tests/unit/observer/test_flaky_test_storage.py
+++ b/tests/unit/observer/test_flaky_test_storage.py
@@ -3,6 +3,7 @@
 """Unit tests for flaky test storage manager."""
 
 import json
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -133,14 +134,18 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old session reports."""
         storage = FlakyTestStorageManager(tmp_path, session_retention_days=3)
 
+        today = datetime.now(UTC)
+        old_date = (today - timedelta(days=10)).strftime("%Y-%m-%d")
+        recent_date = today.strftime("%Y-%m-%d")
+
         # Manually create old session files
-        old_date_dir = storage.session_dir / "2026-06-01"
+        old_date_dir = storage.session_dir / old_date
         old_date_dir.mkdir(parents=True, exist_ok=True)
         old_file = old_date_dir / "10-00-00-session.json"
         old_file.write_text("{}")
 
         # Create recent session file
-        today_date_dir = storage.session_dir / "2026-06-07"
+        today_date_dir = storage.session_dir / recent_date
         today_date_dir.mkdir(parents=True, exist_ok=True)
         today_file = today_date_dir / "10-00-00-session.json"
         today_file.write_text("{}")
@@ -157,12 +162,16 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old aggregation reports."""
         storage = FlakyTestStorageManager(tmp_path, aggregation_retention_days=30)
 
+        today = datetime.now(UTC)
+        old_date = (today - timedelta(days=60)).strftime("%Y-%m-%d")
+        recent_date = today.strftime("%Y-%m-%d")
+
         # Manually create old aggregation file
-        old_agg = storage.aggregation_dir / "2026-05-01-aggregation.json"
+        old_agg = storage.aggregation_dir / f"{old_date}-aggregation.json"
         old_agg.write_text("{}")
 
         # Create recent aggregation file
-        recent_agg = storage.aggregation_dir / "2026-06-07-aggregation.json"
+        recent_agg = storage.aggregation_dir / f"{recent_date}-aggregation.json"
         recent_agg.write_text("{}")
 
         # Run cleanup


### PR DESCRIPTION
## Summary

Extends WO-3 (self-retracting reviewer verdicts) with a CI-green retraction path.

**Problem**: When a PR is escalated (`escalated_needs_human=True`) with the **same head SHA** (no new push), the reviewer permanently skips it. This creates an infinite wait when the reviewer's concerns were false positives due to diff truncation — the implementation is present and verified by the test suite, but the reviewer couldn't see it.

**Fix**: In `_phase1`, after the "same head SHA → skip" check, add a WO-3 path:
- If `auto_merge_on_ci_green` is enabled for the repo and CI is fully green on the escalated head
- Retract the escalation/concerns comment with "CI green on unchanged head — test suite validates implementation"
- Clear `escalated_needs_human`, reset `fix_attempts=0`, and fall through to normal self-review

**Bounds**: `_MAX_CI_GREEN_RETRACTIONS=1` — only one automatic CI-green retraction allowed per PR. If the reviewer escalates again with the same head after retraction, it stays escalated (operator action required).

## Test plan
- [ ] `test_wo3_ci_green_retracts_escalation_and_resumes` — retraction fires when CI green
- [ ] `test_wo3_ci_green_retraction_bounded_by_max` — no retraction when count exhausted
- [ ] `test_wo3_ci_red_does_not_retract` — CI red keeps the skip
- [ ] All 91 reviewer tests pass
- [ ] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)