### PR TITLE
fix(reviewer): don't retract concern-escalations on green CI

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-17 — fix: reviewer verdict authoritative — don't retract concern-escalations on green CI
+
+Governance fix for how #313 shipped broken. `pr_review_watcher._phase1`'s WO-3
+CI-green retraction (the `else` branch when the escalated head is unchanged)
+assumed "CI green ⇒ the test suite validated the implementation" and retracted
+ANY escalation on green CI — including `fix_pass_no_progress` escalations whose
+concerns CI never covered (incomplete STEP-3 integration, docs, completeness).
+It even popped `last_concerns_summary` (forgetting the concerns), so a fresh
+self-review pass then LGTM'd the same broken code → auto-merged. Fix: skip the
+CI-green retraction when there are unresolved concerns on THIS exact unchanged
+head (`last_concerns_head_sha == current_head_sha`) — CI was already green when
+they were raised, so it's not new information. Such escalations now wait for a
+real new push (changed head, already handled) or a human. The WO-3 blind-spot
+path (no concerns recorded on head) is preserved. 2 regression tests; full
+pr_review_watcher suite 103 green; ruff + ty + custodian-doctor clean.
+
 ## 2026-06-17 — Stage 3: Extend watchdog collector schema to capture extraction signal ✅
 
 **Analysis Complete**: Identified critical gap in watchdog collector visibility into extraction signal quality. Haiku collector currently reports aggregate signal counts (failures, violations, errors) but provides no metrics on extraction success rates — preventing operators from diagnosing collection failures (e.g., "50 test failures reported but only 12 test names extracted").

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1574,9 +1574,22 @@ def _phase1(
             # validated the implementation. Retract the escalation once so the
             # reviewer can re-evaluate without a diff-truncation blind spot.
             # Bounded by _MAX_CI_GREEN_RETRACTIONS to prevent loops.
+            #
+            # EXCEPT when the escalation carries unresolved review concerns on
+            # THIS exact (unchanged) head: CI was ALREADY green when those
+            # concerns were raised, so green CI is not new information and must
+            # not silently clear them. Retracting here shipped #313 — a
+            # fix_pass_no_progress escalation got retracted on green CI, the
+            # concerns were forgotten (last_concerns_* popped below), and a fresh
+            # pass LGTM'd the same broken, CI-invisible integration. A
+            # concern-based escalation waits for a real new push (changed head,
+            # handled above) or a human — never for "CI is still green".
+            _concerns_on_this_head = bool(current_head_sha) and current_head_sha == str(
+                state.get("last_concerns_head_sha") or ""
+            ).strip()
             _ci_green_retracted = state.get("ci_green_retraction_count", 0)
             _did_ci_green_retract = False
-            if _ci_green_retracted < _MAX_CI_GREEN_RETRACTIONS:
+            if not _concerns_on_this_head and _ci_green_retracted < _MAX_CI_GREEN_RETRACTIONS:
                 _rcfg = settings.repos.get(repo_key)
                 if _rcfg and getattr(_rcfg, "auto_merge_on_ci_green", False):
                     _rhead = ((pr_data.get("head") or {}).get("ref") or "").lower()

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -477,6 +477,76 @@ def test_phase1_skips_escalated_pr_without_new_head(tmp_path: Path) -> None:
     assert loaded["escalated_head_sha"] == "abc123"
 
 
+def test_phase1_concern_escalation_not_retracted_on_green_ci(tmp_path: Path) -> None:
+    # Regression for #313: a fix_pass_no_progress escalation carrying unresolved
+    # concerns on THIS unchanged head must NOT be retracted just because CI is
+    # green — CI was already green when the concerns were raised, so it is not
+    # new information. The escalation (and the concerns) must survive.
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="abc123",
+        last_concerns_head_sha="abc123",  # concerns on the current head
+        last_concerns_summary="STEP 3 integration incomplete",
+        no_verdict_passes=0,
+    )
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = []  # CI green
+    gh.get_incomplete_checks.return_value = []  # settled
+    settings = _settings_with_ci_green_repo()
+
+    with (
+        patch.object(watcher, "_run_direct_review") as mock_review,
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc123"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", settings,
+        )
+
+    mock_review.assert_not_called()  # no fresh review to LGTM the same code
+    mock_merge.assert_not_called()
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is True  # NOT retracted
+    assert loaded.get("last_concerns_summary")  # concerns NOT forgotten
+
+
+def test_phase1_blindspot_escalation_still_retracts_on_green_ci(tmp_path: Path) -> None:
+    # The WO-3 path is preserved: an escalation with NO concerns recorded on the
+    # current head (e.g. a diff-truncation blind spot) still retracts on green CI
+    # so the reviewer re-evaluates. Proves the new guard is scoped to concerns.
+    # A real cfg.yaml is provided since retraction falls through to the review.
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("reviewer: {}\n", encoding="utf-8")
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="abc123",
+        no_verdict_passes=0,
+    )  # note: no last_concerns_head_sha
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = []
+    gh.get_incomplete_checks.return_value = []
+    settings = _settings_with_ci_green_repo()
+
+    with (
+        patch.object(
+            watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+        ),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc123"), gh, "owner", "repo",
+            tmp_path, cfg, settings,
+        )
+
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is False  # retracted (no concerns on head)
+    assert loaded.get("ci_green_retraction_count") == 1
+
+
 def test_phase1_resumes_escalated_pr_with_null_sha(tmp_path: Path) -> None:
     # When escalated with escalated_head_sha=None but the current PR data has a
     # head SHA, the watcher should repair the state and keep waiting instead of


### PR DESCRIPTION
## What
`pr_review_watcher._phase1`'s WO-3 CI-green retraction no longer fires when the escalation carries **unresolved review concerns on the current (unchanged) head**.

## Why — this is how #313 shipped broken
The retraction's premise (line ~1573) was *"if CI is green on the escalated head, the test suite has validated the implementation."* That's false for `fix_pass_no_progress` escalations — the concerns there (incomplete STEP-3 integration, contradictory completion claims, a dead `get_extraction_health()` method) are **invisible to CI**. The old code retracted the escalation on green CI **and popped `last_concerns_summary`** (forgetting the concerns), so a fresh self-review pass then LGTM'd the same broken code → `auto_merge_on_ci_green` shipped it.

CI was **already green** when those concerns were raised, so "CI is still green" is not new information and must not clear them.

## Fix
Guard the CI-green retraction with `not _concerns_on_this_head`, where `_concerns_on_this_head = current_head_sha == last_concerns_head_sha`. A concern-based escalation now waits for a **real new push** (changed head — already handled one branch up) or a **human**. The WO-3 blind-spot path (no concerns recorded on the head, e.g. diff-truncation) is preserved.

## Tests
- `test_phase1_concern_escalation_not_retracted_on_green_ci` — concerns on head + green CI → **stays escalated, concerns retained** (the #313 regression).
- `test_phase1_blindspot_escalation_still_retracts_on_green_ci` — no concerns on head + green CI → **still retracts** (guard is scoped).
- Full `pr_review_watcher` suite **103 green**; ruff + ty + custodian-doctor clean.

First of three follow-ups to the #313 post-mortem (this = the governance gap; also: fix-forward the broken integration, and a planning/detector change so OC plans more thoroughly for end-to-end completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)