### PR TITLE
chore(observer): declare flaky_metrics public API in __all__

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,4 +1,16 @@
-## 2026-06-17 — fix: reviewer verdict authoritative — don't retract concern-escalations on green CI
+## 2026-06-17 — chore(observer): declare flaky_metrics public API in __all__ (D12 triage)
+
+First batch of the OperationsCenter D12 triage (Custodian's new "tested but never
+wired" detector found 176 → 161 after this). `observer/flaky_metrics.py` is a
+consumed pure-function metrics library (flaky_test_reporter/collector/models
+import it); several metrics are implemented + tested but intentionally not yet
+wired to a collector (the module docstring says so — environment_correlation,
+isolation_score). Declared its 15 public metric functions in `__all__` — marks
+them as intentional public API rather than dead code, the correct D12 resolution
+("declare or wire"), and clears 10 D12 findings. No behaviour change (no
+`import *` consumer); 82 flaky-metric tests green. Remaining D12 backlog (~161,
+mostly observer + execution) burns down per-subsystem with the same declare /
+wire / remove triage.
 
 Governance fix for how #313 shipped broken. `pr_review_watcher._phase1`'s WO-3
 CI-green retraction (the `else` branch when the escalated head is unchanged)

--- a/src/operations_center/observer/flaky_metrics.py
+++ b/src/operations_center/observer/flaky_metrics.py
@@ -22,6 +22,31 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 
+# Public metrics API. Declared explicitly because this is a consumed library
+# (flaky_test_reporter / collector / models import from it) and several metrics
+# are implemented + tested but not yet wired into a collector (e.g.
+# environment_correlation, isolation_score — see the module docstring). Declaring
+# the public surface marks them as intentional API rather than dead code.
+__all__ = [
+    # per-test metrics
+    "failure_rate",
+    "failure_entropy",
+    "streak_variance",
+    "percentile",
+    "recovery_time_percentile_90",
+    "duration_stability",
+    "environment_correlation",
+    "isolation_score",
+    # repository-level metrics
+    "flaky_test_percentage",
+    "median_failure_rate",
+    "flaky_growth_rate",
+    "category_concentration",
+    "critical_test_flakiness_ratio",
+    "flaky_velocity",
+    "repository_health_score",
+]
+
 # ── Per-test metrics ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
First batch of the D12 triage. flaky_metrics.py is a consumed pure-function metrics library; several metrics are tested-but-intentionally-unwired (per the module docstring). Declaring its 15 public functions in `__all__` marks them as intentional public API (the correct D12 'declare or wire' resolution) and clears 10 findings (176→161). No behaviour change; 82 flaky-metric tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)