### PR TITLE
feat(observer): flaky_metrics — correct, validated flakiness metric library

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,17 @@
+## 2026-06-12 — feat(observer): flaky_metrics — correct, validated metric library
+
+Implements the flakiness metrics the reverted #269 botched, as pure validated functions in
+observer/flaky_metrics.py: 7 per-test (failure_rate, failure_entropy [normalised binary Shannon],
+streak_variance, recovery_time_percentile_90, duration_stability [CoV], environment_correlation
+[Pearson], isolation_score) and 7 repository-level (flaky_test_percentage, median_failure_rate,
+flaky_growth_rate, category_concentration, critical_test_flakiness_ratio, flaky_velocity,
+repository_health_score). Each has well-defined edge behaviour (div-by-zero, empty, no-variation)
+and a derived-ground-truth test (80 tests). Expected values are correct: e.g. failure_entropy(1,99)
+= 0.080793, NOT the 0.081296 the reverted suite asserted. The 3 per-test metrics computable from
+collected data (failure_entropy, streak_variance, duration_stability) are wired into FlakyTestMetric
++ the reporter + to_dict; environment_correlation and isolation_score are implemented+tested but need
+a collector that records env vectors / serial-vs-parallel failures before wiring (documented).
+
 ## 2026-06-12 — fix(reviewer): require CI *settled* before declaring green (root cause of #269 merging red)
 
 The merge gate declared CI green whenever get_failed_checks returned [] — but that only means

