### PR TITLE
feat(maintenance): convergence stall breaker (escalate + suppress)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,22 @@
+## 2026-06-17 — feat: convergence stall breaker (escalate + suppress)
+
+New `operations-center-detect-convergence-stall` one-shot
+(`entrypoints/maintenance/detect_convergence_stall.py`): groups Blocked tasks by
+`(source_family, failure_category)`; when a family hits `--threshold` (default 2)
+identical env/transport failures (`backend_error`/`timeout` — NOT genuine code
+failures), it (1) **escalates** once to the operator ledger
+(`cl ledger capture convergence-stalled "<family>|<cat>|n=<count>"`) so the class
+reaches a human, and (2) **suppresses** re-proposal by recording each stalled
+`dedup_key` in the existing `ProposalRejectionStore` — which the proposer's
+guardrail already consults (`is_rejected`), so NO proposer change is needed.
+Read-only without `--apply`; wired into the watchdog loop. Closes the silent
+unbounded propose→fail→re-propose loop (2026-06-17 incident: one family
+re-proposed ~190× while the agent was blocked on the CL_ANCHOR gap). Pairs with
+the CL_ANCHOR unblock (#311): that fixes the cause, this makes the *class* visible
+and bounded so the fleet stops churning instead of failing silently. Pure
+`find_stalls`/`normalize_task` matchers + injected-fake apply. 14 tests; full
+maintenance/proposer suite 221 green; ruff + ty + custodian-doctor clean.
+
 ## 2026-06-17 — fix: anchor the fleet at CL_ANCHOR (unblock agent execution)
 
 `watch-all` now sets `CL_ANCHOR` (→ the sibling PlatformManifest manifest, unless

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ operations-center-verify-sandbox-branches = "operations_center.entrypoints.maint
 # description references a now-merged PR). Fixes done-but-open board debt. Read-
 # only without --apply.
 operations-center-reconcile-merged-tasks = "operations_center.entrypoints.maintenance.reconcile_merged_tasks:main"
+# Convergence stall breaker — when a source_family's Blocked tasks fail
+# identically past a threshold (env/transport, not code), escalate to the
+# operator ledger and suppress re-proposal via the existing rejection store.
+operations-center-detect-convergence-stall = "operations_center.entrypoints.maintenance.detect_convergence_stall:main"
 
 [project.entry-points."pytest11"]
 flaky-detection = "operations_center.observer.pytest_flaky_plugin"

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -563,6 +563,10 @@ start_watchdog() {
       # sandbox_base_branch exists on origin (heal from default if missing), so a
       # queue of tasks doesn't stall serially discovering it deep in execution.
       '${VENV_DIR}/bin/operations-center-verify-sandbox-branches' --config '${CONFIG_PATH}' --heal 2>&1 || true
+      # Convergence stall breaker (~hourly): when a candidate family's Blocked
+      # tasks fail identically (env/transport), escalate to the operator ledger
+      # and suppress re-proposal so the propose->fail->re-propose loop converges.
+      '${VENV_DIR}/bin/operations-center-detect-convergence-stall' --config '${CONFIG_PATH}' --apply 2>&1 || true
       _slept=0
       while [[ \$_slept -lt 3600 && -f '${pid_file}' ]]; do
         sleep 300

--- a/src/operations_center/entrypoints/maintenance/detect_convergence_stall.py
+++ b/src/operations_center/entrypoints/maintenance/detect_convergence_stall.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Convergence stall breaker — stop a candidate family that can never converge.
+
+A proposer ``source_family`` (e.g. ``test_visibility``) keeps observing a symptom,
+proposing a fix, the fix fails *identically* (e.g. ``backend_error`` — the agent
+blocked by an environment fault), the task lands Blocked, the symptom is
+re-observed, and a new task is proposed. With no upper bound this loops unbounded
+(the 2026-06-17 incident: one family re-proposed ~190×) — burning cycles while
+nothing converges, and silently (no human is told).
+
+This breaker closes both gaps. It groups Blocked tasks by
+``(source_family, failure_category)``; when a group reaches ``--threshold``
+identical failures it:
+
+  1. **Escalates** once to the operator-interventions ledger
+     (``cl ledger capture convergence-stalled "<family>|<category>|n=<count>"``),
+     so the failure class *reaches a human* — capture, never auto-judge.
+  2. **Suppresses** further re-proposal by recording each stalled task's
+     ``dedup_key`` in the existing ``ProposalRejectionStore``, which the
+     proposer's guardrail already consults (``is_rejected``) before proposing —
+     so no proposer change is needed.
+
+Read-only by default (reports the stalls); ``--apply`` performs the escalation +
+suppression. Run from the watchdog loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from operations_center.config import load_settings
+from operations_center.proposer.rejection_store import ProposalRejectionStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THRESHOLD = 2
+# Only env/transport-shaped failures convey "can never converge as proposed" — a
+# genuine code failure (test/lint) is the task legitimately doing its job.
+_STALL_CATEGORIES = frozenset({"backend_error", "timeout"})
+
+_FAMILY_RE = re.compile(r"source[_-]family:\s*(\S+)", re.IGNORECASE)
+_DEDUP_RE = re.compile(r"(?:candidate_)?dedup_key:\s*(\S+)", re.IGNORECASE)
+_CATEGORY_RE = re.compile(r"category:\s*(\S+)", re.IGNORECASE)
+
+
+@dataclass
+class StalledFamily:
+    """A (family, failure_category) group that has stalled past the threshold."""
+
+    family: str
+    failure_category: str
+    count: int
+    task_ids: list[str] = field(default_factory=list)
+    dedup_keys: list[str] = field(default_factory=list)
+    titles: list[str] = field(default_factory=list)
+
+
+def _label_value(labels: list, prefix: str) -> str:
+    for lab in labels or []:
+        name = (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
+        if name.lower().startswith(prefix.lower() + ":"):
+            return name.split(":", 1)[1].strip()
+    return ""
+
+
+def normalize_task(issue: dict, comments_text: str) -> dict[str, Any]:
+    """Extract (family, dedup_key, failure_category) for one Blocked task.
+
+    ``comments_text`` is the concatenated comment bodies (where board_worker
+    records the failure category); the family/dedup_key live in the description
+    Provenance block (label fallback for family).
+    """
+    desc = str(issue.get("description") or issue.get("description_stripped") or "")
+    family = ""
+    m = _FAMILY_RE.search(desc)
+    if m:
+        family = m.group(1)
+    if not family:
+        family = _label_value(issue.get("labels", []), "source-family") or _label_value(
+            issue.get("labels", []), "source_family"
+        )
+    dedup = ""
+    md = _DEDUP_RE.search(desc) or _DEDUP_RE.search(comments_text)
+    if md:
+        dedup = md.group(1)
+    # Failure category: last category mention wins (most recent attempt).
+    cats = _CATEGORY_RE.findall(comments_text)
+    category = cats[-1].strip().lower() if cats else ""
+    return {
+        "task_id": str(issue.get("id") or ""),
+        "title": str(issue.get("name") or ""),
+        "family": family,
+        "dedup_key": dedup,
+        "failure_category": category,
+    }
+
+
+def find_stalls(
+    normalized: list[dict[str, Any]], *, threshold: int = DEFAULT_THRESHOLD
+) -> list[StalledFamily]:
+    """Group normalized Blocked tasks; return families stalled past ``threshold``.
+
+    A stall is ``threshold``+ tasks sharing the same family AND the same
+    env/transport failure category. Tasks with no family or a non-stall category
+    are ignored (a genuine code failure is the task doing its job).
+    """
+    groups: dict[tuple[str, str], StalledFamily] = {}
+    for t in normalized:
+        family = t.get("family") or ""
+        category = t.get("failure_category") or ""
+        if not family or category not in _STALL_CATEGORIES:
+            continue
+        key = (family, category)
+        g = groups.get(key)
+        if g is None:
+            g = StalledFamily(family=family, failure_category=category, count=0)
+            groups[key] = g
+        g.count += 1
+        if t.get("task_id"):
+            g.task_ids.append(t["task_id"])
+        if t.get("dedup_key"):
+            g.dedup_keys.append(t["dedup_key"])
+        if t.get("title"):
+            g.titles.append(t["title"])
+    stalls = [g for g in groups.values() if g.count >= threshold]
+    stalls.sort(key=lambda s: s.count, reverse=True)
+    return stalls
+
+
+def _capture_escalation(family: str, category: str, count: int) -> None:
+    """Best-effort operator-ledger escalation (mirrors pr_review_watcher)."""
+    try:
+        subprocess.run(
+            [
+                "cl",
+                "ledger",
+                "capture",
+                "convergence-stalled",
+                f"{family}|{category}|n={count}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:  # noqa: BLE001 — escalation is best-effort
+        logger.debug("ledger capture failed for %s — %s", family, exc)
+
+
+def apply_breaker(
+    stalls: list[StalledFamily],
+    *,
+    store: ProposalRejectionStore | None = None,
+    capture: Any = None,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Escalate once per family and suppress each stalled dedup_key. Returns counts."""
+    store = store or ProposalRejectionStore()
+    capture = capture or _capture_escalation
+    now = now or datetime.now(UTC)
+    escalated = 0
+    suppressed = 0
+    for s in stalls:
+        capture(s.family, s.failure_category, s.count)
+        escalated += 1
+        for dedup, title in zip(s.dedup_keys, s.titles + [""] * len(s.dedup_keys)):
+            if not dedup:
+                continue
+            if not store.is_rejected(dedup):
+                store.record_rejection(
+                    dedup,
+                    reason=f"convergence-stalled: {s.family}/{s.failure_category} "
+                    f"x{s.count} (auto-suppressed by convergence breaker)",
+                    task_id=s.task_ids[0] if s.task_ids else "",
+                    task_title=title,
+                    now=now,
+                )
+                suppressed += 1
+    return {"escalated": escalated, "suppressed": suppressed}
+
+
+def _plane_client(settings: Any):
+    from operations_center.adapters.plane import PlaneClient
+
+    return PlaneClient(
+        base_url=settings.plane.base_url,
+        api_token=settings.plane_token(),
+        workspace_slug=settings.plane.workspace_slug,
+        project_id=settings.plane.project_id,
+    )
+
+
+def scan(settings: Any, *, threshold: int = DEFAULT_THRESHOLD) -> list[StalledFamily]:
+    """Fetch Blocked tasks + their comments, normalize, and find stalls."""
+    plane = _plane_client(settings)
+    normalized: list[dict[str, Any]] = []
+    try:
+        for issue in plane.list_issues():
+            state = issue.get("state")
+            sname = (state.get("name", "") if isinstance(state, dict) else str(state or "")).strip()
+            if sname.lower() != "blocked":
+                continue
+            try:
+                comments = plane.list_comments(str(issue["id"]))
+            except Exception:  # noqa: BLE001 — a task with unreadable comments is skipped
+                comments = []
+            text = "\n".join(
+                re.sub("<[^>]+>", "", c.get("comment_html", "") or "") for c in comments
+            )
+            normalized.append(normalize_task(issue, text))
+    finally:
+        plane.close()
+    return find_stalls(normalized, threshold=threshold)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convergence stall breaker")
+    parser.add_argument("--config", required=True, help="Path to operations_center.local.yaml")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        help=f"Identical Blocked failures per family to trip the breaker (default {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Escalate + suppress (default: report only)",
+    )
+    parser.add_argument("--json", dest="output_json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    settings = load_settings(args.config)
+    stalls = scan(settings, threshold=args.threshold)
+    result = apply_breaker(stalls) if args.apply else {"escalated": 0, "suppressed": 0}
+
+    if args.output_json:
+        print(
+            json.dumps(
+                {
+                    "scanned_at": datetime.now(UTC).isoformat(),
+                    "threshold": args.threshold,
+                    "applied": bool(args.apply),
+                    "stalls": [
+                        {
+                            "family": s.family,
+                            "failure_category": s.failure_category,
+                            "count": s.count,
+                            "dedup_keys": sorted(set(s.dedup_keys)),
+                        }
+                        for s in stalls
+                    ],
+                    **result,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        if stalls:
+            verb = "BROKE" if args.apply else "WOULD BREAK"
+            print(f"{verb} {len(stalls)} convergence stall(s):")
+            for s in stalls:
+                print(
+                    f"  {s.family} / {s.failure_category}: {s.count} blocked "
+                    f"({len(set(s.dedup_keys))} dedup_key(s))"
+                )
+            if not args.apply:
+                print("Re-run with --apply to escalate + suppress re-proposal.")
+        else:
+            print("No convergence stalls found.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/maintenance/test_detect_convergence_stall.py
+++ b/tests/maintenance/test_detect_convergence_stall.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Unit tests for the convergence stall breaker."""
+
+from __future__ import annotations
+
+from operations_center.entrypoints.maintenance import detect_convergence_stall as mod
+from operations_center.entrypoints.maintenance.detect_convergence_stall import (
+    StalledFamily,
+    apply_breaker,
+    find_stalls,
+    main,
+    normalize_task,
+)
+
+_DESC = "## Provenance\nsource_family: test_visibility\ncandidate_dedup_key: candidate|test_visibility|tv|unknown\n"
+_FAIL_COMMENT = "board_worker[improve] failed\n- status: failed\n- category: backend_error\n- reason: non-JSON from agent"
+
+
+def _issue(tid, *, state="Blocked", desc=_DESC, name="t", labels=None):
+    return {
+        "id": tid,
+        "name": name,
+        "state": {"name": state},
+        "description": desc,
+        "labels": labels or [],
+    }
+
+
+# ── normalize_task ───────────────────────────────────────────────────────────
+
+
+def test_normalize_extracts_family_dedup_category():
+    n = normalize_task(_issue("1"), _FAIL_COMMENT)
+    assert n["family"] == "test_visibility"
+    assert n["dedup_key"] == "candidate|test_visibility|tv|unknown"
+    assert n["failure_category"] == "backend_error"
+
+
+def test_normalize_family_from_label_fallback():
+    issue = _issue("1", desc="no provenance here", labels=[{"name": "source-family: observation_coverage"}])
+    assert normalize_task(issue, _FAIL_COMMENT)["family"] == "observation_coverage"
+
+
+def test_normalize_last_category_wins():
+    comments = "category: timeout\n...\ncategory: backend_error"
+    assert normalize_task(_issue("1"), comments)["failure_category"] == "backend_error"
+
+
+# ── find_stalls ──────────────────────────────────────────────────────────────
+
+
+def _norm(family, category, dedup, tid):
+    return {"task_id": tid, "title": f"t{tid}", "family": family, "dedup_key": dedup, "failure_category": category}
+
+
+def test_two_backend_errors_same_family_trips_threshold():
+    items = [
+        _norm("test_visibility", "backend_error", "k1", "1"),
+        _norm("test_visibility", "backend_error", "k2", "2"),
+    ]
+    stalls = find_stalls(items, threshold=2)
+    assert len(stalls) == 1
+    assert isinstance(stalls[0], StalledFamily)
+    assert stalls[0].count == 2
+    assert sorted(stalls[0].dedup_keys) == ["k1", "k2"]
+
+
+def test_below_threshold_not_a_stall():
+    items = [_norm("test_visibility", "backend_error", "k1", "1")]
+    assert find_stalls(items, threshold=2) == []
+
+
+def test_genuine_code_failure_category_ignored():
+    # A real test/lint failure is the task doing its job — not a convergence stall.
+    items = [
+        _norm("lint_fix", "test_failure", "k1", "1"),
+        _norm("lint_fix", "test_failure", "k2", "2"),
+    ]
+    assert find_stalls(items, threshold=2) == []
+
+
+def test_no_family_ignored():
+    items = [_norm("", "backend_error", "k1", "1"), _norm("", "backend_error", "k2", "2")]
+    assert find_stalls(items, threshold=2) == []
+
+
+def test_distinct_families_grouped_separately():
+    items = [
+        _norm("a", "backend_error", "k1", "1"),
+        _norm("a", "backend_error", "k2", "2"),
+        _norm("b", "backend_error", "k3", "3"),  # only 1 → below threshold
+    ]
+    stalls = find_stalls(items, threshold=2)
+    assert [s.family for s in stalls] == ["a"]
+
+
+def test_sorted_by_count_desc():
+    items = (
+        [_norm("hot", "backend_error", f"h{i}", str(i)) for i in range(3)]
+        + [_norm("low", "backend_error", f"l{i}", str(10 + i)) for i in range(2)]
+    )
+    stalls = find_stalls(items, threshold=2)
+    assert [s.family for s in stalls] == ["hot", "low"]
+
+
+# ── apply_breaker ────────────────────────────────────────────────────────────
+
+
+class _FakeStore:
+    def __init__(self, rejected=()):
+        self.rejected = set(rejected)
+        self.records: list[str] = []
+
+    def is_rejected(self, k):
+        return k in self.rejected
+
+    def record_rejection(self, k, *, reason, task_id, task_title="", now=None):
+        self.records.append(k)
+        self.rejected.add(k)
+
+
+def test_apply_escalates_once_and_suppresses_each_dedup():
+    captures = []
+    store = _FakeStore()
+    s = StalledFamily("fam", "backend_error", 2, task_ids=["1", "2"], dedup_keys=["k1", "k2"], titles=["t1", "t2"])
+    res = apply_breaker([s], store=store, capture=lambda f, c, n: captures.append((f, c, n)))
+    assert res == {"escalated": 1, "suppressed": 2}
+    assert captures == [("fam", "backend_error", 2)]
+    assert sorted(store.records) == ["k1", "k2"]
+
+
+def test_apply_skips_already_rejected_dedup():
+    store = _FakeStore(rejected=["k1"])
+    s = StalledFamily("fam", "backend_error", 2, task_ids=["1"], dedup_keys=["k1", "k2"], titles=["t1", "t2"])
+    res = apply_breaker([s], store=store, capture=lambda *a: None)
+    assert res["suppressed"] == 1  # only k2 newly suppressed
+    assert store.records == ["k2"]
+
+
+def test_apply_empty_is_noop():
+    store = _FakeStore()
+    res = apply_breaker([], store=store, capture=lambda *a: None)
+    assert res == {"escalated": 0, "suppressed": 0}
+    assert store.records == []
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+
+def test_main_report_only(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: object())
+    monkeypatch.setattr(
+        mod, "scan", lambda *a, **k: [StalledFamily("fam", "backend_error", 3, dedup_keys=["k1"])]
+    )
+    applied = {"called": False}
+    monkeypatch.setattr(mod, "apply_breaker", lambda *a, **k: applied.__setitem__("called", True) or {})
+    rc = main(["--config", "x.yaml"])
+    assert rc == 0
+    assert "WOULD BREAK" in capsys.readouterr().out
+    assert applied["called"] is False
+
+
+def test_main_apply(monkeypatch, capsys):
+    monkeypatch.setattr(mod, "load_settings", lambda _c: object())
+    monkeypatch.setattr(mod, "scan", lambda *a, **k: [StalledFamily("fam", "backend_error", 3, dedup_keys=["k1"])])
+    monkeypatch.setattr(mod, "apply_breaker", lambda *a, **k: {"escalated": 1, "suppressed": 1})
+    rc = main(["--config", "x.yaml", "--apply"])
+    assert rc == 0
+    assert "BROKE" in capsys.readouterr().out


### PR DESCRIPTION
## What
New `operations-center-detect-convergence-stall` one-shot: groups Blocked tasks by `(source_family, failure_category)`; when a family hits `--threshold` (default 2) identical **env/transport** failures (`backend_error`/`timeout`), it:
1. **Escalates** once to the operator-interventions ledger — `cl ledger capture convergence-stalled "<family>|<category>|n=<count>"` — so the failure *class* reaches a human (capture, never auto-judge).
2. **Suppresses** re-proposal by recording each stalled `dedup_key` in the **existing** `ProposalRejectionStore`, which the proposer's guardrail already consults (`is_rejected`) — so **no proposer change** is needed.

Read-only by default; `--apply` performs escalation + suppression; wired into the watchdog loop.

## Why
A `source_family` keeps observing a symptom → proposing a fix → the fix fails *identically* (the agent blocked by an env fault) → Blocked → re-observe → re-propose, **unbounded and silent**. The 2026-06-17 incident: one family re-proposed **~190×** while the agent was blocked on the `CL_ANCHOR` gap. There was no outer circuit-breaker and no escalation path — exactly the gap the fleet's own backlog flagged ("add backend_error retry limit").

Pairs with the `CL_ANCHOR` unblock (#311): **that fixes the cause; this makes the class visible and bounded** so the fleet stops churning instead of failing silently. Genuine **code** failures (`test_failure`, etc.) are deliberately ignored — those are the task doing its job.

## Design
- Pure `normalize_task` (family/dedup_key/category from description + comments) and `find_stalls` (group, threshold, sort) — fully unit-tested.
- `apply_breaker` takes an injected store + capture fn; escalates once per family, skips already-rejected dedup_keys.
- Reuses `ProposalRejectionStore.record_rejection` — the same permanent-veto mechanism humans already use.

## Tests
14 new (matcher coverage + apply path + `main` report-vs-apply). Full maintenance/proposer suite **221 green**. ruff + ty + custodian-doctor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)