### PR TITLE
fix(reviewer): require a completed check on the current head before green (divergence guard C)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,14 @@
+## 2026-06-13 — fix(reviewer): gate merge on the rebased head's CI (divergence guard C)
+
+#272 stopped merging on incomplete/red CI, but left a window: a freshly pushed/auto-rebased head
+has no check runs yet, so get_failed_checks and get_incomplete_checks both return [] and the gate
+would declare green on a head with NO CI — a stale pre-rebase green carrying a self-review LGTM
+straight to merge (the clean-but-semantically-broken merge that the goal/3476567d divergence rode).
+Fix: new GitHubPRClient.get_completed_checks; the self-review gate and the WO-3 no-progress
+direct-merge now additionally require ≥1 completed check on the current head (failed==[] AND
+pending==[] AND completed!=[]) before green/merge; otherwise defer via the existing ci_wait_cycles
+machinery. +4 tests (adapter + gate defers-on-no-checks) + mock defaults.
+
 ## 2026-06-12 — Stage 4: Verify implementation completeness and create PR-ready commit (✅ COMPLETE)
 
 ### Objective

--- a/src/operations_center/adapters/github_pr.py
+++ b/src/operations_center/adapters/github_pr.py
@@ -301,6 +301,49 @@ class GitHubPRClient:
                 pending.append(name)
         return pending
 
