### PR TITLE
chore: bump custodian pin to 223c9da (doctor config-integrity checks)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,12 @@
+## 2026-06-16 — chore: bump custodian pin to 223c9da (doctor config-integrity checks)
+
+Bumped the `custodian` pin `0fa072f` → `223c9da` (Custodian #40: doctor
+duplicate-key + capabilities.enforce-without-locator checks). Previously OC's CI
+`Custodian doctor` job ran a custodian that predated those checks, so a duplicate
+`audit:` block or an enforce-without-locator could slip through OC unnoticed.
+Verified `custodian-doctor --strict --repo .` is still OK against OC with the new
+pin (no new findings) before bumping.
+
 ## 2026-06-16 — feat: capture human-resolved escalations to the interventions ledger
 
 `pr_review_watcher` now emits an operator-interventions ledger candidate when an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev = [
   "pytest-cov>=6.0",
   "ruff==0.15.13",
   "ty==0.0.40",
-  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@0fa072fef04824416039394bb763ecc5a74f1670",
+  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@223c9dadd18c8e9526fbdc7185cef7220edde613",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Bumps the `custodian` pin `0fa072f` → `223c9da` (Custodian #40) so OC's CI **Custodian doctor** job actually runs the new config-integrity checks: duplicate-key detection and `capabilities.enforce`-without-locator.

Before this, OC's doctor job installed a custodian that predated those checks — so a duplicate `audit:` block (which silently drops an `enforce`/suppression) or an enforce-theater config could slip through OC unnoticed. This makes the "the doctor checks are automatic everywhere" claim true for OC too.

Verified locally: `custodian-doctor --strict --repo .` is **OK** against OC at the new pin (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)