### PR TITLE
fix(observer): wire STEP 3 to get_extraction_health (real end-to-end)

### DIFF
--- a/.console/backlog.md
+++ b/.console/backlog.md
@@ -1265,8 +1265,17 @@ _Durable work inventory. Update after each meaningful chunk of progress._
 
 ### Next Steps
 
-**Stage 5 (Ready to Start)**:
-- Update haiku_collector_prompt.md STEP 3 to call get_extraction_health()
-- Integrate extraction metrics into watchdog output JSON
-- Add watchdog-level monitoring and alerting for extraction health
+**Stage 5 — integration (post-#313 fix-forward, 2026-06-17)**:
+- ✅ Update haiku_collector_prompt.md STEP 3 to call get_extraction_health() —
+  done via the new `observer extraction-health` CLI command. (#313 merged with
+  this still TODO while claiming "end-to-end" — the self-review flagged exactly
+  this contradiction; it shipped anyway via the CI-green escalation-retraction
+  hole, since fixed. STEP 3 had parsed `query-flaky-tests` output as a `tests[]`
+  array that command never emits.)
+- ⏳ Integrate extraction metrics into watchdog output JSON
+- ⏳ Add watchdog-level monitoring and alerting for extraction health
+
+**Accurate status:** Stage 4 delivered the *backend* (query methods + schema);
+the collector integration is the `extraction-health` command + STEP 3 rewrite
+above. "End-to-end" is true only as of this fix-forward, not at #313's merge.
 

--- a/.console/haiku_collector_prompt.md
+++ b/.console/haiku_collector_prompt.md
@@ -164,61 +164,34 @@ Collect extraction health data from observer to monitor failure categorization c
 
 ```bash
 source .env.operations-center.local
-# Query extraction health from flaky tests
-.venv/bin/operations-center observer query-flaky-tests --format json --output /tmp/oc_extraction_health.json 2>&1
+# Aggregate extraction-coverage health from the observer. This calls
+# get_extraction_health() (FlakyTestQueryMixin) which assesses how many flaky
+# tests have extracted test_name / assertion_message fields. NOTE: use
+# `extraction-health`, NOT `query-flaky-tests` — the latter emits per-test
+# extraction *records* (a `test_failures` array), not the aggregate health, and
+# parsing it as `tests[]` silently yields nothing.
+.venv/bin/operations-center observer extraction-health --format json --hours 24 > /tmp/oc_extraction_health.json 2>/dev/null
 ```
 
-Extract metrics using python3:
+Map the structured ExtractionHealth into the collector's metric schema:
 
 ```bash
 python3 -c "
 import json
 try:
-    d = json.load(open('/tmp/oc_extraction_health.json'))
-    
-    # Collection logic:
-    # Count extracted tests (have test_name or assertion_message) vs total test failures
-    # success_rate = (tests_with_extraction / total_tests) * 100
-    # gaps = tests without any extraction data (both fields missing)
-    # edge_cases = tests with truncated messages or special character issues
-    
-    tests = d.get('tests', []) if isinstance(d, dict) else []
-    total = len(tests)
-    extracted = 0
-    gaps = []
-    edge_cases = []
-    
-    for test in tests:
-        if isinstance(test, dict):
-            has_name = bool(test.get('test_name'))
-            has_msg = bool(test.get('assertion_message'))
-            
-            # Count as extracted if has at least one field
-            if has_name or has_msg:
-                extracted += 1
-            else:
-                gaps.append(test.get('test_id', 'unknown'))
-            
-            # Track edge cases
-            msg = test.get('assertion_message', '')
-            if msg:
-                # Truncation indicator: message ends with ellipsis
-                if msg.endswith('...'):
-                    edge_cases.append({'test_id': test.get('test_id'), 'issue': 'truncated_message'})
-                # Special character tracking: non-ASCII or control chars
-                if not all(ord(c) < 128 for c in msg if c not in '\\t\\n\\r'):
-                    edge_cases.append({'test_id': test.get('test_id'), 'issue': 'special_characters'})
-    
-    success_rate = round((extracted / total * 100) if total > 0 else 0, 1)
-    
+    h = json.load(open('/tmp/oc_extraction_health.json'))
+    complete = int(h.get('complete_extraction', 0))
+    partial  = int(h.get('partial_extraction', 0))
+    missing  = int(h.get('no_extraction', 0))
+    total    = complete + partial + missing
+    edge     = h.get('edge_case_summary', {}) or {}
     result = {
-        'success_rate': success_rate,
-        'extracted_count': extracted,
+        'success_rate': round(float(h.get('success_rate', 0.0)), 1),
+        'extracted_count': complete + partial,
         'total_count': total,
-        'gap_count': len(gaps),
-        'edge_case_count': len(edge_cases),
-        'gaps': gaps[:10],  # Sample first 10
-        'edge_cases': edge_cases[:10]  # Sample first 10
+        'gap_count': missing,
+        'edge_case_count': sum(int(v) for v in edge.values()),
+        'edge_cases': edge,  # {'truncated_messages': N, 'special_chars': N, ...}
     }
     print(json.dumps(result))
 except Exception as e:

--- a/src/operations_center/observer/cli.py
+++ b/src/operations_center/observer/cli.py
@@ -912,6 +912,65 @@ def cmd_query_flaky_tests(
         raise typer.Exit(EXIT_CONFIG_ERROR)
 
 
+@app.command("extraction-health")
+def cmd_extraction_health(
+    hours: int = typer.Option(24, "--hours", help="Look back N hours (default: 24)"),
+    storage_root: Path | None = typer.Option(
+        None,
+        "--storage-root",
+        help="Storage root for snapshots (default: tools/report/operations_center/observer)",
+    ),
+    format_str: str = typer.Option("json", "--format", help="Output format: json|table"),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Minimal output"),
+) -> None:
+    """Report extraction coverage health for flaky test data.
+
+    Emits the structured ExtractionHealth metrics (success_rate,
+    complete/partial/no_extraction counts, edge_case_summary) from
+    ``get_extraction_health()`` — the signal the watchdog collector consumes.
+    Unlike ``query-flaky-tests`` (which emits per-test extraction *records*),
+    this emits the aggregate coverage health as a single object.
+
+    Examples:
+
+        # JSON for the collector (haiku_collector_prompt.md STEP 3)
+        cli extraction-health --format json --hours 24
+    """
+    from dataclasses import asdict
+
+    try:
+        root = storage_root or Path("tools/report/operations_center/observer")
+        if not root.exists():
+            if not quiet:
+                console.print(f"[yellow]Warning: snapshot root does not exist: {root}[/yellow]")
+            raise typer.Exit(EXIT_NOT_FOUND)
+
+        query = TestSignalQuery(root=root)
+        health = query.get_extraction_health(TimeRange.last_hours(hours))
+        payload = asdict(health)
+
+        if format_str == "json":
+            # typer.echo (not the rich console) so piped/redirected JSON is not
+            # soft-wrapped — the watchdog collector parses this from a file.
+            typer.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+        else:  # table
+            console.print(
+                f"extraction success_rate={payload['success_rate']:.1f}%  "
+                f"complete={payload['complete_extraction']}  "
+                f"partial={payload['partial_extraction']}  "
+                f"none={payload['no_extraction']}"
+            )
+        raise typer.Exit(EXIT_SUCCESS)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not quiet:
+            console.print(f"[red]Error querying extraction health: {e}[/red]")
+        logger.exception("Error in extraction-health command")
+        raise typer.Exit(EXIT_CONFIG_ERROR)
+
+
 def main() -> None:
     """Entry point for CLI."""
     app()

--- a/tests/unit/observer/test_cli_extraction_health.py
+++ b/tests/unit/observer/test_cli_extraction_health.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the observer `extraction-health` CLI command.
+
+This command is what `haiku_collector_prompt.md` STEP 3 calls. It exposes the
+aggregate ExtractionHealth from get_extraction_health() — the integration that
+#313 claimed but never wired (STEP 3 had parsed the wrong command's output).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from operations_center.observer.cli import app
+from operations_center.observer.query_flaky import ExtractionHealth
+
+runner = CliRunner()
+
+
+def _query_returning(health: ExtractionHealth) -> MagicMock:
+    q = MagicMock()
+    q.get_extraction_health.return_value = health
+    return q
+
+
+class TestExtractionHealthCommand:
+    def test_command_help(self) -> None:
+        result = runner.invoke(app, ["extraction-health", "--help"])
+        assert result.exit_code == 0
+        assert "extraction coverage health" in result.stdout.lower()
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_no_snapshots_found(self, mock_cls: MagicMock) -> None:
+        with patch("pathlib.Path.exists", return_value=False):
+            result = runner.invoke(app, ["extraction-health"])
+        assert result.exit_code == 2  # EXIT_NOT_FOUND
+        assert "does not exist" in result.stdout
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_json_output_is_the_extraction_health_shape(self, mock_cls: MagicMock) -> None:
+        # The regression: STEP 3 must receive the aggregate ExtractionHealth
+        # fields, NOT a test_failures array (which query-flaky-tests emits).
+        mock_cls.return_value = _query_returning(
+            ExtractionHealth(
+                success_rate=80.0,
+                complete_extraction=4,
+                partial_extraction=0,
+                no_extraction=1,
+                edge_case_summary={"truncated_messages": 2, "special_chars": 0},
+            )
+        )
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["extraction-health", "--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        # Exactly the keys STEP 3's python parser reads:
+        assert payload["success_rate"] == 80.0
+        assert payload["complete_extraction"] == 4
+        assert payload["partial_extraction"] == 0
+        assert payload["no_extraction"] == 1
+        assert payload["edge_case_summary"]["truncated_messages"] == 2
+        assert "test_failures" not in payload  # NOT the query-flaky-tests shape
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_step3_parser_maps_the_output(self, mock_cls: MagicMock) -> None:
+        # Exercise STEP 3's exact mapping over this command's output, proving the
+        # end-to-end contract: success_rate/extracted/total/gap all resolve.
+        mock_cls.return_value = _query_returning(
+            ExtractionHealth(
+                success_rate=75.0,
+                complete_extraction=3,
+                partial_extraction=0,
+                no_extraction=1,
+                edge_case_summary={"truncated_messages": 1, "special_chars": 0},
+            )
+        )
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["extraction-health", "--format", "json"])
+        h = json.loads(result.stdout)
+        complete, partial, missing = (
+            int(h["complete_extraction"]),
+            int(h["partial_extraction"]),
+            int(h["no_extraction"]),
+        )
+        total = complete + partial + missing
+        mapped = {
+            "success_rate": round(float(h["success_rate"]), 1),
+            "extracted_count": complete + partial,
+            "total_count": total,
+            "gap_count": missing,
+            "edge_case_count": sum(int(v) for v in h["edge_case_summary"].values()),
+        }
+        assert mapped == {
+            "success_rate": 75.0,
+            "extracted_count": 3,
+            "total_count": 4,
+            "gap_count": 1,
+            "edge_case_count": 1,
+        }
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_table_format(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _query_returning(ExtractionHealth(success_rate=50.0))
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["extraction-health", "--format", "table"])
+        assert result.exit_code == 0
+        assert "success_rate=50.0%" in result.stdout
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_error_handling(self, mock_cls: MagicMock) -> None:
+        q = MagicMock()
+        q.get_extraction_health.side_effect = RuntimeError("boom")
+        mock_cls.return_value = q
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["extraction-health"])
+        assert result.exit_code == 4  # EXIT_CONFIG_ERROR
+        assert "Error querying extraction health" in result.stdout
+
+    @patch("operations_center.observer.cli.TestSignalQuery")
+    def test_empty_health_when_no_flaky_tests(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _query_returning(ExtractionHealth())  # all defaults
+        with patch("pathlib.Path.exists", return_value=True):
+            result = runner.invoke(app, ["extraction-health", "--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["success_rate"] == 0.0
+        assert payload["no_extraction"] == 0


### PR DESCRIPTION
## What
Makes #313's claimed "end-to-end" integration actually real:
1. New **`observer extraction-health`** CLI command — exposes the aggregate `ExtractionHealth` (`success_rate`, `complete/partial/no_extraction`, `edge_case_summary`) from `get_extraction_health()` as JSON (`typer.echo`, so piped output isn't soft-wrapped).
2. **STEP 3 rewritten** in `haiku_collector_prompt.md` to call it and map the real fields into the collector's metric schema.
3. **backlog.md reconciled** — the contradictory "Stage 5: update STEP 3 to call get_extraction_health()" TODO is now done; "end-to-end" is dated to this fix-forward.

## Why
This is fix-forward #2 from the #313 post-mortem. #313 merged with the integration as a **dead end**: `get_extraction_health()` was defined but **called nowhere**, and STEP 3 called `query-flaky-tests` (which emits a `test_failures` array) then parsed `d.get('tests', [])` — **always empty**. So STEP 3 silently collected nothing. The self-review caught exactly this ("incomplete integration / replicates the known-broken pattern") but it shipped via the CI-green retraction hole (fixed in the companion PR).

## Tests
7 new CLI tests including `test_step3_parser_maps_the_output`, which runs STEP 3's exact field-mapping over this command's real output and asserts the resolved metrics. Observer suite green; ruff + ty + custodian-doctor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)