### PR TITLE
feat(maintenance): reconcile merged PRs to Plane tasks

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,22 @@
+## 2026-06-17 — feat: merged-PR → Plane-task reconciler (close done-but-open debt)
+
+New `operations-center-reconcile-merged-tasks` one-shot
+(`entrypoints/maintenance/reconcile_merged_tasks.py`): marks a non-terminal Plane
+task Done when a *merged* PR closes it, via either (1) an explicit
+`Closes/Fixes/Resolves <task-id>` reference in the merged PR title/body, or
+(2) the In-Review convention — an `In Review` task whose description references a
+now-merged PR number (`#<n>`/`/<n>`, the same link `_find_plane_task_id` uses).
+Scoped per-repo by the `repo:` label; read-only by default, `--apply` transitions
++ comments. Closes the gap where `pr_review_watcher._merge_and_done` only marks
+Done when *it* merges — PRs merged out-of-band (manual `gh pr merge`, another
+host, watcher down) left tasks stuck open, which is the root cause of the
+done-but-open board debt found during the 2026-06-17 backlog triage. Pure
+`find_closures` matcher (explicit-ref wins over convention; each task closed once;
+terminal/ wrong-repo skipped) + injected-fake I/O. 15 tests; maintenance suite 67
+green; ruff + ty + custodian-doctor clean. Human-implemented per operator decision
+(fleet won't autonomously self-modify from a watchdog source) — closes the Plane
+"Promote: detect 'Closes <task-id>' commits" task.
+
 ## 2026-06-17 — feat: sandbox base-branch preflight (watchdog)
 
 New `operations-center-verify-sandbox-branches` maintenance one-shot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ operations-center-orphan-branch-check = "operations_center.entrypoints.maintenan
 # on origin (--heal creates it from default). Run in the watchdog loop so a
 # missing branch is fixed before any task stalls on it. Exit 1 if any missing.
 operations-center-verify-sandbox-branches = "operations_center.entrypoints.maintenance.verify_sandbox_base_branches:main"
+# Merged-PR → Plane-task reconciler — mark a non-terminal task Done when a merged
+# PR closes it (explicit "Closes <task-id>" ref, or an In-Review task whose
+# description references a now-merged PR). Fixes done-but-open board debt. Read-
+# only without --apply.
+operations-center-reconcile-merged-tasks = "operations_center.entrypoints.maintenance.reconcile_merged_tasks:main"
 
 [project.entry-points."pytest11"]
 flaky-detection = "operations_center.observer.pytest_flaky_plugin"

--- a/src/operations_center/entrypoints/maintenance/reconcile_merged_tasks.py
+++ b/src/operations_center/entrypoints/maintenance/reconcile_merged_tasks.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Reconcile merged PRs to their Plane tasks — mark a task Done on merge.
+
+The pr_review_watcher marks a task Done only when *it* merges the PR
+(`_merge_and_done`). A PR merged by any other path — a manual `gh pr merge`,
+another host, or while this watcher was down — leaves its Plane task stuck in a
+non-terminal state forever. The board then accretes "done-but-open" debt that
+looks like a pending queue.
+
+This reconciler closes that gap. A non-terminal task is marked Done when a
+*merged* PR closes it, via either signal:
+
+  1. **Explicit close-reference** — a merged PR's title/body says
+     ``Closes <task-id>`` / ``Fixes <task-id>`` / ``Resolves <task-id>``
+     naming the task's id. Robust and unambiguous; works for any merge path.
+  2. **In-Review convention** — an ``In Review`` task whose description
+     references a now-merged PR number (``#<n>`` / ``/<n>``), the exact link the
+     watcher itself uses (`_find_plane_task_id`). Catches PRs merged out-of-band.
+
+Read-only by default (reports proposed closures); ``--apply`` transitions the
+tasks to Done with a citation comment. Scoped per-repo by the ``repo:`` label so
+it never closes a task against an unrelated repo's PR.
+
+Run (report only):
+  python -m operations_center.entrypoints.maintenance.reconcile_merged_tasks \\
+      --config config/operations_center.local.yaml
+
+Apply (mark matched tasks Done):
+  python -m operations_center.entrypoints.maintenance.reconcile_merged_tasks \\
+      --config config/operations_center.local.yaml --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from operations_center.adapters.github_pr import GitHubPRClient
+from operations_center.config import load_settings
+
+logger = logging.getLogger(__name__)
+
+_TERMINAL_STATES = frozenset({"done", "cancelled"})
+
+# "Closes <id>", "Fixes: <id>", "Resolved task <id>", "Promotes <id>" — capture
+# the id token (a Plane UUID, or any 6+ hex/alnum-dash run). Case-insensitive.
+_CLOSE_REF_RE = re.compile(
+    r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|promote[sd]?)"
+    r"\s*:?\s+(?:task\s+|plane\s+|issue\s+)?"
+    r"([0-9a-fA-F]{8}-[0-9a-fA-F-]{8,}|[A-Za-z0-9][A-Za-z0-9-]{5,})",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class TaskClosure:
+    """A non-terminal task that a merged PR has closed."""
+
+    repo_key: str
+    task_id: str
+    task_name: str
+    pr_number: int
+    via: str  # "closes-ref" | "in-review-pr-merged"
+
+
+def _label_value(labels: list, prefix: str) -> str:
+    for lab in labels or []:
+        name = (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
+        if name.lower().startswith(prefix.lower() + ":"):
+            return name.split(":", 1)[1].strip()
+    return ""
+
+
+def _state_name(issue: dict) -> str:
+    state = issue.get("state")
+    if isinstance(state, dict):
+        return str(state.get("name", "")).strip().lower()
+    return str(state or "").strip().lower()
+
+
+def find_closures(
+    issues: list[dict], merged_prs: list[dict], repo_key: str
+) -> list[TaskClosure]:
+    """Pure matcher: which non-terminal `repo_key` tasks are closed by a merge.
+
+    ``merged_prs`` are dicts with ``number``, ``title``, ``body``. Each task is
+    matched at most once; the explicit close-ref wins over the In-Review
+    convention.
+    """
+    merged_numbers = sorted({int(pr["number"]) for pr in merged_prs if pr.get("number")})
+    # token (lowercased) -> earliest merged PR number that close-referenced it
+    ref_to_pr: dict[str, int] = {}
+    for pr in merged_prs:
+        num = pr.get("number")
+        if num is None:
+            continue
+        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        for m in _CLOSE_REF_RE.finditer(text):
+            ref_to_pr.setdefault(m.group(1).lower(), int(num))
+
+    closures: list[TaskClosure] = []
+    for issue in issues:
+        if _state_name(issue) in _TERMINAL_STATES:
+            continue
+        if _label_value(issue.get("labels", []), "repo") != repo_key:
+            continue
+        task_id = str(issue.get("id") or "").strip()
+        if not task_id:
+            continue
+        name = str(issue.get("name") or "").strip()
+
+        # (1) explicit close-reference naming this task's id
+        if task_id.lower() in ref_to_pr:
+            closures.append(
+                TaskClosure(repo_key, task_id, name, ref_to_pr[task_id.lower()], "closes-ref")
+            )
+            continue
+
+        # (2) In-Review task whose description references a now-merged PR number
+        if _state_name(issue) == "in review":
+            desc = str(issue.get("description") or issue.get("description_stripped") or "")
+            for n in merged_numbers:
+                if f"#{n}" in desc or f"/{n}" in desc:
+                    closures.append(
+                        TaskClosure(repo_key, task_id, name, n, "in-review-pr-merged")
+                    )
+                    break
+    return closures
+
+
+def _merged_prs_recent(
+    github: GitHubPRClient, clone_url: str, *, days: int, now: datetime
+) -> list[dict]:
+    """Closed PRs that were merged within the last ``days``."""
+    try:
+        owner, repo = GitHubPRClient.owner_repo_from_clone_url(clone_url)
+        prs = github.list_closed_prs(owner, repo)
+    except Exception as exc:  # noqa: BLE001 — network/transport; treat as no data
+        logger.warning("could not list closed PRs for %s: %s", clone_url, exc)
+        return []
+    cutoff = now - timedelta(days=days)
+    out: list[dict] = []
+    for pr in prs:
+        merged_at = pr.get("merged_at")
+        if not merged_at:
+            continue  # closed-unmerged — not a completion
+        try:
+            when = datetime.fromisoformat(str(merged_at).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if when >= cutoff:
+            out.append(pr)
+    return out
+
+
+def _plane_client(settings: Any):
+    from operations_center.adapters.plane import PlaneClient
+
+    return PlaneClient(
+        base_url=settings.plane.base_url,
+        api_token=settings.plane_token(),
+        workspace_slug=settings.plane.workspace_slug,
+        project_id=settings.plane.project_id,
+    )
+
+
+def scan(
+    settings: Any,
+    *,
+    days: int = 7,
+    github: GitHubPRClient | None = None,
+    issues: list[dict] | None = None,
+    now: datetime | None = None,
+) -> list[TaskClosure]:
+    """Find all task closures across configured repos (read-only)."""
+    now = now or datetime.now(UTC)
+    if github is None:
+        token = os.environ.get("GITHUB_TOKEN", "") or os.environ.get("GH_TOKEN", "")
+        github = GitHubPRClient(token=token)
+
+    if issues is None:
+        plane = _plane_client(settings)
+        try:
+            issues = plane.list_issues()
+        finally:
+            plane.close()
+
+    closures: list[TaskClosure] = []
+    for repo_key, repo_cfg in settings.repos.items():
+        if not getattr(repo_cfg, "clone_url", None):
+            continue
+        merged = _merged_prs_recent(github, repo_cfg.clone_url, days=days, now=now)
+        if not merged:
+            continue
+        closures.extend(find_closures(issues, merged, repo_key))
+    return closures
+
+
+def apply_closures(settings: Any, closures: list[TaskClosure]) -> int:
+    """Transition each closure's task to Done with a citation comment."""
+    if not closures:
+        return 0
+    plane = _plane_client(settings)
+    applied = 0
+    try:
+        for c in closures:
+            try:
+                plane.transition_issue(c.task_id, "Done")
+                plane.comment_issue(
+                    c.task_id,
+                    f"Auto-closed: merged PR #{c.pr_number} in {c.repo_key} "
+                    f"({c.via}). Reconciled by reconcile_merged_tasks.",
+                )
+                applied += 1
+            except Exception as exc:  # noqa: BLE001 — one bad task shouldn't abort the rest
+                logger.warning("failed to close task %s: %s", c.task_id, exc)
+    finally:
+        plane.close()
+    return applied
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reconcile merged PRs to Plane tasks")
+    parser.add_argument("--config", required=True, help="Path to operations_center.local.yaml")
+    parser.add_argument(
+        "--days", type=int, default=7, help="Only consider PRs merged within N days (default 7)"
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Mark matched tasks Done (default: report only)"
+    )
+    parser.add_argument("--json", dest="output_json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    settings = load_settings(args.config)
+    closures = scan(settings, days=args.days)
+    applied = apply_closures(settings, closures) if args.apply else 0
+
+    if args.output_json:
+        print(
+            json.dumps(
+                {
+                    "scanned_at": datetime.now(UTC).isoformat(),
+                    "days": args.days,
+                    "applied": bool(args.apply),
+                    "closures": [
+                        {
+                            "repo_key": c.repo_key,
+                            "task_id": c.task_id,
+                            "task_name": c.task_name,
+                            "pr_number": c.pr_number,
+                            "via": c.via,
+                        }
+                        for c in closures
+                    ],
+                    "applied_count": applied,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        if closures:
+            verb = "CLOSED" if args.apply else "WOULD CLOSE"
+            print(f"{verb} ({len(closures)}):")
+            for c in closures:
+                print(f"  {c.repo_key} «{c.task_name[:48]}» ← PR #{c.pr_number} ({c.via})")
+            if not args.apply:
+                print("Re-run with --apply to mark these Done.")
+        else:
+            print("No merged-but-open tasks found.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/maintenance/test_reconcile_merged_tasks.py
+++ b/tests/maintenance/test_reconcile_merged_tasks.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for the merged-PR → Plane-task reconciler."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from operations_center.entrypoints.maintenance import reconcile_merged_tasks as mod
+from operations_center.entrypoints.maintenance.reconcile_merged_tasks import (
+    TaskClosure,
+    _merged_prs_recent,
+    apply_closures,
+    find_closures,
+    main,
+)
+
+_UUID = "abcdef12-3456-7890-abcd-ef1234567890"
+
+
+def _issue(tid, state, *, repo="OperationsCenter", name="t", desc=""):
+    return {
+        "id": tid,
+        "name": name,
+        "state": {"name": state},
+        "labels": [{"name": f"repo: {repo}"}],
+        "description": desc,
+    }
+
+
+def _pr(number, *, title="", body="", merged_at="2026-06-17T00:00:00Z"):
+    return {"number": number, "title": title, "body": body, "merged_at": merged_at}
+
+
+# ── find_closures: the pure matcher ──────────────────────────────────────────
+
+
+def test_explicit_closes_ref_matches_uuid():
+    issues = [_issue(_UUID, "Backlog")]
+    prs = [_pr(42, body=f"Implements the thing.\n\nCloses {_UUID}")]
+    cl = find_closures(issues, prs, "OperationsCenter")
+    assert len(cl) == 1
+    assert isinstance(cl[0], TaskClosure)
+    assert cl[0].task_id == _UUID and cl[0].pr_number == 42 and cl[0].via == "closes-ref"
+
+
+def test_close_keyword_variants_and_case_insensitive():
+    for kw in ("Fixes", "resolved", "RESOLVES task", "Promotes"):
+        cl = find_closures([_issue(_UUID, "Todo")], [_pr(7, title=f"{kw} {_UUID}")], "OperationsCenter")
+        assert len(cl) == 1, kw
+
+
+def test_in_review_task_with_merged_pr_number_in_desc():
+    issues = [_issue(_UUID, "In Review", desc="Tracking work in PR #99.")]
+    cl = find_closures(issues, [_pr(99)], "OperationsCenter")
+    assert len(cl) == 1
+    assert cl[0].via == "in-review-pr-merged" and cl[0].pr_number == 99
+
+
+def test_backlog_task_with_pr_number_is_NOT_closed_by_convention():
+    # The description convention only applies to In Review (where the watcher
+    # actively tracks the PR). A Backlog task merely mentioning #99 is not closed.
+    issues = [_issue(_UUID, "Backlog", desc="see PR #99")]
+    assert find_closures(issues, [_pr(99)], "OperationsCenter") == []
+
+
+def test_terminal_tasks_are_skipped():
+    for st in ("Done", "Cancelled"):
+        issues = [_issue(_UUID, st, desc="PR #99")]
+        prs = [_pr(99, body=f"Closes {_UUID}")]
+        assert find_closures(issues, prs, "OperationsCenter") == []
+
+
+def test_wrong_repo_label_skipped():
+    issues = [_issue(_UUID, "In Review", repo="OtherRepo", desc="PR #99")]
+    assert find_closures(issues, [_pr(99)], "OperationsCenter") == []
+
+
+def test_in_review_without_matching_merged_pr_not_closed():
+    issues = [_issue(_UUID, "In Review", desc="PR #5")]
+    assert find_closures(issues, [_pr(99)], "OperationsCenter") == []  # #5 not merged
+
+
+def test_explicit_ref_wins_over_in_review_convention():
+    issues = [_issue(_UUID, "In Review", desc="PR #99")]
+    prs = [_pr(99), _pr(7, body=f"Closes {_UUID}")]
+    cl = find_closures(issues, prs, "OperationsCenter")
+    assert len(cl) == 1 and cl[0].via == "closes-ref" and cl[0].pr_number == 7
+
+
+def test_each_task_closed_at_most_once():
+    issues = [_issue(_UUID, "In Review", desc="PR #99 and #100")]
+    cl = find_closures(issues, [_pr(99), _pr(100)], "OperationsCenter")
+    assert len(cl) == 1
+
+
+# ── _merged_prs_recent: filtering ────────────────────────────────────────────
+
+
+class _FakeGitHub:
+    def __init__(self, prs):
+        self._prs = prs
+
+    def list_closed_prs(self, owner, repo):
+        return self._prs
+
+
+def test_merged_prs_recent_filters_unmerged_and_old():
+    now = datetime(2026, 6, 17, tzinfo=UTC)
+    prs = [
+        _pr(1, merged_at="2026-06-16T00:00:00Z"),  # recent merged → kept
+        _pr(2, merged_at=None),  # closed-unmerged → dropped
+        _pr(3, merged_at="2026-05-01T00:00:00Z"),  # old → dropped (7d window)
+    ]
+    gh = _FakeGitHub(prs)
+    # owner_repo_from_clone_url is a staticmethod on the real class; patch via clone_url
+    kept = _merged_prs_recent(gh, "https://github.com/ProtocolWarden/OperationsCenter.git", days=7, now=now)
+    assert [p["number"] for p in kept] == [1]
+
+
+# ── apply_closures: I/O via injected fake plane ──────────────────────────────
+
+
+class _FakePlane:
+    def __init__(self):
+        self.transitions = []
+        self.comments = []
+        self.closed = False
+
+    def transition_issue(self, tid, state):
+        self.transitions.append((tid, state))
+
+    def comment_issue(self, tid, md):
+        self.comments.append((tid, md))
+
+    def close(self):
+        self.closed = True
+
+
+def test_apply_closures_transitions_and_comments(monkeypatch):
+    fake = _FakePlane()
+    monkeypatch.setattr(mod, "_plane_client", lambda settings: fake)
+    n = apply_closures(object(), [TaskClosure("R", _UUID, "t", 42, "closes-ref")])
+    assert n == 1
+    assert fake.transitions == [(_UUID, "Done")]
+    assert "PR #42" in fake.comments[0][1]
+    assert fake.closed is True
+
+
+def test_apply_closures_one_failure_does_not_abort(monkeypatch):
+    class _PartialPlane(_FakePlane):
+        def transition_issue(self, tid, state):
+            if tid == "bad":
+                raise RuntimeError("boom")
+            super().transition_issue(tid, state)
+
+    fake = _PartialPlane()
+    monkeypatch.setattr(mod, "_plane_client", lambda settings: fake)
+    n = apply_closures(
+        object(),
+        [TaskClosure("R", "bad", "x", 1, "closes-ref"), TaskClosure("R", _UUID, "y", 2, "closes-ref")],
+    )
+    assert n == 1  # the good one still applied
+    assert fake.closed is True
+
+
+def test_apply_closures_empty_is_noop(monkeypatch):
+    called = {"n": 0}
+    monkeypatch.setattr(mod, "_plane_client", lambda settings: called.__setitem__("n", called["n"] + 1))
+    assert apply_closures(object(), []) == 0
+    assert called["n"] == 0  # no client constructed when nothing to do
+
+
+# ── main: report-only vs apply ───────────────────────────────────────────────
+
+
+def test_main_report_only(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: object())
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [TaskClosure("R", _UUID, "task name", 42, "closes-ref")])
+    applied = {"called": False}
+    monkeypatch.setattr(mod, "apply_closures", lambda *a, **k: applied.__setitem__("called", True) or 1)
+    rc = main(["--config", "x.yaml"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "WOULD CLOSE" in out and "--apply" in out
+    assert applied["called"] is False  # report-only must not apply
+
+
+def test_main_apply(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: object())
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [TaskClosure("R", _UUID, "t", 42, "closes-ref")])
+    monkeypatch.setattr(mod, "apply_closures", lambda *a, **k: 1)
+    rc = main(["--config", "x.yaml", "--apply"])
+    assert rc == 0
+    assert "CLOSED" in capsys.readouterr().out


### PR DESCRIPTION
## What
New `operations-center-reconcile-merged-tasks` one-shot: marks a non-terminal Plane task **Done** when a *merged* PR closes it.

Two signals:
1. **Explicit close-ref** — a merged PR's title/body says `Closes/Fixes/Resolves <task-id>` naming the task's id. Works for any merge path.
2. **In-Review convention** — an `In Review` task whose description references a now-merged PR number (`#<n>`/`/<n>`), the same link `_find_plane_task_id` already uses. Catches PRs merged out-of-band.

Scoped per-repo by the `repo:` label; **read-only by default**, `--apply` transitions + leaves a citation comment.

## Why
`pr_review_watcher._merge_and_done` only marks a task Done when *it* merges the PR. A PR merged any other way — manual `gh pr merge`, another host, or while the watcher was down — leaves its Plane task stuck non-terminal **forever**. That's the root cause of the **done-but-open board debt** surfaced in the 2026-06-17 backlog triage (4 of 5 "fix" tasks were already resolved but never closed). This reconciler closes that gap.

## Design
- Pure `find_closures(issues, merged_prs, repo_key)` matcher — explicit-ref wins over the convention; each task closed at most once; terminal/wrong-repo tasks skipped; Backlog tasks are *not* closed by the description convention (only In-Review, where the watcher actively tracks the PR).
- `_merged_prs_recent` filters to PRs actually merged within `--days` (default 7).
- I/O (`scan`/`apply_closures`) takes injected clients; one failed task doesn't abort the rest.

## Tests
15 new (pure matcher coverage + recency filter + apply path + `main` report-vs-apply). Maintenance suite **67 green**. ruff + ty + custodian-doctor clean.

Human-implemented per operator decision — the fleet won't autonomously self-modify from a `watchdog` source. Closes the `Promote: detect 'Closes <task-id>' commits` Plane task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)