### PR TITLE
fix(ci): expand custodian-audit push trigger to all branches

### DIFF
--- a/.github/workflows/custodian-audit.yml
+++ b/.github/workflows/custodian-audit.yml
@@ -2,7 +2,7 @@ name: custodian-audit
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Expand `custodian-audit` push trigger from `branches: [main]` to `branches: ["**"]`

## Root cause

GitHub does **not** send `pull_request:synchronize` events for `CONFLICTING` PRs. Without `push: branches: ["**"]`, the audit check never runs when commits are pushed to a conflicting PR branch, leaving the `audit` check absent from the CI suite. The review watcher's `ci_wait` loop stalls indefinitely waiting for a check that will never appear.

## Why this matters

- `spec-author/baf9bfc8` (PR #293) is missing the `audit` check because of this
- Every future PR that becomes CONFLICTING before its first audit run will hit the same deadlock
- Review watcher cannot merge or close without all required checks present

## Change

Single-line YAML change — no functional code change.

Supersedes PR #294 (which carried unrelated observer-CLI history causing merge conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)