### PR TITLE
chore(deps): bump custodian pin to CAP1-aware + cwd-safe hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre_tool_use.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pre_tool_use.sh\""
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/stop.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stop.sh\""
           }
         ]
       }

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-06-15 — chore: bump custodian pin to CAP1-aware + cwd-safe hook
+
+Bumped the `custodian` dependency pin from the pre-CAP1 SHA `4a1a0aec` to
+`0fa072f` (the CAP1 decouple+enforce merge) so the venv build and single-repo CI
+install a CAP1-aware custodian — previously the pinned copy ran no CAP1 even
+though `audit.capabilities.enforce` was set. The doctor job's `capabilities`
+plugin-audit-key shim stays valid (now a no-op since main's doctor knows the key
+natively). Also hardened the ContextGuard hook command to
+`${CLAUDE_PROJECT_DIR:-.}` so it resolves regardless of the shell cwd.
+
 ## 2026-06-15 — chore: enable CAP1 capability-ref enforcement
 
 Set `audit.capabilities.enforce: true` so Custodian's CAP1 detector verifies the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev = [
   "pytest-cov>=6.0",
   "ruff==0.15.13",
   "ty==0.0.40",
-  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@4a1a0aec1fc09c122feee6018f19e19ea41d6263",
+  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@0fa072fef04824416039394bb763ecc5a74f1670",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## What

- **Bump custodian pin** from the pre-CAP1 SHA `4a1a0aec` to `0fa072f` (the CAP1 decouple+enforce merge). The old pin meant the venv build and single-repo CI installed a custodian with no CAP1 detector — so `audit.capabilities.enforce: true` (set in #303) did nothing on this repo's own builds. With the bump, CAP1 is present (and, in a single-repo CI runner with no PlatformManifest sibling, cleanly skips — CI stays green). The `capabilities` plugin-audit-key shim added for the pinned-custodian doctor job stays valid and is now a no-op, since main's doctor knows the key natively.
- **cwd-safe ContextGuard hook**: hardened the hook command from relative `bash .claude/hooks/pre_tool_use.sh` to `bash "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pre_tool_use.sh"` so it resolves regardless of the shell's cwd (the relative form errored non-blockingly when a tool ran from a non-root cwd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)