+    def get_completed_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]:
+        """Return names of checks in a terminal (``completed``) state for the PR head.
+
+        An EMPTY result means CI has not produced any result on the current head
+        yet — which happens in the window after a branch is pushed or auto-rebased,
+        before its checks register. In that window :meth:`get_failed_checks` and
+        :meth:`get_incomplete_checks` both return empty, so a gate that only asks
+        "nothing failed and nothing pending?" would declare green on a head that
+        has no CI at all. Callers gating a merge MUST additionally require this to
+        be non-empty so the green they merge on is the green of the *current* head.
+        """
+        if pr_data is None:
+            pr_data = self.get_pr(owner, repo, pr_number)
+        head_sha = (pr_data.get("head") or {}).get("sha", "")
+        if not head_sha:
+            return []
+        try:
+            check_runs = self.get_check_runs(owner, repo, head_sha)
+        except Exception:
+            return []
+        ignored = [s.lower() for s in (ignored_checks or [])]
+        latest: dict[str, dict] = {}
+        for cr in check_runs:
+            name = cr.get("name", "unknown")
+            if cr.get("id", 0) > latest.get(name, {}).get("id", 0):
+                latest[name] = cr
+        completed = []
+        for cr in latest.values():
+            if cr.get("status") == "completed":
+                name = cr.get("name", "unknown")
+                if ignored and any(pat in name.lower() for pat in ignored):
+                    continue
+                completed.append(name)
+        return completed
+
     def list_open_prs(self, owner: str, repo: str) -> list[dict]:
         resp = self._request(
             "GET",

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1655,14 +1655,31 @@ def _phase1(
                     pr_data=pr_data,
                     ignored_checks=ignored,
                 )
-                if pending:
+                # Guard C: the gating green must belong to the CURRENT head. An empty
+                # completed-checks list means CI has produced no result on this head
+                # yet (just pushed / auto-rebased) — failed==[] and pending==[] would
+                # otherwise read as green on a head that has no CI at all, so a stale
+                # pre-rebase green could carry a self-review LGTM straight to merge.
+                completed = gh_client.get_completed_checks(
+                    owner,
+                    repo,
+                    pr_number,
+                    pr_data=pr_data,
+                    ignored_checks=ignored,
+                )
+                if pending or not completed:
                     state["ci_wait_cycles"] = state.get("ci_wait_cycles", 0) + 1
+                    _why = (
+                        f"{len(pending)} still running: {', '.join(pending[:5])}"
+                        if pending
+                        else "no checks have reported on the current head yet"
+                    )
                     if state["ci_wait_cycles"] >= _MAX_CI_WAIT_CYCLES:
                         detail = (
-                            f"CI has not settled after {state['ci_wait_cycles']} checks "
-                            f"({len(pending)} still running: {', '.join(pending[:5])}). "
-                            f"Not merged (CI incomplete) and not closed (work preserved) "
-                            f"— needs a human to investigate stuck CI."
+                            f"CI has not settled-green on the current head after "
+                            f"{state['ci_wait_cycles']} checks ({_why}). Not merged (CI "
+                            f"incomplete) and not closed (work preserved) — needs a human "
+                            f"to investigate stuck CI."
                         )
                         record_escalation(
                             pr_number=pr_number,
@@ -1683,10 +1700,10 @@ def _phase1(
                         )
                         return
                     logger.info(
-                        "pr_review_watcher: PR #%d CI still running (%d pending, wait %d/%d) "
-                        "— deferring self-review until checks settle",
+                        "pr_review_watcher: PR #%d CI not settled-green on current head "
+                        "(%s, wait %d/%d) — deferring self-review",
                         pr_number,
-                        len(pending),
+                        _why,
                         state["ci_wait_cycles"],
                         _MAX_CI_WAIT_CYCLES,
                     )
@@ -1971,11 +1988,15 @@ def _phase1(
                         owner, repo, pr_number, pr_data=pr_data, ignored_checks=_ign_np
                     )
                     # Only merge on CI that has SETTLED — never while checks are still
-                    # running (no failure yet != green).
+                    # running (no failure yet != green) and never on a head with no
+                    # reported checks at all (Guard C: gating green must be on THIS head).
                     _pending_np = gh_client.get_incomplete_checks(
                         owner, repo, pr_number, pr_data=pr_data, ignored_checks=_ign_np
                     )
-                    if not _failed_np and not _pending_np:
+                    _completed_np = gh_client.get_completed_checks(
+                        owner, repo, pr_number, pr_data=pr_data, ignored_checks=_ign_np
+                    )
+                    if not _failed_np and not _pending_np and _completed_np:
                         logger.info(
                             "pr_review_watcher: PR #%d repeated no-progress after "
                             "CI-green retraction budget exhausted; CI still green — "

--- a/tests/integration/reviewer/test_ci_green_gate.py
+++ b/tests/integration/reviewer/test_ci_green_gate.py
@@ -131,6 +131,52 @@ class TestCIGreenGateValidation:
         state_after = load_pr_state(state_path)
         assert state_after["ci_wait_cycles"] == 1
 
+    def test_ci_with_no_checks_on_head_defers(
+        self,
+        tmp_path: Path,
+        audit_verdict_builder: AuditVerdictBuilder,
+    ):
+        """Guard C: no failed and no pending, but ZERO completed checks on the head
+        → defer, do NOT declare green.
+
+        This is the window right after a push or auto-rebase, before CI registers
+        on the new head: get_failed_checks and get_incomplete_checks both return []
+        for a head with no check runs, so a gate that only asks "nothing failed,
+        nothing pending?" would merge on a head with no CI at all (a stale
+        pre-rebase green carrying straight through).
+        """
+        settings = mock_settings()
+        gh = mock_github_client()
+
+        state = create_pr_state(
+            repo_key="TestRepo",
+            pr_number=42,
+            phase="self_review",
+            self_review_loops=0,
+        )
+        state_path = save_pr_state(tmp_path, state)
+
+        gh.get_failed_checks.return_value = []
+        gh.get_incomplete_checks.return_value = []
+        gh.get_completed_checks.return_value = []  # CI has not reported on this head
+
+        with patch.object(watcher, "_run_pipeline") as mock_pipeline:
+            watcher._phase1(
+                state,
+                state_path,
+                {"number": 42, "title": "Test PR", "draft": False, "head": {"ref": "goal/42"}},
+                gh,
+                "owner",
+                "TestRepo",
+                tmp_path,
+                tmp_path / "cfg.yaml",
+                settings,
+            )
+
+        mock_pipeline.assert_not_called()
+        gh.merge_pr.assert_not_called()
+        assert load_pr_state(state_path)["ci_wait_cycles"] == 1
+
     def test_ci_red_then_green_allows_merge_after_fix(
         self,
         tmp_path: Path,

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -71,6 +71,9 @@ def _make_gh(*, comment_id: int = 0) -> MagicMock:
     # Default: CI has settled (no checks still running). The premature-green gate
     # treats a non-empty result as "not green yet"; tests override as needed.
     gh.get_incomplete_checks.return_value = []
+    # Default: CI has reported on the current head (Guard C requires ≥1 completed
+    # check before declaring green); the "no CI on this head yet" path overrides [].
+    gh.get_completed_checks.return_value = ["Test (pytest)"]
     return gh
 
 

--- a/tests/unit/adapters/test_github_pr_cov.py
+++ b/tests/unit/adapters/test_github_pr_cov.py
@@ -381,6 +381,32 @@ def test_get_incomplete_checks_honors_ignored_and_latest_run(client):
     assert out == []
 
 
+def test_get_completed_checks_lists_terminal_runs(client):
+    runs = [
+        {"id": 1, "name": "lint", "status": "completed", "conclusion": "success"},
+        {"id": 2, "name": "Test (pytest)", "status": "in_progress", "conclusion": None},
+    ]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_completed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == ["lint"]
+
+
+def test_get_completed_checks_empty_when_no_runs(client):
+    # The Guard C window: head pushed/rebased, no check runs registered yet.
+    with mock.patch.object(client, "get_check_runs", return_value=[]):
+        out = client.get_completed_checks("o", "r", 1, pr_data={"head": {"sha": "x"}})
+    assert out == []
+
+
+def test_get_completed_checks_honors_ignored(client):
+    runs = [{"id": 1, "name": "Snapshot validation", "status": "completed", "conclusion": "success"}]
+    with mock.patch.object(client, "get_check_runs", return_value=runs):
+        out = client.get_completed_checks(
+            "o", "r", 1, pr_data={"head": {"sha": "x"}}, ignored_checks=["snapshot"]
+        )
+    assert out == []
+
+
 def test_get_incomplete_checks_no_head_sha(client):
     assert client.get_incomplete_checks("o", "r", 1, pr_data={"head": {}}) == []
 

--- a/tests/verdicts/conftest.py
+++ b/tests/verdicts/conftest.py
@@ -275,6 +275,9 @@ def mock_github_client() -> MagicMock:
     # Default: CI has settled (no checks still running). Tests exercising the
     # "CI still in progress" path override this with a non-empty list.
     gh.get_incomplete_checks.return_value = []
+    # Default: CI has reported on the current head (≥1 completed check). Tests
+    # exercising the "no CI on this head yet" path override with an empty list.
+    gh.get_completed_checks.return_value = ["Test (pytest)"]
     return gh
 
 


### PR DESCRIPTION
## The remaining hole after #272

#272 stopped the reviewer merging on **incomplete or red** CI. But a window remained: right after a branch is **pushed or auto-rebased**, the new head SHA has **no check runs yet**. In that window both `get_failed_checks` and `get_incomplete_checks` return `[]` for the head — so a gate that asks only *"nothing failed and nothing pending?"* declares **green on a head that has no CI at all**, letting a stale pre-rebase green carry a self-review LGTM straight to merge.

That is precisely the **textually-clean / semantically-broken merge** the divergent `goal/3476567d` branch rode in on (Guard C from the adversarial work order).

## Fix

- **New `GitHubPRClient.get_completed_checks`** — names of checks in a terminal (`completed`) state on the PR head. An empty result means *CI has produced no result on this head yet*.
- The **primary self-review gate** and the **WO-3 no-progress direct-merge path** now require `failed==[] AND pending==[] AND completed!=[]` before treating CI as green / merging. The "no results on this head yet" case **defers** via the existing `ci_wait_cycles` bound (and escalates `ci_never_settled` if it never settles) — identical handling to the pending case.

## Deliberately narrow

No eager per-poll rebase. The adversarial review was explicit that the union-merge `log.md` driver + lazy auto-rebase (#254) already handle the conflict treadmill, and eager rebasing causes throughput collapse / rebase storms. This change **only** gates on the freshness of the gating CI for the current head.

## Tests

`+4`: adapter unit tests for `get_completed_checks` (terminal runs listed; empty when no runs; ignored honored) and a gate integration test that a head with **zero completed checks defers** (no self-review, no merge, wait counter advanced). Mock factories default `get_completed_checks` non-empty (CI has reported). Full reviewer + adapter suites pass (251); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)