### PR TITLE
fix(tests): use relative dates in snapshot/session retention tests (main is red)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-06-13 — fix(tests): date-bomb snapshot/session retention tests (main was red)
+
+3 observer tests hardcoded observed_at/session dates as 2026-06-07 and asserted retention/recency
+counts that only hold within a fixed window. As wall-clock passed 2026-06-14 those dates aged past
+the cutoffs (load_recent_sessions(days=7), retention_days), so cleanup deleted more / loaded fewer
+than the hardcoded expectations — turning main's full pytest RED (and blocking every PR from merging
+green). Fixed: anchor the dates to now (now-1day+i*hours, preserving relative order so sort tests
+still pass; today's date dir for the session test). Full unit suite green (7007). These are time-bomb
+tests; using relative dates is the durable fix.
+
 ## 2026-06-13 — fix(spec-hygiene): active.json projects only active campaigns (campaign GC)
 
 _rebuild_active_projection wrote every campaign — incl. complete/cancelled — to state/campaigns/

--- a/tests/unit/observer/test_flaky_test_storage.py
+++ b/tests/unit/observer/test_flaky_test_storage.py
@@ -3,7 +3,7 @@
 """Unit tests for flaky test storage manager."""
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -134,7 +134,7 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old session reports."""
         storage = FlakyTestStorageManager(tmp_path, session_retention_days=3)
 
-        today = datetime.now(UTC).date()
+        today = datetime.now(timezone.utc).date()
         old_date = (today - timedelta(days=10)).strftime("%Y-%m-%d")
         recent_date = today.strftime("%Y-%m-%d")
 
@@ -162,7 +162,7 @@ class TestFlakyTestStorageManager:
         """Test cleanup of old aggregation reports."""
         storage = FlakyTestStorageManager(tmp_path, aggregation_retention_days=30)
 
-        today = datetime.now(UTC).date()
+        today = datetime.now(timezone.utc).date()
         old_date = (today - timedelta(days=60)).strftime("%Y-%m-%d")
         recent_date = today.strftime("%Y-%m-%d")
 
@@ -220,7 +220,7 @@ class TestFlakyTestStorageManager:
         storage = FlakyTestStorageManager(tmp_path)
 
         # Create a corrupted JSON file
-        date_dir = storage.session_dir / datetime.now(UTC).strftime("%Y-%m-%d")
+        date_dir = storage.session_dir / datetime.now(timezone.utc).strftime("%Y-%m-%d")
         date_dir.mkdir(parents=True, exist_ok=True)
         corrupted_file = date_dir / "10-00-00-session.json"
         corrupted_file.write_text("{invalid json")
@@ -282,7 +282,7 @@ class TestFlakyTestStorageManager:
     def test_load_recent_sessions_skips_old_dates(self, tmp_path):
         """Test load_recent_sessions skips directories older than cutoff."""
         storage = FlakyTestStorageManager(tmp_path)
-        old_date = (datetime.now(UTC).date() - timedelta(days=30)).strftime("%Y-%m-%d")
+        old_date = (datetime.now(timezone.utc).date() - timedelta(days=30)).strftime("%Y-%m-%d")
         old_dir = storage.session_dir / old_date
         old_dir.mkdir(parents=True, exist_ok=True)
         (old_dir / "10-00-00-session.json").write_text('{"session_id": "old"}')
@@ -319,7 +319,7 @@ class TestFlakyTestStorageManager:
         """Test load_recent_aggregations skips files older than cutoff."""
         storage = FlakyTestStorageManager(tmp_path)
         storage.aggregation_dir.mkdir(parents=True, exist_ok=True)
-        old_date = (datetime.now(UTC).date() - timedelta(days=120)).strftime("%Y-%m-%d")
+        old_date = (datetime.now(timezone.utc).date() - timedelta(days=120)).strftime("%Y-%m-%d")
         (storage.aggregation_dir / f"{old_date}-aggregation.json").write_text("{}")
 
         aggs = storage.load_recent_aggregations(days=30)
@@ -338,7 +338,7 @@ class TestFlakyTestStorageManager:
         """Test load_recent_aggregations skips corrupted JSON files."""
         storage = FlakyTestStorageManager(tmp_path)
         storage.aggregation_dir.mkdir(parents=True, exist_ok=True)
-        today = datetime.now(UTC).date().strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).date().strftime("%Y-%m-%d")
         (storage.aggregation_dir / f"{today}-aggregation.json").write_text("{bad json")
 
         aggs = storage.load_recent_aggregations(days=30)

--- a/tests/unit/observer/test_flaky_test_storage.py
+++ b/tests/unit/observer/test_flaky_test_storage.py
@@ -220,7 +220,7 @@ class TestFlakyTestStorageManager:
         storage = FlakyTestStorageManager(tmp_path)
 
         # Create a corrupted JSON file
-        date_dir = storage.session_dir / "2026-06-07"
+        date_dir = storage.session_dir / datetime.now(UTC).strftime("%Y-%m-%d")
         date_dir.mkdir(parents=True, exist_ok=True)
         corrupted_file = date_dir / "10-00-00-session.json"
         corrupted_file.write_text("{invalid json")

--- a/tests/unit/observer/test_snapshot_manager.py
+++ b/tests/unit/observer/test_snapshot_manager.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 ProtocolWarden
 """Tests for snapshot manager."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 import pytest
@@ -152,9 +152,10 @@ class TestSnapshotManagerGet:
     ) -> None:
         """Test getting snapshots with a limit."""
         for i in range(5):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,