--- a/src/operations_center/observer/flaky_metrics.py
+++ b/src/operations_center/observer/flaky_metrics.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Pure, validated computations for flaky-test metrics.
+
+This module is the *correct* implementation of the per-test and repository-level
+flakiness metrics. Each function is a pure function over explicit inputs with
+well-defined edge-case behaviour (division by zero, empty input, no variation),
+so the results are testable against derived ground truth rather than hand-typed
+constants.
+
+Per-test metrics operate on a single test's run history; repository-level metrics
+operate on aggregates across the suite. Two per-test metrics —
+:func:`environment_correlation` and :func:`isolation_score` — require inputs that
+the current pytest collector does not yet capture (per-run environment vectors and
+serial-vs-parallel failure counts). They are implemented and tested as pure
+functions so the computation is correct and ready; wiring them needs a collector
+that records those inputs (tracked separately).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+# ── Per-test metrics ─────────────────────────────────────────────────────────
+
+
+def failure_rate(failures: int, total_runs: int) -> float:
+    """Fraction of runs that failed, in [0, 1]. Zero runs → 0.0."""
+    if total_runs <= 0:
+        return 0.0
+    return failures / total_runs
+
+
+def failure_entropy(pass_count: int, fail_count: int) -> float:
+    """Normalised binary Shannon entropy of the pass/fail distribution, in [0, 1].
+
+    H = -(p·log2 p + q·log2 q). Already normalised because a 2-outcome
+    distribution has maximum entropy of exactly 1 bit (at a 50/50 split). A
+    deterministic test (all pass or all fail) has entropy 0.
+    """
+    total = pass_count + fail_count
+    if total <= 0 or pass_count <= 0 or fail_count <= 0:
+        return 0.0
+    p = pass_count / total
+    q = fail_count / total
+    return -(p * math.log2(p) + q * math.log2(q))
+
+
+def streak_variance(outcomes: Sequence[bool]) -> float | None:
+    """Population variance of consecutive same-outcome streak lengths, normalised
+    by the mean streak length (a coefficient-of-dispersion form).
+
+    ``outcomes`` is the chronological pass/fail sequence (True = pass). Returns
+    ``None`` for fewer than two runs (undefined). A single uninterrupted streak
+    and a perfectly alternating sequence both yield 0.0 (no dispersion).
+    """
+    if len(outcomes) < 2:
+        return None
+    streaks: list[int] = []
+    current = 1
+    for prev, cur in zip(outcomes, outcomes[1:]):
+        if cur == prev:
+            current += 1
+        else:
+            streaks.append(current)
+            current = 1
+    streaks.append(current)
+    mean = sum(streaks) / len(streaks)
+    if mean == 0:
+        return 0.0
+    variance = sum((s - mean) ** 2 for s in streaks) / len(streaks)
+    return variance / mean
+
+
+def percentile(values: Sequence[float], pct: float) -> float | None:
+    """Linear-interpolation percentile (pct in [0, 100]); ``None`` if empty."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return float(ordered[lo])
+    frac = rank - lo
+    return ordered[lo] * (1 - frac) + ordered[hi] * frac
+
+
+def recovery_time_percentile_90(recovery_times: Sequence[float]) -> float | None:
+    """90th-percentile recovery time (runs/days from a failure to the next pass).
+
+    ``recovery_times`` is the list of observed recovery times; never-recovered
+    failures should be passed as ``math.inf``. ``None`` when there were no
+    failures to recover from.
+    """
+    return percentile(recovery_times, 90.0)
+
+
+def duration_stability(durations: Sequence[float]) -> float | None:
+    """Coefficient of variation (stddev / mean) of run durations.
+
+    0.0 for a single run or perfectly identical durations. ``None`` when the
+    mean is 0 (all-zero durations → undefined, no division by zero).
+    """
+    if not durations:
+        return None
+    n = len(durations)
+    mean = sum(durations) / n
+    if mean == 0:
+        return None
+    variance = sum((d - mean) ** 2 for d in durations) / n
+    return math.sqrt(variance) / mean
+
+
+def environment_correlation(
+    failures: Sequence[float], env_values: Sequence[float]
+) -> float | None:
+    """Pearson correlation between per-run failure indicators and an environment
+    metric, in [-1, 1].
+
+    Returns ``None`` for empty/mismatched input. Returns 0.0 when either series
+    has no variation (correlation undefined → treated as "no relationship").
+    """
+    n = len(failures)
+    if n == 0 or n != len(env_values):
+        return None
+    mean_f = sum(failures) / n
+    mean_e = sum(env_values) / n
+    cov = sum((f - mean_f) * (e - mean_e) for f, e in zip(failures, env_values))
+    var_f = sum((f - mean_f) ** 2 for f in failures)
+    var_e = sum((e - mean_e) ** 2 for e in env_values)
+    if var_f == 0 or var_e == 0:
+        return 0.0
+    return cov / math.sqrt(var_f * var_e)
+
+
+def isolation_score(serial_failures: int, parallel_failures: int) -> float:
+    """How much a test's failures are explained by parallel execution.
+
+    ``1 - parallel_failures / serial_failures``: 1.0 = fully isolated (fails the
+    same or less in parallel), values toward 0 = order/parallelism-sensitive, and
+    negative = fails *more* in parallel than serial (anomalous). With no serial
+    failures: 1.0 if it never fails at all, else 0.0 (parallel-only failures are
+    the worst isolation).
+    """
+    if serial_failures == 0:
+        return 1.0 if parallel_failures == 0 else 0.0
+    return 1.0 - parallel_failures / serial_failures
+
+
+# ── Repository-level metrics ─────────────────────────────────────────────────
+
+
+def flaky_test_percentage(flaky_count: int, total_tests: int) -> float:
+    """Fraction of the suite that is flaky, in [0, 1]. No tests → 0.0."""
+    if total_tests <= 0:
+        return 0.0
+    return flaky_count / total_tests
+
+
+def median_failure_rate(failure_rates: Sequence[float]) -> float:
+    """Median failure rate across flaky tests; 0.0 when there are none."""
+    if not failure_rates:
+        return 0.0
+    ordered = sorted(failure_rates)
+    n = len(ordered)
+    mid = n // 2
+    if n % 2 == 1:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def flaky_growth_rate(previous_count: int, current_count: int) -> float:
+    """Relative change in flaky-test count: ``(cur - prev) / prev``.
+
+    No previous flaky tests: 0.0 if there are still none, else ``inf`` (growth
+    from zero is unbounded).
+    """
+    if previous_count == 0:
+        return 0.0 if current_count == 0 else math.inf
+    return (current_count - previous_count) / previous_count
+
+
+def category_concentration(category_counts: dict[str, int]) -> float:
+    """Share of flaky tests in the single largest root-cause category, in [0, 1].
+
+    1.0 = all in one category, → 0 = evenly spread. Empty → 0.0.
+    """
+    total = sum(category_counts.values())
+    if total <= 0:
+        return 0.0
+    return max(category_counts.values()) / total
+
+
+def critical_test_flakiness_ratio(critical_flaky: int, total_critical: int) -> float:
+    """Fraction of critical-path tests that are flaky, in [0, 1]. None → 0.0."""
+    if total_critical <= 0:
+        return 0.0
+    return critical_flaky / total_critical
+
+
+def flaky_velocity(new_flaky_count: int, window_days: float) -> float:
+    """Newly-detected flaky tests per day over the window. Non-positive window → 0.0."""
+    if window_days <= 0:
+        return 0.0
+    return new_flaky_count / window_days
+
+
+def repository_health_score(
+    flaky_pct: float,
+    growth_rate: float,
+    critical_ratio: float,
+    unknown_ratio: float,
+) -> float:
+    """Composite suite-health score in [0, 1] (1.0 = healthy).
+
+    Starts from flakiness headroom against a 10%-flaky ceiling and subtracts
+    penalties for flaky growth, flakiness on critical-path tests, and
+    uncategorised (hard-to-diagnose) flakiness::
+
+        health = (1 - flaky_pct / 0.10)
+                 - 0.5 · growth_rate
+                 - 2.0 · critical_ratio
+                 - 0.3 · unknown_ratio
+
+    clamped to [0, 1].
+    """
+    score = (
+        (1.0 - flaky_pct / 0.10)
+        - 0.5 * growth_rate
+        - 2.0 * critical_ratio
+        - 0.3 * unknown_ratio
+    )
+    return max(0.0, min(1.0, score))

--- a/src/operations_center/observer/flaky_test_models.py
+++ b/src/operations_center/observer/flaky_test_models.py
@@ -48,6 +48,12 @@ class FlakyTestMetric:
     last_failure_reason: str = ""
     flakiness_score: float = 0.0
     confidence: float = 0.0
+    # Derived flakiness metrics (see observer.flaky_metrics). Normalised
+    # pass/fail entropy in [0,1]; dispersion of streak lengths; coefficient of
+    # variation of run durations. None where undefined (e.g. <2 runs, zero mean).
+    failure_entropy: float = 0.0
+    streak_variance: float | None = None
+    duration_stability: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert metric to dictionary for JSON serialization."""
@@ -68,6 +74,13 @@ class FlakyTestMetric:
             "last_failure_reason": self.last_failure_reason,
             "flakiness_score": round(self.flakiness_score, 4),
             "confidence": round(self.confidence, 4),
