### PR TITLE
chore(custodian): enable CAP1 capability-ref enforcement

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,14 @@
+## 2026-06-15 — chore: enable CAP1 capability-ref enforcement
+
+Set `audit.capabilities.enforce: true` so Custodian's CAP1 detector verifies the
+capability this repo owns (`board_unblock`) points at invocation.ref code that
+resolves here — `operations_center.entrypoints.maintenance.board_unblock`. Uses
+the existing `cross_repo.platform_manifest_repo` pointer to locate the registry +
+manifest. Activates once the local custodian install is refreshed to @main
+(post-CAP1); CI installs custodian@main fresh, where it skips (no PM sibling).
+Also declared `capabilities` in `plugin_audit_keys` — ci.yml's doctor job uses
+the pinned pre-CAP1 `[dev]` custodian which would otherwise flag it as unknown.
+
 ## 2026-06-15 — fix: reconcile in-flight ledger at watcher startup
 
 A dispatch records `execution_started` and pairs `execution_finished` in a `finally`

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -60,6 +60,11 @@ audit:
   cross_repo:
     platform_manifest_repo: ../PlatformManifest
 
+  # CAP1 — enforce that the capabilities this repo owns (board_unblock) point at
+  # invocation.ref code that actually resolves here. Anti-rot for the registry.
+  capabilities:
+    enforce: true
+
   plumbing:
     # P1/P2/P3: OC heartbeat JSON → OperatorConsole stale-role check.
     # Reader uses mtime only; P2 ignore_keys suppresses pid-check dict accesses
@@ -805,6 +810,9 @@ audit:
     - oc1_exempt
     - oc7_exempt
     - reconcile_enforce
+    # CAP1 enforcement key — a core key in current custodian, declared here so
+    # the doctor job (pinned to a pre-CAP1 custodian commit) accepts it.
+    - capabilities
 
   # Additional well-known string values for OC9 to recognise without
   # requiring a string-literal anchor in src/.


### PR DESCRIPTION
Sets `audit.capabilities.enforce: true` so Custodian's **CAP1** detector verifies the capability this repo owns — `board_unblock` — points at `invocation.ref` code that actually resolves here (`operations_center.entrypoints.maintenance.board_unblock`). Anti-rot for the capability registry.

Uses the existing `cross_repo.platform_manifest_repo` pointer to locate the registry + manifest. Verified locally: with CAP1 active (custodian@main + PlatformManifest sibling), OperationsCenter's audit is clean — the ref resolves. Activates fleet-wide once the local custodian install is refreshed to `@main`; single-repo CI installs `custodian@main` fresh where CAP1 skips (no sibling checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)