### PR TITLE
chore(custodian): C29-exempt github_pr.py — restore clean audit on main

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,14 @@
+## 2026-06-13 — feat(custodian): OC13 — test re-implements a metric inline without calling production (guard B)
+
+New LOW custodian detector flagging a test that computes a metric formula inline (math.log/log2/log10
+entropy signature) and asserts on it, while never calling a production metric function. This is the
+#269 anti-pattern: tests recomputed Shannon entropy inline and asserted constants that didn't match
+their own formula (0.081296 vs correct 0.080793), never exercising production. Per the adversarial
+review it deliberately does NOT fire on the legitimate golden-value cross-check (where the test CALLS
+the production function — e.g. reporter._compute_pattern_entropy — and uses inline math only as a
+reference): a production-metric call in the same function suppresses the finding. Keyed on inline-
+formula + call-absence, never on literal values. Zero findings on main; +5 unit tests.
+
 ## 2026-06-13 — feat(custodian): OC12 detector — model construction field mismatch (divergence guard A)
 
 New static-AST custodian detector flagging construction of a local @dataclass / Pydantic BaseModel

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,10 @@
+## 2026-06-13 — chore(custodian): C29-exempt github_pr.py (API adapter, 506 lines)
+
+Guard C's get_completed_checks pushed src/operations_center/adapters/github_pr.py to 506 lines
+(>500), tripping C29. It is the GitHub PR REST client — one responsibility, many small request
+methods — the same cohesive-adapter category C29 already exempts (usage_store.py). Exempted with
+rationale. (Landed via #277 whose audit ran red; this restores a clean audit on main.)
+
 ## 2026-06-13 — feat(custodian): OC13 — test re-implements a metric inline without calling production (guard B)
 
 New LOW custodian detector flagging a test that computes a metric formula inline (math.log/log2/log10

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -508,6 +508,12 @@ audit:
       # self-contained; splitting by channel would scatter the shared AlertResult
       # and factory in ways that add indirection without clarity.
       - src/operations_center/observer/alert_channels.py
+      # github_pr.py is the GitHub PR API client adapter — one responsibility (the
+      # REST surface) with many small request methods (get_pr, get_*_checks,
+      # merge_pr, list_open_prs, ...). A clean boundary that grows by one method as
+      # the API surface does; splitting would scatter a cohesive client. Same
+      # rationale as usage_store.py above.
+      - src/operations_center/adapters/github_pr.py
     C11:
       # Agent-spawning entrypoints: board_worker, intake, pr_review_watcher invoke
       # the coding backend (team_executor, aider, etc.) which runs for an unbounded

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -350,6 +350,7 @@ audit:
       - tests/unit/detectors/test_r1_console_presence_validator.py
       - tests/unit/detectors/test_r2_console_budget_validator.py
       - tests/unit/detectors/test_oc12_model_field_mismatch.py
+      - tests/unit/detectors/test_oc13_test_reimplements_metric.py
     C1:
       - src/operations_center/observer/collectors/todo_signal.py
       - src/operations_center/observer/artifact_writer.py

--- a/.custodian/detectors.py
+++ b/.custodian/detectors.py
@@ -738,6 +738,103 @@ def _detect_oc12_model_field_mismatch(ctx: AuditContext) -> DetectorResult:
     return DetectorResult(count=len(samples), samples=samples[:20])
 
 
+# ── OC13: test re-implements a metric formula instead of calling production ───
+#
+# Flags a test function that computes a metric formula INLINE (currently the
+# log-based entropy signature: math.log / log2 / log10) and asserts on it, while
+# never calling any production metric function. This is the #269 anti-pattern: its
+# tests recomputed Shannon entropy inline and asserted hardcoded constants that did
+# not even match the formula (asserted 0.081296; correct value 0.080793) — and the
+# production code was never exercised, so the test validated nothing real.
+#
+# It deliberately does NOT fire on the legitimate golden-value cross-check pattern,
+# where a test CALLS the production function and compares it to an independently
+# computed reference, e.g.:
+#     entropy = reporter._compute_pattern_entropy(runs)   # production exercised
+#     assert abs(entropy - (-math.log(0.5) * 0.5 * 2)) < 1e-3
+# Here the inline math is a reference value, not a replacement — so a call to a
+# production metric symbol in the same function suppresses the finding. The rule
+# keys on import/call-absence and inline-formula presence, never on literal values.
+
+_INLINE_METRIC_FNS = {"log", "log2", "log10"}  # math.* entropy signature
+_PRODUCTION_METRIC_RE = re.compile(r"^_compute_[a-z_]+$")
+
+
+def _flaky_metric_symbols(src_root: Path) -> set[str]:
+    """Public function names exported by observer/flaky_metrics.py (the canonical
+    metric implementations a test should call instead of re-deriving)."""
+    fm = src_root / "observer" / "flaky_metrics.py"
+    names: set[str] = set()
+    try:
+        tree = ast.parse(fm.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return names
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_"):
+            names.add(node.name)
+    return names
+
+
+def _calls_production_metric(fn: ast.AST, production: set[str]) -> bool:
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        name = (
+            callee.attr if isinstance(callee, ast.Attribute)
+            else callee.id if isinstance(callee, ast.Name)
+            else None
+        )
+        if name and (name in production or _PRODUCTION_METRIC_RE.match(name)):
+            return True
+    return False
+
+
+def _computes_metric_inline(fn: ast.AST) -> bool:
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        if isinstance(callee, ast.Attribute) and callee.attr in _INLINE_METRIC_FNS:
+            if isinstance(callee.value, ast.Name) and callee.value.id == "math":
+                return True
+        if isinstance(callee, ast.Name) and callee.id in _INLINE_METRIC_FNS:
+            return True  # `from math import log2`
+    return False
+
+
+def _has_assert(fn: ast.AST) -> bool:
+    return any(isinstance(n, ast.Assert) for n in ast.walk(fn))
+
+
+def _detect_oc13_test_reimplements_metric(ctx: AuditContext) -> DetectorResult:
+    tests = ctx.tests_root
+    if not tests.is_dir():
+        return DetectorResult(count=0, samples=[])
+    production = _flaky_metric_symbols(ctx.src_root)
+    samples: list[str] = []
+    for py in tests.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        rel = py.relative_to(ctx.repo_root)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.FunctionDef) and node.name.startswith("test")):
+                continue
+            if (
+                _computes_metric_inline(node)
+                and _has_assert(node)
+                and not _calls_production_metric(node, production)
+            ):
+                samples.append(
+                    f"{rel}:{node.lineno}: {node.name}() computes a metric inline "
+                    f"(math.log*) and asserts on it without calling a production metric "
+                    f"function — import observer.flaky_metrics (or call the reporter) instead"
+                )
+    return DetectorResult(count=len(samples), samples=samples[:20])
+
+
 # ── contributor entry point ───────────────────────────────────────────────────
 
 
@@ -775,5 +872,12 @@ def build_oc_detectors() -> list[Detector]:
             "open",
             _detect_oc12_model_field_mismatch,
             MEDIUM,
+        ),
+        Detector(
+            "OC13",
+            "test re-implements a metric formula inline without calling production",
+            "open",
+            _detect_oc13_test_reimplements_metric,
+            LOW,
         ),
     ]

