### PR TITLE
feat(ledger): controller runs the consolidation loop (observe + promote)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,24 @@
+## 2026-06-17 — feat: controller runs the ledger consolidation loop (observe + promote)
+
+New `LedgerMaintainTask` (`maintenance/ledger_maintain.py`), registered in the
+`spec_hygiene` maintenance registry (the durable `spec` fleet role hosts the
+registry loop), runs the controller's half of the operator-interventions ledger
+each cycle (1h interval, best-effort):
+- `cl ledger promote --repos-root <root>` — auto-promote each recurrence of a
+  signal whose first human judgment carries a live `[check: ref]` by re-verifying
+  the check still resolves. Exit 1 (an encoded check regressed) is surfaced in
+  the result details (`regressed=True`), NOT a task failure.
+- `cl ledger observe` — surface signals recurring without a judgment yet.
+
+`repos_root` resolves from a configured repo `local_path` parent, else the
+checkout layout (`parents[4]`). Shell-out matches the capture-side pattern
+(timeout 30, try/except, never breaks the cycle). No commit/push of the private
+manifest — writes land in the working tree only and are idempotent. 9 tests;
+maintenance suite 41 green; ruff + custodian-doctor --strict clean (sole audit
+finding is the pre-existing environmental B2 boundary-artifact check). Pairs with
+ContextLifecycle #32 (the observe/promote engine). Operator decision 2026-06-17:
+controller may auto-promote the self-verifying class.
+
 ## 2026-06-16 — chore: bump custodian pin to 223c9da (doctor config-integrity checks)
 
 Bumped the `custodian` pin `0fa072f` → `223c9da` (Custodian #40: doctor

--- a/src/operations_center/entrypoints/spec_hygiene/main.py
+++ b/src/operations_center/entrypoints/spec_hygiene/main.py
@@ -35,6 +35,7 @@ from operations_center.maintenance import (
     MaintenanceRegistry,
     MaintenanceResult,
 )
+from operations_center.maintenance.ledger_maintain import LedgerMaintainTask
 from operations_center.spec_author.campaign_builder import CampaignBuilder
 from operations_center.spec_author.models import (
     ActiveCampaigns,
@@ -680,6 +681,10 @@ def main() -> None:
     registry = MaintenanceRegistry(state_path=args.maintenance_state)
     task = SpecHygieneTask(settings, client)
     registry.register(task)
+    # Operator-interventions ledger consolidation loop (observe + self-verifying
+    # promote). Runs the controller's half of the ledger so a human only ever
+    # encodes a judgment once; recurrences self-verify. Best-effort by design.
+    registry.register(LedgerMaintainTask(settings))
 
     def _build_ctx() -> MaintenanceContext:
         return MaintenanceContext(

--- a/src/operations_center/maintenance/ledger_maintain.py
+++ b/src/operations_center/maintenance/ledger_maintain.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""LedgerMaintainTask — run the operator-interventions ledger consolidation loop.
+
+The fleet already *captures* candidates (pr_review_watcher shells out to
+``cl ledger capture``). This maintenance task runs the other half each cycle, so
+the controller — not a human — does the observing and the verifiable promoting:
+
+- ``cl ledger promote --repos-root <root>`` — auto-promote each recurrence of a
+  signal whose first (human) judgment carries a live ``[check: ref]``, by
+  re-verifying that check still resolves. Exit 1 means an encoded check
+  *regressed* (its candidates are left for a human); that is surfaced in the
+  result details, not treated as a task failure.
+- ``cl ledger observe`` — surface signals recurring without a judgment yet (the
+  patterns a human still needs to encode once).
+
+Both are best-effort shell-outs to the ``cl`` CLI (ContextLifecycle), matching
+the capture-side pattern. Neither commits or pushes the private manifest —
+mutations land in the working tree only; promotion writes are idempotent (a
+promoted line is no longer a candidate, so a re-run won't touch it).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+from operations_center.config.settings import Settings
+from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceResult
+
+logger = logging.getLogger(__name__)
+
+# 1 hour: candidates accrue slowly (a genuine human intervention is rare), and
+# promotion is idempotent, so there's no value polling tighter than this.
+DEFAULT_INTERVAL_SECONDS = 3600
+_TIMEOUT_SECONDS = 30
+
+
+def resolve_repos_root(settings: Settings) -> Path:
+    """Directory holding the managed repo checkouts (for resolving ``[check: ref]``).
+
+    A check ref names a repo by directory (``custodian:Custodian:OC3``), so the
+    root is the parent those checkouts share. Prefer a configured repo's
+    ``local_path`` parent; fall back to this package's checkout layout
+    (``…/<repos-root>/OperationsCenter/src/operations_center/…``).
+    """
+    for cfg in settings.repos.values():
+        if cfg.local_path:
+            return Path(cfg.local_path).resolve().parent
+    # parents: ledger_maintain → maintenance → operations_center → src → OC root
+    return Path(__file__).resolve().parents[4]
+
+
+class LedgerMaintainTask:
+    """MaintenanceTask: promote verifiable recurrences + observe novel patterns."""
+
+    name = "ledger_maintain"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        repos_root: Path | None = None,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+        enabled: bool = True,
+        cl_bin: str = "cl",
+        runner=subprocess.run,
+    ) -> None:
+        self._settings = settings
+        self._repos_root = repos_root if repos_root is not None else resolve_repos_root(settings)
+        self.interval_seconds = interval_seconds
+        self.enabled = enabled
+        self._cl_bin = cl_bin
+        self._run = runner
+
+    def _cl(self, *args: str) -> tuple[int, str]:
+        """Best-effort `cl` call. Returns (returncode, combined output)."""
+        try:
+            proc = self._run(
+                [self._cl_bin, *args],
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort, never break the cycle
+            logger.debug("ledger_maintain: `cl %s` failed — %s", " ".join(args), exc)
+            return (-1, str(exc))
+        out = (proc.stdout or "") + (proc.stderr or "")
+        return (proc.returncode, out.strip())
+
+    def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
+        started = time.monotonic()
+        details: dict[str, object] = {"repos_root": str(self._repos_root)}
+
+        # Promote first: clear the verifiable recurrences and catch regressions.
+        promote_rc, promote_out = self._cl(
+            "ledger", "promote", "--repos-root", str(self._repos_root)
+        )
+        details["promote_rc"] = promote_rc
+        details["promoted"] = promote_out.count("\n  ✓ ")
+        details["regressed"] = promote_rc == 1  # exit 1 == an encoded check rotted
+        if promote_out:
+            details["promote_out"] = promote_out[:2000]
+
+        # Then observe: what novel patterns still await a first human judgment.
+        observe_rc, observe_out = self._cl("ledger", "observe")
+        details["observe_rc"] = observe_rc
+        details["recurring"] = observe_out.count("\n  x")
+        if observe_out:
+            details["observe_out"] = observe_out[:2000]
+
+        return MaintenanceResult(
+            name=self.name,
+            status="ok",
+            duration_seconds=time.monotonic() - started,
+            details=details,
+        )
+
+
+__all__ = ["DEFAULT_INTERVAL_SECONDS", "LedgerMaintainTask", "resolve_repos_root"]

--- a/tests/maintenance/test_ledger_maintain.py
+++ b/tests/maintenance/test_ledger_maintain.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for LedgerMaintainTask (ledger consolidation loop, controller side)."""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from operations_center.maintenance import MaintenanceContext, MaintenanceTask
+from operations_center.maintenance.ledger_maintain import (
+    DEFAULT_INTERVAL_SECONDS,
+    LedgerMaintainTask,
+    resolve_repos_root,
+)
+
+
+def _ctx() -> MaintenanceContext:
+    return MaintenanceContext(cycle_id=str(uuid.uuid4()), now=datetime.now(UTC))
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _recorder(responses: dict[str, _FakeProc]):
+    """Return a fake subprocess.run that dispatches on the cl subcommand."""
+    calls: list[list[str]] = []
+
+    def run(cmd, capture_output=True, text=True, timeout=None):  # noqa: ARG001
+        calls.append(cmd)
+        sub = cmd[2] if len(cmd) > 2 else ""  # cl ledger <sub>
+        return responses.get(sub, _FakeProc(0, ""))
+
+    return run, calls
+
+
+def _settings(repos=None):
+    # LedgerMaintainTask only reads settings.repos — a lightweight fake suffices
+    # (same approach as test_spec_hygiene_task's SimpleNamespace settings).
+    return SimpleNamespace(repos=repos or {})
+
+
+def test_satisfies_maintenance_task_protocol():
+    task = LedgerMaintainTask(_settings())
+    assert isinstance(task, MaintenanceTask)
+    assert task.name == "ledger_maintain"
+    assert task.enabled is True
+    assert task.interval_seconds == DEFAULT_INTERVAL_SECONDS
+
+
+def test_run_once_invokes_promote_then_observe():
+    run, calls = _recorder(
+        {
+            "promote": _FakeProc(0, "cl ledger promote: nothing to promote\n"),
+            "observe": _FakeProc(0, "cl ledger observe: no recurring unjudged signals\n"),
+        }
+    )
+    task = LedgerMaintainTask(_settings(), repos_root=Path("/repos"), runner=run)
+    result = task.run_once(_ctx())
+    assert result.status == "ok"
+    # promote runs before observe, with the repos-root passed through
+    assert calls[0] == ["cl", "ledger", "promote", "--repos-root", "/repos"]
+    assert calls[1] == ["cl", "ledger", "observe"]
+
+
+def test_run_once_counts_promotions_and_recurrences():
+    run, _ = _recorder(
+        {
+            "promote": _FakeProc(0, "cl ledger promote: promoted 2 recurrence(s):\n  ✓ a\n  ✓ b\n"),
+            "observe": _FakeProc(0, "recurring:\n  x4  sig  (latest 2026-06-20)\n  x3  s2\n"),
+        }
+    )
+    task = LedgerMaintainTask(_settings(), repos_root=Path("/repos"), runner=run)
+    details = task.run_once(_ctx()).details
+    assert details["promoted"] == 2
+    assert details["recurring"] == 2
+    assert details["regressed"] is False
+
+
+def test_run_once_flags_regression_without_failing():
+    # promote exit 1 == an encoded check rotted. Surfaced in details, NOT a
+    # task failure (the registry would otherwise mark the whole task failed).
+    run, _ = _recorder(
+        {
+            "promote": _FakeProc(1, "cl ledger promote: 1 encoded check(s) REGRESSED:\n"),
+            "observe": _FakeProc(0, ""),
+        }
+    )
+    task = LedgerMaintainTask(_settings(), repos_root=Path("/repos"), runner=run)
+    result = task.run_once(_ctx())
+    assert result.status == "ok"
+    assert result.details["regressed"] is True
+
+
+def test_run_once_is_best_effort_when_cl_raises():
+    def boom(cmd, **kwargs):  # noqa: ARG001
+        raise FileNotFoundError("cl not found")
+
+    task = LedgerMaintainTask(_settings(), repos_root=Path("/repos"), runner=boom)
+    result = task.run_once(_ctx())
+    assert result.status == "ok"  # never breaks the cycle
+    assert result.details["promote_rc"] == -1
+
+
+def test_resolve_repos_root_prefers_configured_local_path(tmp_path):
+    repo = tmp_path / "RepoGraph"
+    repo.mkdir()
+    settings = _settings({"RepoGraph": SimpleNamespace(local_path=str(repo))})
+    assert resolve_repos_root(settings) == tmp_path
+
+
+def test_resolve_repos_root_falls_back_to_checkout_layout():
+    # No configured local paths → derive from this package's location.
+    root = resolve_repos_root(_settings())
+    assert root.name  # a real directory name, not empty
+    assert (root / "OperationsCenter").exists() or root.is_dir()
+
+
+def test_default_timeout_passed_through():
+    captured = {}
+
+    def run(cmd, capture_output=True, text=True, timeout=None):  # noqa: ARG001
+        captured["timeout"] = timeout
+        return _FakeProc(0, "")
+
+    LedgerMaintainTask(_settings(), repos_root=Path("/r"), runner=run).run_once(_ctx())
+    assert captured["timeout"] == 30
+
+
+def test_uses_real_subprocess_run_by_default():
+    # Guard: the default runner is subprocess.run (best-effort live shell-out).
+    task = LedgerMaintainTask(_settings(), repos_root=Path("/r"))
+    assert task._run is subprocess.run


### PR DESCRIPTION
## What
Wires the **controller** to run the operator-interventions ledger's consolidation loop each cycle — the half that pairs with ContextLifecycle #32 (the `cl ledger observe` / `promote` engine).

New `LedgerMaintainTask` (`maintenance/ledger_maintain.py`) registered in the `spec_hygiene` maintenance registry. The durable `spec` fleet role hosts that registry loop, so this runs in-fleet under systemd with no new process.

Each cycle (1h interval, best-effort):
- **`cl ledger promote --repos-root <root>`** — auto-promote each recurrence of a signal whose *first human judgment* carries a live `[check: ref]`, by re-verifying that check still resolves. Invents no judgment. Exit 1 (an encoded check **regressed**) is surfaced in `result.details["regressed"]`, **not** treated as a task failure.
- **`cl ledger observe`** — surface signals recurring without a judgment yet (patterns a human still needs to encode once).

## Design notes
- `repos_root` resolves from a configured repo `local_path` parent, else the checkout layout (`parents[4]`).
- Shell-out matches the capture-side pattern (`pr_review_watcher._capture_human_intervention`): `timeout=30`, try/except, **never breaks the cycle**.
- **No commit or push** of the private manifest — writes land in the working tree only and are idempotent (a promoted line is no longer a candidate). Operator still owns the commit/push.

## Tests
9 new (`tests/maintenance/test_ledger_maintain.py`); maintenance suite **41 green**. ruff + `custodian-doctor --strict` clean (sole audit finding is the pre-existing environmental B2 boundary-artifact check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)