### PR TITLE
chore: D12 triage Phase 1 — declare cxrp_mapper + alert_config public API

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-06-17 — chore: D12 triage Phase 1 — declare cxrp_mapper + alert_config public API
+
+Phase 1 (declare module-function public-API libraries via __all__) continues:
+`contracts/cxrp_mapper.py` (7 OC↔CxRP converters) and `observer/alert_config.py`
+(3 dataclasses + 4 lookup helpers) declared in __all__. Both are consumed
+libraries with no `import *` users; several functions are tested as the contract
+boundary but not all wired into a caller — declaring marks them public API, not
+dead code. D12 count 161 → 153 (8 cleared); 81 tests green; ruff clean. Roadmap:
+~13 module-func modules remain for Phase 1; the 140 methods (UsageStore 27, the
+git/PR clients, stores, queries) are class public-API surfaces best handled by a
+D12 symbol-baseline (accept + gate new code) rather than wire/remove, with the
+genuinely-dead minority removed deliberately.
+
 ## 2026-06-17 — chore(observer): declare flaky_metrics public API in __all__ (D12 triage)
 
 First batch of the OperationsCenter D12 triage (Custodian's new "tested but never

--- a/src/operations_center/contracts/cxrp_mapper.py
+++ b/src/operations_center/contracts/cxrp_mapper.py
@@ -62,6 +62,21 @@ from .execution import OcExecutionRequest, OcExecutionResult, RuntimeBindingSumm
 from .proposal import OcPlanningProposal
 from .routing import OcRoutingDecision
 
+# Public OC↔CxRP mapping surface. Declared explicitly: this is a consumed
+# converter library and several directions (the to_cxrp_* / *_to_summary
+# mappers) are tested as the contract boundary but not all wired into a caller
+# yet — declaring them marks the public API rather than leaving them as apparent
+# dead code.
+__all__ = [
+    "to_cxrp_task_proposal",
+    "to_cxrp_lane_decision",
+    "from_cxrp_lane_decision",
+    "to_cxrp_execution_request",
+    "to_cxrp_execution_result",
+    "runtime_binding_to_summary",
+    "runtime_binding_from_summary",
+]
+
 CODING_AGENT_INPUT_SCHEMA_ID = "coding_agent_input/v0.2"
 CODING_AGENT_TARGET_SCHEMA_ID = "coding_agent_target/v0.2"
 

--- a/src/operations_center/observer/alert_config.py
+++ b/src/operations_center/observer/alert_config.py
@@ -14,6 +14,20 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+# Public alert-config surface. Declared explicitly: this is a consumed config
+# library; the lookup helpers (get_alert_route, list_collector_names,
+# list_condition_names) are tested but not all wired into a caller yet — declaring
+# them marks the public API rather than leaving them as apparent dead code.
+__all__ = [
+    "CollectorThresholds",
+    "AlertRoute",
+    "AlertContext",
+    "get_collector_thresholds",
+    "get_alert_route",
+    "list_collector_names",
+    "list_condition_names",
+]
+
 
 @dataclass
 class CollectorThresholds:


### PR DESCRIPTION
Phase 1 of the D12 backlog burn-down (declare module-function public-API libraries via `__all__`). cxrp_mapper (7 converters) + alert_config (3 dataclasses + 4 helpers) — consumed libraries, tested-as-boundary, no import* users. D12 161→153. 81 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)