### PR TITLE
fix(fleet): anchor at CL_ANCHOR to unblock agent execution

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-17 — fix: anchor the fleet at CL_ANCHOR (unblock agent execution)
+
+`watch-all` now sets `CL_ANCHOR` (→ the sibling PlatformManifest manifest, unless
+the operator already set it). Root cause of 3+ Blocked self-modify tasks: an agent
+dispatched into the OC repo loads `.claude/hooks/pre_tool_use.sh` (ContextGuard),
+which **blocks** when `CL_ANCHOR` is unset — the agent returns a prose refusal
+("CL_ANCHOR is not set…") instead of a JSON plan → planner sees non-JSON →
+`backend_error` → task Blocked. The fleet's systemd/login env carried no
+CL_ANCHOR (only an operator shell does), so EVERY agent-driven self-modify failed,
+and the proposer non-convergently re-proposed the same families 100-190×. Same
+class as the cl-on-PATH gap (#308): the fleet env missing a CL integration var.
+Verified: hook exits 0 (ALLOW) with the resolved anchor; `cl_dispatch_wrap`
+activates but no-ops gracefully without a session (`SessionNotStarted` caught in
+cl_wrap, so dispatch never breaks). Sibling to the convergence escalation+breaker
+(separate PR) that makes this failure class *reach* a human next time.
+
 ## 2026-06-17 — feat: merged-PR → Plane-task reconciler (close done-but-open debt)
 
 New `operations-center-reconcile-merged-tasks` one-shot

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -34,6 +34,26 @@ for _cl_dir in "${CL_HOME:-}/bin" "${ROOT_DIR}/../ContextLifecycle/bin"; do
 done
 unset _cl_dir
 
+# Anchor the fleet's ContextLifecycle sessions at the PlatformManifest manifest.
+# OC's CLAUDE.md / ContextGuard (`.claude/hooks/pre_tool_use.sh`) BLOCK any Claude
+# Code session whose CL_ANCHOR is unset — so an agent dispatched into the OC repo
+# returns a prose refusal ("CL_ANCHOR is not set…") instead of a JSON plan, and
+# every self-modify task fails as backend_error (non-JSON from agent). The fleet's
+# systemd/login env carries no CL_ANCHOR, so set it here; the watchers and the
+# agents they spawn (os.environ.copy()) inherit it. `cl_dispatch_wrap` activates
+# but no-ops gracefully without an active session (SessionNotStarted is caught).
+# Respect an operator-set CL_ANCHOR; else resolve the sibling PlatformManifest.
+if [[ -z "${CL_ANCHOR:-}" ]]; then
+  for _anchor in "${CL_HOME:-}/../PlatformManifest" "${ROOT_DIR}/../PlatformManifest"; do
+    if [[ -d "${_anchor}/.context" ]]; then
+      CL_ANCHOR="$(cd "${_anchor}" && pwd)"
+      export CL_ANCHOR
+      break
+    fi
+  done
+  unset _anchor
+fi
+
 ensure_venv() {
   ensure_pip_conf
   if [[ ! -x "${VENV_DIR}/bin/python" ]]; then


### PR DESCRIPTION
## What
`watch-all` now sets `CL_ANCHOR` (→ the sibling PlatformManifest manifest, unless the operator already set it), so the watchers and the agents they spawn (`os.environ.copy()`) inherit it.

## Why
**Root cause of repeated Blocked self-modify tasks.** An agent dispatched into the OC repo loads `.claude/hooks/pre_tool_use.sh` (ContextGuard), which **blocks** when `CL_ANCHOR` is unset:
```
{"decision": "block", "reason": "ContextGuard: CL_ANCHOR is not set…"}
```
The agent then returns that prose refusal instead of a JSON plan → the planner stage gets "non-JSON from agent" → `backend_error` → task **Blocked**. The fleet's systemd/login env carries no `CL_ANCHOR` (only an interactive operator shell does), so **every** agent-driven self-modify task failed — and the proposer non-convergently re-proposed the same `test_visibility`/`observation_coverage` families **100-190×**.

Same class as the cl-on-PATH gap (#308): the fleet environment missing a ContextLifecycle integration variable.

## Verified
- ContextGuard `pre_tool_use.sh` exits **0 (ALLOW)** with the resolved anchor (the anchor's `.context/config.yaml` has `require_capsule: false`, so no secondary block).
- `cl_dispatch_wrap` activates but **no-ops gracefully** without an active session — `hydrate` catches `SessionNotStarted`/`AnchorMissing` (`cl_wrap.py:143`), and `capture` can't mask dispatch — so dispatch never breaks.
- `bash -n` clean; resolution simulated in a stripped `env -i`.

## Scope note
This unblocks execution (clears the ContextGuard block). Full per-dispatch `cl session start` lifecycle (so agent work is captured under the anchor) is a separate enhancement; `cl_wrap`'s graceful no-op makes it safe to ship the anchor alone now.

Paired with the convergence escalation+breaker (separate PR) so this failure class **reaches a human** next time instead of churning silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)