### PR TITLE
feat(watchdog): sandbox base-branch preflight

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-06-17 — feat: sandbox base-branch preflight (watchdog)
+
+New `operations-center-verify-sandbox-branches` maintenance one-shot
+(`entrypoints/maintenance/verify_sandbox_base_branches.py`): per repo with a
+configured `sandbox_base_branch`, verifies it exists on origin (reuses
+`GitClient.verify_remote_branch_exists`); `--heal` creates a missing branch from
+the remote default (`create_remote_branch_from`). Wired into the watchdog loop
+(`operations-center.sh`, hourly, `--heal`) so a missing sandbox branch is fixed
+once, up front, instead of a queue of tasks each stalling on it deep in
+`WorkspaceManager.prepare`. Exit 1 when any configured branch is still missing
+(gate-able). Read-only without `--heal`. 11 tests (injected fake GitClient);
+maintenance suite 52 green; ruff + ty + custodian-doctor clean. Human-implemented
+per operator decision (fleet won't autonomously self-modify from a watchdog
+source) — closes the Plane "[Watchdog] preflight: verify sandbox_base_branch" task.
+
 ## 2026-06-17 — fix: ensure `cl` is resolvable on the fleet watchers' PATH
 
 `watch-all` now resolves the ContextLifecycle `cl` CLI and prepends its dir to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ operations-center-spec-hygiene      = "operations_center.entrypoints.spec_hygien
 # WO-4 orphan-branch detector — remote branches with commits ahead of main,
 # no open PR, older than 24 h. Run in watchdog STEP-2 or as a one-shot sweep.
 operations-center-orphan-branch-check = "operations_center.entrypoints.maintenance.orphan_branch_check:main"