+            "failure_entropy": round(self.failure_entropy, 4),
+            "streak_variance": (
+                round(self.streak_variance, 4) if self.streak_variance is not None else None
+            ),
+            "duration_stability": (
+                round(self.duration_stability, 4) if self.duration_stability is not None else None
+            ),
         }
 
 

--- a/src/operations_center/observer/flaky_test_reporter.py
+++ b/src/operations_center/observer/flaky_test_reporter.py
@@ -24,6 +24,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from . import flaky_metrics
 from .flaky_test_models import (
     FlakynessCategory,
     FlakyTestConfig,
@@ -129,6 +130,14 @@ class FlakyTestReporter:
         retry_success_count = self._count_retry_successes(runs)
         recovery_time = self._compute_recovery_time(runs)
 
+        # Derived metrics (observer.flaky_metrics) — normalised entropy, streak
+        # dispersion, and duration coefficient-of-variation over this test's runs.
+        outcomes = [r.outcome == TestOutcome.PASSED for r in runs]
+        durations = [r.duration for r in runs]
+        failure_entropy = flaky_metrics.failure_entropy(run_count - failure_count, failure_count)
+        streak_variance = flaky_metrics.streak_variance(outcomes)
+        duration_stability = flaky_metrics.duration_stability(durations)
+
         last_failure_reason = ""
         for r in reversed(runs):
             if r.outcome == TestOutcome.FAILED and r.exception_type:
@@ -150,6 +159,9 @@ class FlakyTestReporter:
             last_failure_reason=last_failure_reason,
             flakiness_score=flakiness_score,
             confidence=confidence,
+            failure_entropy=failure_entropy,
+            streak_variance=streak_variance,
+            duration_stability=duration_stability,
         )
 
     def _compute_flakiness_score(

--- a/tests/unit/observer/test_flaky_metrics.py
+++ b/tests/unit/observer/test_flaky_metrics.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Validated tests for flaky_metrics.
+
+Expected values are derived from the metric definitions (and cross-checked against
+independent computation), not hand-typed approximations. Notably, the binary
+Shannon entropy of a 1/99 split is 0.080793 bits — an earlier, reverted test suite
+asserted 0.081296, which does not match any correct entropy computation.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from operations_center.observer import flaky_metrics as m
+
+P, F = True, False  # pass / fail
+
+
+# ── failure_rate ─────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "failures,total,expected",
+    [
+        (0, 0, 0.0),
+        (0, 1, 0.0),
+        (1, 1, 1.0),
+        (1, 20, 0.05),
+        (1, 2, 0.5),
+        (9999, 10000, 0.9999),
+    ],
+)
+def test_failure_rate(failures, total, expected):
+    assert m.failure_rate(failures, total) == pytest.approx(expected)
+
+
+# ── failure_entropy ──────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "passes,fails,expected",
+    [
+        (10, 0, 0.0),  # deterministic
+        (0, 10, 0.0),
+        (5, 5, 1.0),  # maximum entropy at 50/50
+        (1, 0, 0.0),
+        (0, 0, 0.0),
+        (1, 99, 0.0807931),  # NOT 0.081296 (the reverted suite's wrong value)
+        (99, 1, 0.0807931),  # symmetric
+        (10, 1, 0.4394970),
+    ],
+)
+def test_failure_entropy(passes, fails, expected):
+    assert m.failure_entropy(passes, fails) == pytest.approx(expected, abs=1e-6)
+
+
+def test_failure_entropy_in_unit_range():
+    for passes in range(0, 11):
+        for fails in range(0, 11):
+            assert 0.0 <= m.failure_entropy(passes, fails) <= 1.0 + 1e-9
+
+
+# ── streak_variance ──────────────────────────────────────────────────────────
+def test_streak_variance_single_run_undefined():
+    assert m.streak_variance([P]) is None
+
+
+@pytest.mark.parametrize(
+    "outcomes,expected",
+    [
+        ([P, P, P, P, P], 0.0),  # one streak → no dispersion
+        ([F, F, F, F, F], 0.0),
+        ([P, F] * 5, 0.0),  # all streaks length 1
+        ([P, P, P, F, F], 0.1),  # streaks [3,2]: var .25 / mean 2.5
+    ],
+)
+def test_streak_variance(outcomes, expected):
+    assert m.streak_variance(outcomes) == pytest.approx(expected)
+
+
+def test_streak_variance_mixed():
+    # streaks [5,1,5]: mean 11/3, var = ((5-11/3)^2*2 + (1-11/3)^2)/3
+    mean = 11 / 3
+    var = ((5 - mean) ** 2 * 2 + (1 - mean) ** 2) / 3
+    assert m.streak_variance([P] * 5 + [F] + [P] * 5) == pytest.approx(var / mean)
+
+
+# ── recovery_time_percentile_90 ──────────────────────────────────────────────
+def test_recovery_p90_empty_is_none():
+    assert m.recovery_time_percentile_90([]) is None
+
+
+def test_recovery_p90_single():
+    assert m.recovery_time_percentile_90([5.0]) == 5.0
+
+
+def test_recovery_p90_linear():
+    # p90 of 1..10 by linear interpolation: rank 8.1 → 9*0.9 + 10*0.1
+    assert m.recovery_time_percentile_90([float(i) for i in range(1, 11)]) == pytest.approx(9.1)
+
+
+def test_recovery_p90_with_never_recovered():
+    assert m.recovery_time_percentile_90([1.0, 2.0, math.inf, math.inf]) == math.inf
+
+
+# ── duration_stability ───────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "durations,expected",
+    [
+        ([1.0, 1.0, 1.0], 0.0),
+        ([2.0], 0.0),
+        ([1.0, 2.0, 3.0, 4.0, 5.0], math.sqrt(2.0) / 3.0),  # std √2, mean 3
+    ],
+)
+def test_duration_stability(durations, expected):
+    assert m.duration_stability(durations) == pytest.approx(expected)
+
+
+def test_duration_stability_all_zero_is_none():
+    assert m.duration_stability([0.0, 0.0, 0.0]) is None
+
+
+def test_duration_stability_empty_is_none():
+    assert m.duration_stability([]) is None
+
+
+# ── environment_correlation ──────────────────────────────────────────────────
+def test_env_corr_perfect_positive():
+    f = [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    assert m.environment_correlation(f, list(f)) == pytest.approx(1.0)
+
+
+def test_env_corr_perfect_negative():
+    f = [1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+    e = [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    assert m.environment_correlation(f, e) == pytest.approx(-1.0)
+
+
+def test_env_corr_no_variation_is_zero():
+    assert m.environment_correlation([1, 1, 1], [1, 1, 1]) == 0.0
+    assert m.environment_correlation([0, 0, 0], [1, 2, 3]) == 0.0
+
+
+def test_env_corr_empty_or_mismatched_is_none():
+    assert m.environment_correlation([], []) is None
+    assert m.environment_correlation([1, 0], [1]) is None
+
+
+# ── isolation_score ──────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "serial,parallel,expected",
+    [
+        (0, 0, 1.0),
+        (10, 0, 1.0),
+        (0, 10, 0.0),
+        (10, 10, 0.0),
+        (10, 5, 0.5),
+        (5, 10, -1.0),
+    ],
+)
+def test_isolation_score(serial, parallel, expected):
+    assert m.isolation_score(serial, parallel) == pytest.approx(expected)
+
+
+# ── repository-level ─────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "flaky,total,expected",
+    [(0, 0, 0.0), (0, 1, 0.0), (1, 1, 1.0), (5, 100, 0.05), (1, 10000, 0.0001)],
+)
+def test_flaky_test_percentage(flaky, total, expected):
+    assert m.flaky_test_percentage(flaky, total) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "rates,expected",
+    [
+        ([], 0.0),
+        ([0.1], 0.1),
+        ([0.1, 0.2], 0.15),
+        ([0.1, 0.2, 0.3], 0.2),
+        ([0.01, 0.5, 0.99], 0.5),
+    ],
+)
+def test_median_failure_rate(rates, expected):
+    assert m.median_failure_rate(rates) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "prev,cur,expected",
+    [
+        (0, 0, 0.0),
+        (1, 1, 0.0),
+        (10, 12, 0.2),
+        (10, 8, -0.2),
+        (10, 0, -1.0),
+        (5, 10, 1.0),
+    ],
+)
+def test_flaky_growth_rate(prev, cur, expected):
+    assert m.flaky_growth_rate(prev, cur) == pytest.approx(expected)
+
+
+def test_flaky_growth_rate_from_zero_is_inf():
+    assert m.flaky_growth_rate(0, 1) == math.inf
+
+
+@pytest.mark.parametrize(
+    "counts,expected",
+    [
+        ({}, 0.0),
+        ({"intermittent": 1}, 1.0),
+        ({"a": 1, "b": 1, "c": 1, "d": 1}, 0.25),
+        ({"a": 6, "b": 4}, 0.6),
+        ({"a": 1000, "b": 1}, 1000 / 1001),
+    ],
+)
+def test_category_concentration(counts, expected):
+    assert m.category_concentration(counts) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "crit_flaky,total_crit,expected",
+    [(0, 0, 0.0), (0, 1, 0.0), (1, 1, 1.0), (1, 10, 0.1), (1, 11, 1 / 11), (10, 100, 0.1)],
+)
+def test_critical_test_flakiness_ratio(crit_flaky, total_crit, expected):
+    assert m.critical_test_flakiness_ratio(crit_flaky, total_crit) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "new,window,expected",
+    [(0, 7, 0.0), (1, 7, 1 / 7), (7, 7, 1.0), (10, 2, 5.0), (1, 0, 0.0)],
+)
+def test_flaky_velocity(new, window, expected):
+    assert m.flaky_velocity(new, window) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "flaky_pct,growth,critical,unknown,expected",
+    [
+        (0.0, 0.0, 0.0, 0.0, 1.0),
+        (0.05, 0.0, 0.0, 0.0, 0.5),
+        (0.10, 0.0, 0.0, 0.0, 0.0),
+        (0.05, 0.2, 0.0, 0.0, 0.4),
+        (0.05, 0.0, 0.1, 0.0, 0.3),
+        (0.05, 0.0, 0.0, 0.5, 0.35),
+        (0.20, 0.5, 0.2, 1.0, 0.0),  # clamped
+    ],
+)
+def test_repository_health_score(flaky_pct, growth, critical, unknown, expected):
+    assert m.repository_health_score(flaky_pct, growth, critical, unknown) == pytest.approx(expected)