@@ -266,9 +267,10 @@ class TestSnapshotManagerCleanup:
         )
 
         for i in range(4):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,

--- a/tests/unit/observer/test_snapshot_repository.py
+++ b/tests/unit/observer/test_snapshot_repository.py
@@ -3,7 +3,7 @@
 """Tests for snapshot repository implementations."""
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 import pytest
@@ -227,9 +227,10 @@ class TestLocalSnapshotRepositoryList:
     ) -> None:
         """Test listing snapshots with a limit."""
         for i in range(5):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,
@@ -246,9 +247,10 @@ class TestLocalSnapshotRepositoryList:
         """Test that snapshots are listed in reverse chronological order."""
         snaps = []
         for i in range(3):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,
@@ -356,9 +358,10 @@ class TestLocalSnapshotRepositoryCleanup:
         """Test that recent snapshots are retained."""
         # Store snapshots within retention period
         for i in range(3):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,
@@ -384,9 +387,10 @@ class TestLocalSnapshotRepositoryCleanup:
 
         # Store 5 snapshots
         for i in range(5):
+            ts = datetime.now(timezone.utc) - timedelta(days=1) + timedelta(hours=i)
             snap = RepoStateSnapshot(
-                run_id=f"test_obs_20260607T{i:02d}0000Z_abc123_x7k9m",
-                observed_at=datetime(2026, 6, 7, i, 0, 0, tzinfo=timezone.utc),
+                run_id=f"test_obs_{ts.strftime('%Y%m%dT%H%M%S')}Z_abc123_x7k9m",
+                observed_at=ts,
                 observer_version=1,
                 source_command="test",
                 repo=test_snapshot.repo,


### PR DESCRIPTION
## Main is red right now

Three observer tests hardcode their dates as **2026-06-07** and assert retention/recency outcomes that only hold within a fixed window:
- `test_snapshot_repository.py::test_cleanup_retains_recent_snapshots`
- `test_snapshot_manager.py::test_cleanup_old_snapshots`
- `test_flaky_test_storage.py::test_storage_handles_corrupted_json`

As wall-clock passed **2026-06-14**, those dates aged beyond the cutoffs (`load_recent_sessions(days=7)`, `retention_days`), so cleanup deletes more / loads fewer than the hardcoded counts and the assertions flip. **main's full pytest suite is RED**, which blocks every PR from merging green (including the campaign/state GC PRs in this series).

Confirmed pre-existing: these fail on clean current main, independent of any feature branch.

## Fix

Anchor the dates to `now` instead of a fixed past date:
- loop-based snapshots → `now - 1 day + i*hours` — **preserves relative ordering**, so the sort-order tests (`test_list_snapshots_sorted_by_date`, etc.) still pass while the retention windows now hold;
- flaky-session dir → today's date.

Relative dates are the durable fix for these time-bombs.

## Verification

Full `tests/unit` suite: **7007 passed**, 0 failed. `ruff` clean; audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)