### PR TITLE
feat: enable DC10 (claims-integrated-while-deferring) on CI gate

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,11 @@
+## 2026-06-18 — feat: enable DC10 (claims-integrated-while-deferring) on the CI gate
+
+Point-1 of the #313 flow fix now GATES OC: bumped custodian pin to a29648a (DC10),
+extended the gate step to `--only D12,DC10`, baselined OC's 3 existing DC10 docs
+(.console/backlog.md, .console/log.md, STAGE2 design). A NEW doc that claims a
+feature integrated end-to-end while deferring the integration now fails CI — the
+planner-level over-claim that shipped #313 is deterministically caught.
+
 ## 2026-06-18 — chore: bump custodian pin to a34b8b3 (D12 baseline + doctor key)
 
 OC CI installed custodian@223c9da (pre-D12) via the pyproject pin, overriding the

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -3,6 +3,13 @@ src_root: src/operations_center
 tests_root: tests
 
 audit:
+  # DC10 baseline ratchet — accepted pre-existing docs that claim integrated
+  # while deferring the integration. DC10 gates NEW such over-claims; burn
+  # these down (reconcile the doc's status vs its deferred work) and prune.
+  dc10_baseline:
+    - .console/backlog.md
+    - .console/log.md
+    - docs/design/STAGE2_CI_INTEGRATION_TEST_RUNNER_IMPLEMENTATION.md
   # D12 baseline ratchet (Custodian audit.d12_baseline). The accepted
   # pre-existing set of public symbols that are tested but not yet wired into
   # production (145 as of 2026-06-17). D12 runs as a dedicated CI gate

--- a/.github/workflows/custodian-audit.yml
+++ b/.github/workflows/custodian-audit.yml
@@ -56,4 +56,4 @@ jobs:
         # a NEW tested-but-unwired public symbol fails CI; the backlog is burned
         # down separately (declare __all__ / wire / remove → prune the baseline).
         run: |
-          custodian-multi --repos . --only D12 --include-deprecated --fail-on-findings --no-color
+          custodian-multi --repos . --only D12,DC10 --include-deprecated --fail-on-findings --no-color

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
   "pytest-cov>=6.0",
   "ruff==0.15.13",
   "ty==0.0.40",
-  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@a34b8b39afe7d4978120fc1e0d94db3415a92333",
+  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@a29648a77adc190be45f5570f9373992c669333c",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Makes Point-1 of the #313 fix actually gate OC. Bumps the custodian pin to a29648a (adds DC10), extends the gate step to `--only D12,DC10`, and baselines OC's 3 existing DC10 docs. A **new** doc claiming a feature integrated end-to-end while deferring the integration now **fails CI** — the planner-level over-claim that shipped #313. Verified: combined gate = 0 on baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)