### PR DESCRIPTION
## What

Implements the flakiness metrics as **pure, validated functions** in `observer/flaky_metrics.py` — the correct version of what the reverted **#269** attempted. (#269's tests targeted metrics that were never implemented and asserted miscomputed expected values; this re-derives every formula and value from definitions.)

**Per-test (7):** `failure_rate`, `failure_entropy` (normalised binary Shannon, `[0,1]`), `streak_variance` (dispersion of streak lengths), `recovery_time_percentile_90`, `duration_stability` (coefficient of variation), `environment_correlation` (Pearson), `isolation_score`.

**Repository-level (7):** `flaky_test_percentage`, `median_failure_rate`, `flaky_growth_rate`, `category_concentration`, `critical_test_flakiness_ratio`, `flaky_velocity`, `repository_health_score` (composite, clamped to `[0,1]`).

## Correctness

Every function has explicit, documented edge-case behaviour (division by zero, empty input, no variation → `None`/`0.0`/`inf` as appropriate), and is covered by **80 tests whose expected values are derived from the definitions**, not hand-typed.

Concretely: the binary Shannon entropy of a 1/99 split is **0.080793 bits**. The reverted #269 suite asserted `0.081296`, which matches no correct entropy computation — that mismatch (against its own inline formula) was one of the failures that held main red.

## Wiring

The three per-test metrics computable from **currently-collected** run data — `failure_entropy`, `streak_variance`, `duration_stability` — are added to `FlakyTestMetric`, populated in `FlakyTestReporter._analyze_test_runs`, and serialized in `to_dict` (new fields default-valued; no breakage).

`environment_correlation` and `isolation_score` are **implemented and tested** but deliberately **not wired**: they need a collector that records per-run environment vectors and serial-vs-parallel failure counts, which the pytest plugin does not capture today. Implementing them as correct pure functions now means the computation is ready when that collection lands — without fabricating inputs.

## Tests

`tests/unit/observer/test_flaky_metrics.py` — 80 tests, all green. Full `tests/unit/observer` suite passes (725) with the model/reporter wiring; `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)