--- a/tests/unit/detectors/test_oc13_test_reimplements_metric.py
+++ b/tests/unit/detectors/test_oc13_test_reimplements_metric.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for OC13: test re-implements a metric inline without calling production."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from custodian.audit_kit.detector import AuditContext
+
+_custodian_path = Path(__file__).parent.parent.parent.parent / ".custodian"
+if str(_custodian_path.parent) not in sys.path:
+    sys.path.insert(0, str(_custodian_path.parent))
+_spec = importlib.util.spec_from_file_location("detectors", _custodian_path / "detectors.py")
+assert _spec is not None and _spec.loader is not None
+_detectors = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_detectors)
+_detect = _detectors._detect_oc13_test_reimplements_metric
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> AuditContext:
+    src = tmp_path / "src" / "operations_center"
+    tests = tmp_path / "tests"
+    (src / "observer").mkdir(parents=True)
+    tests.mkdir(parents=True)
+    # minimal production metric surface
+    (src / "observer" / "flaky_metrics.py").write_text(
+        "import math\n\ndef failure_entropy(p, q):\n    return -(p*math.log2(p) + q*math.log2(q))\n",
+        encoding="utf-8",
+    )
+    return AuditContext(repo_root=tmp_path, src_root=src, tests_root=tests, config={}, plugin_modules=[])
+
+
+def _t(ctx: AuditContext, name: str, body: str) -> None:
+    (ctx.tests_root / name).write_text("import math\n\n\n" + body, encoding="utf-8")
+
+
+def test_flags_inline_entropy_without_production_call(ctx: AuditContext) -> None:
+    # The #269 anti-pattern: compute entropy inline, assert, never call production.
+    _t(
+        ctx,
+        "test_bad.py",
+        "def test_failure_entropy_calc():\n"
+        "    p = q = 0.5\n"
+        "    entropy = -(p*math.log2(p) + q*math.log2(q))\n"
+        "    assert abs(entropy - 1.0) < 1e-5\n",
+    )
+    res = _detect(ctx)
+    assert res.count == 1
+    assert "test_failure_entropy_calc" in res.samples[0]
+
+
+def test_golden_value_crosscheck_not_flagged(ctx: AuditContext) -> None:
+    # Legitimate: CALLS production (_compute_pattern_entropy) and uses inline math
+    # only as an independently-derived reference value. Must NOT fire.
+    _t(
+        ctx,
+        "test_good.py",
+        "def test_pattern_entropy(reporter, runs):\n"
+        "    entropy = reporter._compute_pattern_entropy(runs)\n"
+        "    expected = -math.log(0.5) * 0.5 * 2\n"
+        "    assert abs(entropy - expected) < 1e-3\n",
+    )
+    assert _detect(ctx).count == 0
+
+
+def test_calls_flaky_metrics_function_not_flagged(ctx: AuditContext) -> None:
+    _t(
+        ctx,
+        "test_calls_prod.py",
+        "from operations_center.observer.flaky_metrics import failure_entropy\n\n"
+        "def test_entropy():\n"
+        "    got = failure_entropy(0.5, 0.5)\n"
+        "    ref = -(0.5*math.log2(0.5) + 0.5*math.log2(0.5))\n"
+        "    assert abs(got - ref) < 1e-9\n",
+    )
+    assert _detect(ctx).count == 0
+
+
+def test_inline_math_without_assert_not_flagged(ctx: AuditContext) -> None:
+    _t(
+        ctx,
+        "test_noassert.py",
+        "def test_logs_something():\n    x = math.log2(8)\n    print(x)\n",
+    )
+    assert _detect(ctx).count == 0
+
+
+def test_no_inline_metric_not_flagged(ctx: AuditContext) -> None:
+    _t(
+        ctx,
+        "test_plain.py",
+        "def test_plain():\n    assert 1 + 1 == 2\n",
+    )
+    assert _detect(ctx).count == 0


### PR DESCRIPTION
## Why

Guard C (#277) added `get_completed_checks` to `src/operations_center/adapters/github_pr.py`, pushing it to **506 lines** (>500), which trips **C29**. #277 and #278 both merged anyway (the reviewer doesn't treat the `audit` check as blocking — a separate gap), so **main's audit is currently red** on this finding.

## Fix

Add `github_pr.py` to the C29 exemption list with rationale. It's the GitHub PR REST client — one responsibility (the API surface) with many small request methods (`get_pr`, `get_failed_checks`, `get_incomplete_checks`, `get_completed_checks`, `merge_pr`, `list_open_prs`, …) — the same cohesive-adapter category C29 already exempts (e.g. `usage_store.py`, `engine.py`, `settings.py`). It grows by one method as the API surface does; splitting would scatter a cohesive client.

Custodian audit clean (0 findings) with this exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)