+# Sandbox base-branch preflight — verify each repo's sandbox_base_branch exists
+# on origin (--heal creates it from default). Run in the watchdog loop so a
+# missing branch is fixed before any task stalls on it. Exit 1 if any missing.
+operations-center-verify-sandbox-branches = "operations_center.entrypoints.maintenance.verify_sandbox_base_branches:main"
 
 [project.entry-points."pytest11"]
 flaky-detection = "operations_center.observer.pytest_flaky_plugin"

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -539,6 +539,10 @@ start_watchdog() {
       # limit lifted before the estimated reset, so status surfaces self-heal even
       # when the board is idle. No-op when nothing is cooling.
       '${ROOT_DIR}/scripts/operations-center.sh' worker-backend-probe --timeout 30 >/dev/null 2>&1 || true
+      # Sandbox base-branch preflight (~hourly): ensure each repo's
+      # sandbox_base_branch exists on origin (heal from default if missing), so a
+      # queue of tasks doesn't stall serially discovering it deep in execution.
+      '${VENV_DIR}/bin/operations-center-verify-sandbox-branches' --config '${CONFIG_PATH}' --heal 2>&1 || true
       _slept=0
       while [[ \$_slept -lt 3600 && -f '${pid_file}' ]]; do
         sleep 300

--- a/src/operations_center/entrypoints/maintenance/verify_sandbox_base_branches.py
+++ b/src/operations_center/entrypoints/maintenance/verify_sandbox_base_branches.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Sandbox base-branch preflight — verify each repo's sandbox_base_branch exists.
+
+A repo with a configured ``sandbox_base_branch`` targets autonomy PRs at that
+branch instead of the default branch. If the branch does not exist on origin,
+``WorkspaceManager.prepare`` self-heals per task — but that discovery happens
+*deep in execution, once per task*, so a whole queue of tasks can stall serially
+on the same missing branch before anyone notices.
+
+This preflight surfaces (and optionally heals) the problem *once, up front* — run
+from the watchdog loop so the base branch is guaranteed before any task is
+claimed. Read-only by default; ``--heal`` creates a missing branch from the
+remote default (reusing the same GitClient helpers the per-task self-heal uses).
+
+Run (read-only — report + nonzero exit if any sandbox branch is missing):
+  python -m operations_center.entrypoints.maintenance.verify_sandbox_base_branches \\
+      --config config/operations_center.local.yaml
+
+Run and heal (create any missing sandbox branch from the remote default):
+  python -m operations_center.entrypoints.maintenance.verify_sandbox_base_branches \\
+      --config config/operations_center.local.yaml --heal
+
+Exit code: 0 when every configured sandbox branch exists (or was healed); 1 when
+any remains missing (so a watchdog wrapper can alarm).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from operations_center.adapters.git.client import GitClient
+from operations_center.config import load_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SandboxBranchResult:
+    """Per-repo outcome of the sandbox base-branch preflight."""
+
+    repo_key: str
+    sandbox_base_branch: str | None
+    exists: bool = False
+    healed: bool = False
+    skipped: bool = False
+    error: str | None = None
+
+    @property
+    def missing(self) -> bool:
+        """A configured branch that is absent on origin and was not healed."""
+        return (
+            not self.skipped
+            and self.sandbox_base_branch is not None
+            and not self.exists
+            and self.error is None
+        )
+
+
+def _fetch_origin(local_path: Path) -> None:
+    """Best-effort ``git fetch`` so origin/<default> is resolvable for a heal."""
+    GitClient()._run(["git", "fetch", "origin", "--quiet"], cwd=local_path, timeout=120)
+
+
+def _check_repo(
+    repo_key: str,
+    local_path: Path,
+    sandbox_base_branch: str | None,
+    default_branch: str,
+    *,
+    heal: bool,
+    git: GitClient,
+    fetch: Any,
+) -> SandboxBranchResult:
+    result = SandboxBranchResult(repo_key=repo_key, sandbox_base_branch=sandbox_base_branch)
+
+    # No sandbox branch configured → nothing to verify (the repo uses its default).
+    if not sandbox_base_branch:
+        result.skipped = True
+        return result
+    if not (local_path / ".git").exists():
+        result.skipped = True
+        result.error = "no local checkout"
+        return result
+
+    try:
+        git.verify_remote_branch_exists(local_path, sandbox_base_branch)
+        result.exists = True
+        return result
+    except ValueError:
+        result.exists = False  # branch genuinely absent on origin
+    except Exception as exc:  # noqa: BLE001 — ls-remote network/transport failure
+        result.error = f"ls-remote failed: {exc}"
+        return result
+
+    if not heal:
+        return result
+
+    try:
+        fetch(local_path)
+        git.create_remote_branch_from(local_path, sandbox_base_branch, f"origin/{default_branch}")
+        result.exists = True
+        result.healed = True
+    except Exception as exc:  # noqa: BLE001 — push/fetch failure during heal
+        result.error = f"heal failed: {exc}"
+    return result
+
+
+def scan(
+    settings: Any,
+    *,
+    heal: bool = False,
+    git: GitClient | None = None,
+    fetch: Any = None,
+) -> list[SandboxBranchResult]:
+    """Check every configured repo's sandbox base branch; optionally heal missing."""
+    git = git or GitClient()
+    fetch = fetch or _fetch_origin
+    results: list[SandboxBranchResult] = []
+    for repo_key, repo_cfg in settings.repos.items():
+        local_path_str = repo_cfg.local_path
+        if not local_path_str:
+            # No local checkout configured — can't verify; skip silently (the
+            # repo isn't serviced from this host).
+            continue
+        results.append(
+            _check_repo(
+                repo_key=repo_key,
+                local_path=Path(local_path_str),
+                sandbox_base_branch=repo_cfg.sandbox_base_branch,
+                default_branch=repo_cfg.default_branch,
+                heal=heal,
+                git=git,
+                fetch=fetch,
+            )
+        )
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sandbox base-branch preflight")
+    parser.add_argument("--config", required=True, help="Path to operations_center.local.yaml")
+    parser.add_argument(
+        "--heal",
+        action="store_true",
+        help="Create any missing sandbox branch from the remote default branch",
+    )
+    parser.add_argument(
+        "--json", dest="output_json", action="store_true", help="Emit JSON output"
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    settings = load_settings(args.config)
+    results = scan(settings, heal=args.heal)
+
+    missing = [r for r in results if r.missing]
+    healed = [r for r in results if r.healed]
+    errors = [r for r in results if r.error]
+
+    if args.output_json:
+        print(
+            json.dumps(
+                {
+                    "scanned_at": datetime.now(UTC).isoformat(),
+                    "healed": args.heal,
+                    "results": [
+                        {
+                            "repo_key": r.repo_key,
+                            "sandbox_base_branch": r.sandbox_base_branch,
+                            "exists": r.exists,
+                            "healed": r.healed,
+                            "skipped": r.skipped,
+                            "error": r.error,
+                        }
+                        for r in results
+                    ],
+                    "missing_count": len(missing),
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        checked = [r for r in results if not r.skipped]
+        if healed:
+            print(f"HEALED ({len(healed)}):")
+            for r in healed:
+                print(f"  {r.repo_key}: created {r.sandbox_base_branch} from default")
+        if missing:
+            print(f"MISSING sandbox base branches ({len(missing)}):")
+            for r in missing:
+                print(f"  {r.repo_key}: {r.sandbox_base_branch} not on origin")
+        if errors:
+            print(f"ERRORS ({len(errors)}):")
+            for r in errors:
+                print(f"  {r.repo_key}: {r.error}")
+        if not missing and not errors:
+            print(f"OK — {len(checked)} configured sandbox branch(es) present.")
+
+    # Nonzero only when a configured branch is still missing (gate the watchdog).
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/maintenance/test_verify_sandbox_base_branches.py
+++ b/tests/maintenance/test_verify_sandbox_base_branches.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for the sandbox base-branch preflight."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from operations_center.entrypoints.maintenance import verify_sandbox_base_branches as mod
+from operations_center.entrypoints.maintenance.verify_sandbox_base_branches import (
+    SandboxBranchResult,
+    main,
+    scan,
+)
+
+
+class _FakeGit:
+    """Duck-typed GitClient: tracks which remote branches 'exist' and creations."""
+
+    def __init__(self, existing=(), verify_raises=None):
+        self.existing = set(existing)
+        self.created: list[tuple[str, str]] = []
+        self._verify_raises = verify_raises
+
+    def verify_remote_branch_exists(self, repo_path, branch):
+        if self._verify_raises is not None:
+            raise self._verify_raises
+        if branch not in self.existing:
+            raise ValueError(f"Base branch does not exist on remote: {branch}")
+
+    def create_remote_branch_from(self, repo_path, branch, source_ref):
+        self.created.append((branch, source_ref))
+        self.existing.add(branch)
+
+
+def _repo(tmp_path, *, sandbox="sandbox", default="main", git=True):
+    p = tmp_path
+    if git:
+        (p / ".git").mkdir(parents=True, exist_ok=True)
+    return SimpleNamespace(
+        local_path=str(p), sandbox_base_branch=sandbox, default_branch=default
+    )
+
+
+def _settings(repos):
+    return SimpleNamespace(repos=repos)
+
+
+def _noop_fetch(_path):
+    return None
+
+
+def test_existing_branch_is_present_not_missing(tmp_path):
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox")})
+    res = scan(s, git=_FakeGit(existing=["sandbox"]), fetch=_noop_fetch)
+    assert len(res) == 1
+    assert isinstance(res[0], SandboxBranchResult)
+    assert res[0].exists is True
+    assert res[0].missing is False
+
+
+def test_missing_branch_without_heal_is_flagged(tmp_path):
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox")})
+    res = scan(s, git=_FakeGit(existing=[]), fetch=_noop_fetch)
+    assert res[0].exists is False
+    assert res[0].healed is False
+    assert res[0].missing is True
+
+
+def test_missing_branch_with_heal_is_created(tmp_path):
+    git = _FakeGit(existing=[])
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox", default="main")})
+    res = scan(s, heal=True, git=git, fetch=_noop_fetch)
+    assert res[0].healed is True
+    assert res[0].exists is True
+    assert res[0].missing is False
+    assert git.created == [("sandbox", "origin/main")]
+
+
+def test_no_sandbox_configured_is_skipped(tmp_path):
+    s = _settings({"R": _repo(tmp_path, sandbox=None)})
+    res = scan(s, git=_FakeGit(), fetch=_noop_fetch)
+    assert res[0].skipped is True
+    assert res[0].missing is False
+
+
+def test_no_local_checkout_is_skipped_with_error(tmp_path):
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox", git=False)})
+    res = scan(s, git=_FakeGit(), fetch=_noop_fetch)
+    assert res[0].skipped is True
+    assert res[0].error == "no local checkout"
+    assert res[0].missing is False
+
+
+def test_ls_remote_failure_is_error_not_missing(tmp_path):
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox")})
+    res = scan(s, git=_FakeGit(verify_raises=RuntimeError("network down")), fetch=_noop_fetch)
+    assert res[0].error is not None and "ls-remote failed" in res[0].error
+    assert res[0].missing is False  # transport failure ≠ a known-missing branch
+
+
+def test_heal_failure_records_error(tmp_path):
+    class _BoomGit(_FakeGit):
+        def create_remote_branch_from(self, repo_path, branch, source_ref):
+            raise RuntimeError("push denied")
+
+    s = _settings({"R": _repo(tmp_path, sandbox="sandbox")})
+    res = scan(s, heal=True, git=_BoomGit(existing=[]), fetch=_noop_fetch)
+    assert res[0].healed is False
+    assert "heal failed" in (res[0].error or "")
+
+
+def test_repo_without_local_path_is_dropped(tmp_path):
+    s = _settings({"R": SimpleNamespace(local_path=None, sandbox_base_branch="x", default_branch="main")})
+    res = scan(s, git=_FakeGit(), fetch=_noop_fetch)
+    assert res == []  # no local checkout configured → not serviced here
+
+
+def test_main_exit_1_when_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: _settings({"R": _repo(tmp_path, sandbox="sandbox")}))
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [SandboxBranchResult("R", "sandbox", exists=False)])
+    rc = main(["--config", "x.yaml"])
+    assert rc == 1
+    assert "MISSING" in capsys.readouterr().out
+
+
+def test_main_exit_0_when_all_present(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: _settings({"R": _repo(tmp_path, sandbox="sandbox")}))
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [SandboxBranchResult("R", "sandbox", exists=True)])
+    rc = main(["--config", "x.yaml"])
+    assert rc == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_json_output(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: _settings({"R": _repo(tmp_path, sandbox="sandbox")}))
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [SandboxBranchResult("R", "sandbox", exists=True, healed=True)])
+    rc = main(["--config", "x.yaml", "--json", "--heal"])
+    import json as _json
+
+    payload = _json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["results"][0]["healed"] is True


### PR DESCRIPTION
## What
New `operations-center-verify-sandbox-branches` maintenance one-shot: for each repo with a configured `sandbox_base_branch`, verify it exists on origin; `--heal` creates a missing branch from the remote default. Wired into the watchdog loop (hourly, `--heal`).

## Why
A repo's `sandbox_base_branch` targets autonomy PRs at a non-default branch. If it's missing, `WorkspaceManager.prepare` self-heals **per task, deep in execution** — so a whole queue of tasks can stall serially before anyone notices. This preflight surfaces (and heals) it **once, up front**, at watchdog time.

## How
- Reuses the existing `GitClient` helpers the per-task self-heal already uses: `verify_remote_branch_exists` (check) + `create_remote_branch_from` (heal from `origin/<default>`).
- Read-only without `--heal`; **exit 1** when any configured branch is still missing (so the watchdog wrapper can alarm).
- Mirrors the `orphan_branch_check` one-shot structure.

## Tests
11 new (injected fake `GitClient` — no real git): present/missing/heal/heal-failure/ls-remote-failure/no-sandbox/no-checkout, plus `main()` exit codes + JSON. Maintenance suite **52 green**. ruff + ty + custodian-doctor clean.

Human-implemented per operator decision — the fleet won't autonomously self-modify from a `watchdog` source. Closes the `[Watchdog] preflight: verify sandbox_base_branch` Plane task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)