### PR TITLE
chore: D12 triage Phase 1 batch 2 — declare 8 library modules

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,15 @@
+## 2026-06-17 — chore: D12 triage Phase 1 batch 2 — declare 8 library modules
+
+Declared __all__ on 8 consumed library modules whose public functions were
+tested-but-not-internally-wired: limit_classifier, worker_backend_selector,
+board_worker/labels, execution/binding, execution/validation, coverage_models,
+priority_scans, spec_author/suppressor. All import cleanly; 964 tests green; ruff
+clean. D12 153 → 145. Phase 1 nearly done — 5 module-funcs deferred (setup/main
+45-name CLI app, _scrub private module, multi_step_planning / alert_validation /
+routing/smoke which are NOT-imported and may be genuine gaps needing a real look,
+not blind __all__). Next: Step 2 — the D12 symbol-baseline infra so D12 gates new
+code while the 140 method findings are accepted + tracked.
+
 ## 2026-06-17 — chore: D12 triage Phase 1 — declare cxrp_mapper + alert_config public API
 
 Phase 1 (declare module-function public-API libraries via __all__) continues:

--- a/src/operations_center/backends/limit_classifier.py
+++ b/src/operations_center/backends/limit_classifier.py
@@ -27,6 +27,14 @@ from __future__ import annotations
 
 import re
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "detect_model",
+    "classify_limit",
+    "models_affected",
+]
+
 # limit_kind values
 MODEL_WEEKLY = "model_weekly"
 SESSION_5H = "session_5h"

--- a/src/operations_center/backends/worker_backend_selector.py
+++ b/src/operations_center/backends/worker_backend_selector.py
@@ -13,6 +13,20 @@ from operations_center.backends._capacity_classifier import (
 )
 from operations_center.backends.limit_classifier import GENERIC, classify_limit
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "WorkerBackendSelection",
+    "WorkerBackendExecution",
+    "worker_backend_observed_runtime",
+    "worker_backend_candidates",
+    "alternate_worker_backend",
+    "select_worker_backend",
+    "parse_worker_backend_reset",
+    "maybe_record_worker_backend_cooldown",
+    "execute_with_worker_backend_round_robin",
+]
+
 _T = TypeVar("_T")
 
 # All worker backends — remote (cloud) and local. The executor services

--- a/src/operations_center/entrypoints/board_worker/labels.py
+++ b/src/operations_center/entrypoints/board_worker/labels.py
@@ -7,6 +7,16 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "label_value",
+    "has_label",
+    "retry_count_from_labels",
+    "add_label",
+    "increment_retry_count",
+]
+
 logger = logging.getLogger(__name__)
 
 # ── Plane states ──────────────────────────────────────────────────────────────

--- a/src/operations_center/execution/binding.py
+++ b/src/operations_center/execution/binding.py
@@ -28,6 +28,19 @@ from operations_center.execution.target import (
     BoundExecutionTarget,
 )
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "TargetBindError",
+    "UnknownBackendError",
+    "InvalidRuntimeBindingError",
+    "PolicyViolationError",
+    "MissingProvenanceError",
+    "CatalogLike",
+    "PolicyLike",
+    "bind_execution_target",
+]
+
 # ── Typed errors ────────────────────────────────────────────────────────
 
 

--- a/src/operations_center/execution/validation.py
+++ b/src/operations_center/execution/validation.py
@@ -22,6 +22,14 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "EnvironmentCheck",
+    "ImproveTriageResult",
+    "build_improve_triage_result",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/operations_center/observer/coverage_models.py
+++ b/src/operations_center/observer/coverage_models.py
@@ -13,6 +13,20 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "CoverageMetric",
+    "ModuleCoverage",
+    "FileCoverage",
+    "CoverageSnapshot",
+    "CoverageTrendAnalysis",
+    "CoverageAlert",
+    "compare_snapshots",
+    "is_snapshot_valid",
+    "get_baseline_coverage",
+]
+
 
 class CoverageMetric(BaseModel):
     """A single coverage measurement for a scope (repo/module/file)."""

--- a/src/operations_center/priority_scans.py
+++ b/src/operations_center/priority_scans.py
@@ -23,6 +23,17 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "PriorityRescoreCandidate",
+    "issue_urgency_score",
+    "handle_priority_rescore_scan",
+    "AwaitingInputResult",
+    "handle_awaiting_input_scan",
+    "signal_stale",
+]
+
 if TYPE_CHECKING:
     from operations_center.adapters.plane import PlaneClient
 

--- a/src/operations_center/spec_author/suppressor.py
+++ b/src/operations_center/spec_author/suppressor.py
@@ -7,6 +7,12 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+# Public API of this module — declared explicitly (consumed library; some
+# functions are tested as the boundary but not all internally wired).
+__all__ = [
+    "is_suppressed",
+]
+
 if TYPE_CHECKING:
     from operations_center.spec_author.models import CampaignRecord
 


### PR DESCRIPTION
Declared `__all__` on 8 consumed library modules whose public functions were tested-but-unwired: limit_classifier, worker_backend_selector, board_worker/labels, execution/binding, execution/validation, coverage_models, priority_scans, suppressor. All import cleanly; 964 tests green; ruff clean. **D12 153→145.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)