### PR TITLE
feat(pr_review_watcher): capture human-resolved escalations to interventions ledger

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-06-16 — feat: capture human-resolved escalations to the interventions ledger
+
+`pr_review_watcher` now emits an operator-interventions ledger candidate when an
+*escalated* PR (the worker explicitly handed it to a human via
+`escalated_needs_human`) leaves the open set — i.e. a human resolved the
+escalation. Hook is in `_prune_orphan_state_files`: only escalated orphans are
+captured (plain orphans conflate multi-host races / watcher-down, so they are NOT
+a clean human signal — capturing them would poison the ledger). New
+`_capture_human_intervention` shells out to `cl ledger capture
+worker-escalation-resolved-by-human "<repo>#<n>"` fail-soft (no-op if `cl` is
+absent — never wedges the poll loop). Promotion of the candidate stays manual.
+Pairs with ContextLifecycle #30 (`cl ledger capture`).
+
 ## 2026-06-15 — chore: bump custodian pin to CAP1-aware + cwd-safe hook
 
 Bumped the `custodian` dependency pin from the pre-CAP1 SHA `4a1a0aec` to

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -100,11 +100,44 @@ def _prune_orphan_state_files(oc_root: Path, repo_key: str, open_numbers: set[in
         num_part = f.stem[len(prefix) :]
         if not num_part.isdigit() or int(num_part) in open_numbers:
             continue
+        # A state file surviving to prune time means THIS watcher did not
+        # terminate the PR — its own merge/close paths unlink first. A plain
+        # orphan conflates several causes (a human gh pr merge, another host,
+        # this watcher being down), so it is NOT a clean intervention signal.
+        # But an orphan that was *escalated for human attention* is: the worker
+        # explicitly handed the PR to a human, and the PR has now left the open
+        # set, so a human resolved the escalation. That is a genuine operator
+        # intervention — capture an (unjudged) ledger candidate before pruning.
+        orphan = _load_state(f)
+        if orphan.get("escalated_needs_human"):
+            _capture_human_intervention(
+                "worker-escalation-resolved-by-human", f"{repo_key}#{num_part}"
+            )
         try:
             f.unlink(missing_ok=True)
             logger.info("pr_review_watcher: pruned orphan review-state %s (PR not open)", f.name)
         except Exception as exc:
             logger.debug("pr_review_watcher: prune failed for %s — %s", f.name, exc)
+
+
+def _capture_human_intervention(signal: str, context: str) -> None:
+    """Best-effort: append a candidate to the operator-interventions ledger.
+
+    Calls ``cl ledger capture`` (ContextLifecycle), which appends an *unjudged*
+    candidate to the ledger in the private manifest and dedups on signal+context.
+    Fail-soft by design: if ``cl`` is not on PATH or no private manifest resolves,
+    this is a silent no-op — capture must never wedge, slow, or fail the poll
+    loop. Promotion of the candidate (the judgment line) stays manual.
+    """
+    try:
+        subprocess.run(
+            ["cl", "ledger", "capture", signal, context],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:  # noqa: BLE001 — capture is best-effort telemetry
+        logger.debug("pr_review_watcher: ledger capture failed (%s) — %s", signal, exc)
 
 
 def _load_state(path: Path) -> dict:

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -2224,3 +2224,79 @@ def test_prune_orphan_state_files_empty_open_set_prunes_all_for_repo(tmp_path: P
     (sub / "OperationsCenter-2.json").write_text("{}", encoding="utf-8")
     watcher._prune_orphan_state_files(tmp_path, "OperationsCenter", set())
     assert list(sub.iterdir()) == []
+
+
+def _capture_recorder(monkeypatch):
+    """Record the argv of every subprocess.run the watcher makes."""
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, *args, **kwargs):
+        calls.append(list(argv))
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(watcher.subprocess, "run", _fake_run)
+    return calls
+
+
+def test_prune_escalated_orphan_captures_ledger_candidate(tmp_path: Path, monkeypatch) -> None:
+    """An orphan that was escalated_needs_human → a human resolved it → capture
+    one ledger candidate before pruning."""
+    calls = _capture_recorder(monkeypatch)
+    sub = tmp_path / "state" / "pr_reviews"
+    sub.mkdir(parents=True)
+    (sub / "OperationsCenter-42.json").write_text(
+        json.dumps({"escalated_needs_human": True}), encoding="utf-8"
+    )
+
+    watcher._prune_orphan_state_files(tmp_path, "OperationsCenter", set())
+
+    assert not list(sub.iterdir())  # still pruned
+    ledger_calls = [c for c in calls if c[:3] == ["cl", "ledger", "capture"]]
+    assert ledger_calls == [
+        ["cl", "ledger", "capture", "worker-escalation-resolved-by-human", "OperationsCenter#42"]
+    ]
+
+
+def test_prune_plain_orphan_does_not_capture(tmp_path: Path, monkeypatch) -> None:
+    """A non-escalated orphan conflates multi-host / watcher-down — NOT a clean
+    intervention, so no ledger candidate is captured."""
+    calls = _capture_recorder(monkeypatch)
+    sub = tmp_path / "state" / "pr_reviews"
+    sub.mkdir(parents=True)
+    (sub / "OperationsCenter-42.json").write_text(json.dumps({"phase": "ci_fix"}), encoding="utf-8")
+
+    watcher._prune_orphan_state_files(tmp_path, "OperationsCenter", set())
+
+    assert not [c for c in calls if c[:3] == ["cl", "ledger", "capture"]]
+
+
+def test_prune_escalated_but_open_pr_not_captured(tmp_path: Path, monkeypatch) -> None:
+    """An escalated PR that is STILL open is not an orphan — not pruned, not captured."""
+    calls = _capture_recorder(monkeypatch)
+    sub = tmp_path / "state" / "pr_reviews"
+    sub.mkdir(parents=True)
+    (sub / "OperationsCenter-42.json").write_text(
+        json.dumps({"escalated_needs_human": True}), encoding="utf-8"
+    )
+
+    watcher._prune_orphan_state_files(tmp_path, "OperationsCenter", {42})
+
+    assert {p.name for p in sub.iterdir()} == {"OperationsCenter-42.json"}  # kept
+    assert not [c for c in calls if c[:3] == ["cl", "ledger", "capture"]]
+
+
+def test_capture_human_intervention_fail_soft(monkeypatch) -> None:
+    """If `cl` is missing (FileNotFoundError) capture is a silent no-op."""
+
+    def _boom(*args, **kwargs):
+        raise FileNotFoundError("cl not on PATH")
+
+    monkeypatch.setattr(watcher.subprocess, "run", _boom)
+    # Must not raise, and returns None (silent no-op).
+    assert watcher._capture_human_intervention("sig", "ctx") is None


### PR DESCRIPTION
When an **escalated** PR (the worker set `escalated_needs_human`, explicitly handing it to a human) later leaves the open set, a human resolved the escalation — a genuine operator intervention. This captures an unjudged ledger candidate for it.

## What
- In `_prune_orphan_state_files`: before unlinking an orphan, if its state has `escalated_needs_human`, fire `cl ledger capture worker-escalation-resolved-by-human "<repo>#<n>"`.
- New `_capture_human_intervention` helper shells out to `cl` (ContextLifecycle), **fail-soft**: a no-op if `cl` is absent or no private manifest resolves — must never wedge/slow the poll loop. `cl ledger capture` dedups, so repeats are harmless.

## Why escalated-only (the correctness point)
A surviving state file at prune time means *this* watcher didn't terminate the PR (its own merge/close unlink first). But a **plain** orphan conflates several causes — a human `gh pr merge`, **another OC host** (normal fleet op, not an intervention), or this watcher being down. Capturing all orphans would poison the ledger with multi-host noise. An **escalated** orphan is unambiguous: the worker asked a human, and the PR is gone → a human acted. So only escalated orphans are captured.

Note: the worker's *own* autonomous close (`_close_and_requeue`) is explicitly NOT a capture source — that's the system self-managing, not an operator intervention.

## Tests
4 new in `test_pr_review_watcher.py`: escalated orphan captures (exact argv), plain orphan does not, escalated-but-still-open does not, fail-soft no-op. ruff + ty clean; 101 watcher tests pass; no new custodian findings.

Pairs with ContextLifecycle #30 (`cl ledger capture`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)