### PR TITLE
fix(execution): add SCOPE_TOO_WIDE enum value and guard artifact_writer .value call

### DIFF
--- a/src/operations_center/contracts/enums.py
+++ b/src/operations_center/contracts/enums.py
@@ -146,6 +146,7 @@ class FailureReasonCategory(str, Enum):
     POLICY_BLOCKED = "policy_blocked"
     BUDGET_EXHAUSTED = "budget_exhausted"
     ROUTING_ERROR = "routing_error"
+    SCOPE_TOO_WIDE = "scope_too_wide"
     UNKNOWN = "unknown"
 
 

--- a/src/operations_center/execution/artifact_writer.py
+++ b/src/operations_center/execution/artifact_writer.py
@@ -64,7 +64,8 @@ class RunArtifactWriter:
             "written_at": datetime.now(timezone.utc).isoformat(),
         }
         if result.failure_category is not None:
-            metadata["failure_category"] = result.failure_category.value
+            fc = result.failure_category
+            metadata["failure_category"] = fc.value if hasattr(fc, "value") else str(fc)
         if extra_metadata:
             metadata.update(extra_metadata)
 

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from operations_center.adapters.git.client import GitClient
+from operations_center.contracts.enums import FailureReasonCategory
 from operations_center.contracts.execution import ExecutionRequest, ExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -255,7 +256,7 @@ class WorkspaceManager:
             return result.model_copy(
                 update={
                     "branch_pushed": False,
-                    "failure_category": "scope_too_wide",
+                    "failure_category": FailureReasonCategory.SCOPE_TOO_WIDE,
                     "failure_reason": (
                         f"diff exceeded soft cap: {n_files} files, {n_lines} lines "
                         f"(caps {self._max_files} / {self._max_lines}). "


### PR DESCRIPTION
## Summary

- Add `SCOPE_TOO_WIDE = "scope_too_wide"` to `FailureReasonCategory` enum in `contracts/enums.py`
- Guard `artifact_writer.py` `.value` call to handle string values safely
- Fix `workspace.py` to use the enum member instead of raw string

## Root Cause

`WorkspaceManager.finalize()` sets `failure_category = "scope_too_wide"` (a string), but `artifact_writer.py` calls `.value` on it expecting an enum member. This caused `AttributeError: 'str' object has no attribute 'value'` in the review watcher logs.

## Test plan
- [x] Unit tests pass: `pytest tests/unit/er000_phase0_golden/ tests/unit/execution/ tests/unit/entrypoints/ -q` (1334 passed)
- [x] Ruff clean: 0 violations
- [x] Custodian pre-push: 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)