### PR TITLE
fix(custodian-sweep): raise per-repo timeout from 120s to 180s

### DIFF
--- a/src/operations_center/entrypoints/custodian_sweep/main.py
+++ b/src/operations_center/entrypoints/custodian_sweep/main.py
@@ -38,7 +38,7 @@ from typing import Any
 
 _DEFAULT_HISTORY_PATH = Path("state/custodian_sweep/last_sweep.json")
 _DEDUP_LABEL_PREFIX = "custodian-sweep:"  # one label per repo for dedup
-_DEFAULT_TIMEOUT_SECONDS = 120
+_DEFAULT_TIMEOUT_SECONDS = 180
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- OC custodian-audit takes ~94s under light load but exceeds 120s when the sweep runs parallel jobs
- The 120s timeout caused the sweep to emit `custodian-audit timed out (>120s)` for OperationsCenter every cycle, even though the audit reports 0 findings
- Raising default to 180s eliminates false-positive timeout errors for OC without affecting other repos

## Root cause
OC is the largest managed repo; its audit is CPU-bound across many detectors. Under parallel sweep load, scheduling contention pushes it past 120s. The fix in PR #297 (service.py C29 exclusion) reduced audit time but not enough to reliably stay under 120s.

## Test plan
- [ ] `tests/test_custodian_sweep.py` (11/11 pass — imports `_DEFAULT_TIMEOUT_SECONDS` directly, no hardcoded value)
- [ ] `tests/unit/er000_phase0_golden/` (15/15 pass)
- [ ] OC pre-push audit: 0 findings (confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)