### PR TITLE
feat(reviewer): Self-Heal Ladder — resolve CONCERNS instead of conceding (Point 2)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -6924,3 +6924,12 @@ to merge over a concern.
 
 Updated docs/design/SELF_HEAL_LADDER.md Status -> built and checked off the
 roadmap phases now that P0-P3 are implemented. DC10 gate re-verified clean.
+
+## 2026-06-18 — Self-Heal Ladder: clear DC1/DC7 on the new design doc
+
+Pre-push Custodian audit flagged the new SELF_HEAL_LADDER.md: [DC1] missing YAML
+front matter and [DC7] orphan (unlinked) doc. Added `status: implemented` front
+matter and linked it from docs/specs/reviewer-pr-state-machine.md (the topical
+reviewer spec). Audit now down to the sole pre-existing [B2] boundary-artifact
+MED finding (environmental — present on origin/main; CI materializes the
+artifact from REPOGRAPH_BOUNDARY_ARTIFACT_B64 secret).

--- a/.console/log.md
+++ b/.console/log.md
@@ -6919,3 +6919,8 @@ This completes Point 2 (Self-Heal Ladder): P0 design, P1 structured concerns +
 anti-no-op bar, P2 graduated ladder, P3 rescope-on-exhaustion. Binding
 invariant held throughout — LGTM stays the only merge path; nothing added a way
 to merge over a concern.
+
+## 2026-06-18 — Self-Heal Ladder: mark spec built (P0-P3 shipped)
+
+Updated docs/design/SELF_HEAL_LADDER.md Status -> built and checked off the
+roadmap phases now that P0-P3 are implemented. DC10 gate re-verified clean.

--- a/.console/log.md
+++ b/.console/log.md
@@ -6866,3 +6866,16 @@ L3 human/rescope) + phased roadmap (P1 structured concerns + anti-no-op bar;
 P2 ladder; P3 rescope-on-exhaustion). Verified the doc does not trip the DC10
 gate. Implementation phases follow as their own green-gated PRs.
 
+
+## 2026-06-18 — Self-Heal Ladder Phase 1: structured concerns + anti-no-op bar
+
+Strengthened `_run_fix_pass`. New helpers: `_structure_concerns(summary)` splits
+the reviewer prose into individually-addressable concerns (bullets / numbered /
+paragraph fallback, never empty for non-empty input), and `_build_fix_goal()`
+enumerates them and attaches `_FIX_ACCEPTANCE_BAR` — the #313 lesson encoded:
+"tests passing is necessary but NOT sufficient; a defined/tested-but-unwired
+symbol must be wired to its production call path, not re-tested", plus an
+instruction to clear the D12/DC10 incomplete-integration gate locally before
+finishing. `_run_fix_pass` gained an optional `extra_context` param for the
+ladder's per-rung enrichment (Phase 2). No state-machine change; merge gate
+untouched. 6 new tests; full watcher suite 109 + reviewer integration 80 green.

--- a/.console/log.md
+++ b/.console/log.md
@@ -6903,3 +6903,19 @@ climb-regardless-of-wording, escalate-only-at-top); updated the WO-3 ci-red
 test to ladder-top. Watcher suite 110 + reviewer integration 80 green. (Pre-
 existing unrelated failure: test_documentation_accuracy marker test, red on
 origin/main.)
+
+## 2026-06-18 — Self-Heal Ladder Phase 3: rescope on exhaustion
+
+When the fix cap is hit and the PR is closed + re-queued, the re-queue comment
+was generic ("re-queued, attempt N of M") — the next attempt started blind.
+Now `_close_and_requeue(concerns=...)` threads the still-unresolved verdict
+summary into `_requeue_plane_task`, which enumerates it (same `_structure_concerns`
+parse as the fix pass) under "Unresolved review concerns to address in the next
+attempt" on both the Ready and Blocked re-queue paths. The closed PR's branch
+is gone but its lesson is carried forward. 2 new tests; watcher 112 +
+reviewer integration 80 green; D12/DC10 gate clean; ty clean.
+
+This completes Point 2 (Self-Heal Ladder): P0 design, P1 structured concerns +
+anti-no-op bar, P2 graduated ladder, P3 rescope-on-exhaustion. Binding
+invariant held throughout — LGTM stays the only merge path; nothing added a way
+to merge over a concern.

--- a/.console/log.md
+++ b/.console/log.md
@@ -6879,3 +6879,27 @@ instruction to clear the D12/DC10 incomplete-integration gate locally before
 finishing. `_run_fix_pass` gained an optional `extra_context` param for the
 ladder's per-rung enrichment (Phase 2). No state-machine change; merge gate
 untouched. 6 new tests; full watcher suite 109 + reviewer integration 80 green.
+
+## 2026-06-18 — Self-Heal Ladder Phase 2: graduated fix escalation
+
+The no-progress path used to concede to a human on the FIRST no-progress
+repeat. Now it climbs a ladder of resolving power before giving up:
+
+- New `ReviewerSettings.max_fix_strategy_level` (default 2; 0 = old immediate
+  escalation). New state field `fix_strategy_level`, reset to L0 on head change.
+- `_ladder_enrichment(level, pr_diff)`: L1 = "previous pass changed nothing,
+  take a different approach" + bounded PR-diff orientation; L2 = decompose
+  (resolve ONE concern per pass, rest on following passes).
+- `_phase1` no-progress branch: instead of escalating, bump fix_strategy_level
+  and fall through to re-dispatch with `extra_context=_ladder_enrichment(...)`.
+  Escalate to a human (`fix_pass_no_progress`) ONLY when next_level exceeds
+  max — the terminal rung. The WO-3 CI-green merge guard is untouched and still
+  evaluated first; the ladder is strictly gentler than immediate escalation.
+
+Binding invariant intact: LGTM remains the only merge path; the ladder changes
+how hard the system tries, never what counts as resolved. Tests: replaced the
+two old immediate-escalation tests with three ladder tests (climb-at-L0,
+climb-regardless-of-wording, escalate-only-at-top); updated the WO-3 ci-red
+test to ladder-top. Watcher suite 110 + reviewer integration 80 green. (Pre-
+existing unrelated failure: test_documentation_accuracy marker test, red on
+origin/main.)

--- a/.console/log.md
+++ b/.console/log.md
@@ -6851,3 +6851,18 @@ Stage 5 can now update haiku_collector_prompt.md STEP 3 to:
    - Well documented with clear docstrings
    - Ruff clean, fully formatted
 
+## 2026-06-18 — Self-Heal Ladder (Point 2): design + roadmap
+
+Origin: PR #313 post-mortem. #314 fixed governance (verdict-gate + CI-green
+guard); #319/#320 added the planner-side catch (Custodian D12/DC10 gates).
+Remaining gap: the CONCERNS→fix loop itself was binary and shallow — one fix
+pass on an unstructured prose blob, then escalate straight to a human on the
+first no-progress repeat, with "tests pass" as the (wrong) acceptance bar.
+
+Phase 0: wrote `docs/design/SELF_HEAL_LADDER.md` — design + binding invariant
+(self-heal RESOLVES the concern, never bypasses it; LGTM stays the only merge
+path) + the strategy ladder (L0 structured -> L1 enriched -> L2 decompose ->
+L3 human/rescope) + phased roadmap (P1 structured concerns + anti-no-op bar;
+P2 ladder; P3 rescope-on-exhaustion). Verified the doc does not trip the DC10
+gate. Implementation phases follow as their own green-gated PRs.
+

--- a/docs/design/SELF_HEAL_LADDER.md
+++ b/docs/design/SELF_HEAL_LADDER.md
@@ -1,6 +1,6 @@
 # Self-Heal Ladder for CONCERNS verdicts
 
-**Status:** design + roadmap (phased build in progress)
+**Status:** built — Phases 0–3 shipped (see roadmap below)
 **Owner:** pr_review_watcher
 **Origin:** PR #313 post-mortem — a fleet-authored PR shipped broken because the
 self-heal loop was binary (one shallow fix pass → give up to a human) and the
@@ -77,20 +77,22 @@ The fix worker is told, explicitly:
 
 ## Roadmap (phases)
 
-- **Phase 0 — this document.** Design, invariant, ladder, acceptance bar.
-- **Phase 1 — Structured concern delivery + anti-no-op acceptance bar.**
-  Parse the reviewer summary into an enumerated concern list; rewrite the fix
-  goal with the acceptance bar above. No state-machine change → low risk.
-- **Phase 2 — The ladder.** Add `fix_strategy_level`; on no-progress /
-  non-convergence climb a rung (enrich context, then decompose per concern)
-  instead of escalating to a human; escalate to a human only at the top rung.
-- **Phase 3 — Rescope on exhaustion.** When the fix cap is hit and the PR is
-  closed + re-queued, carry the still-unresolved concerns into the re-queued
-  task so the next attempt is scoped to what actually remained, not a blank
-  retry.
+- **Phase 0 — this document.** ✅ Design, invariant, ladder, acceptance bar.
+- **Phase 1 — Structured concern delivery + anti-no-op acceptance bar.** ✅
+  `_structure_concerns()` parses the reviewer summary into an enumerated concern
+  list; `_build_fix_goal()` rewrites the fix goal with `_FIX_ACCEPTANCE_BAR`
+  (tests-necessary-not-sufficient; wire don't re-test; clear the D12/DC10 gate).
+  No state-machine change.
+- **Phase 2 — The ladder.** ✅ `fix_strategy_level` state +
+  `ReviewerSettings.max_fix_strategy_level`; on no-progress the fix pass is
+  re-dispatched with `_ladder_enrichment()` (L1 enriched context, L2 decompose
+  per concern) instead of escalating; a human is reached only at the top rung.
+- **Phase 3 — Rescope on exhaustion.** ✅ `_close_and_requeue(concerns=…)` →
+  `_requeue_plane_task()` carries the still-unresolved concerns (enumerated)
+  onto the re-queued task so the next attempt is scoped to what remained.
 
-Each phase ships as its own green-gated PR. None of them touches the merge
-gate; all of them keep LGTM as the sole merge path.
+Each phase shipped as a commit on one green-gated PR. None touches the merge
+gate; all keep LGTM as the sole merge path.
 
 ## Test coverage the build must keep / add
 

--- a/docs/design/SELF_HEAL_LADDER.md
+++ b/docs/design/SELF_HEAL_LADDER.md
@@ -1,0 +1,107 @@
+# Self-Heal Ladder for CONCERNS verdicts
+
+**Status:** design + roadmap (phased build in progress)
+**Owner:** pr_review_watcher
+**Origin:** PR #313 post-mortem — a fleet-authored PR shipped broken because the
+self-heal loop was binary (one shallow fix pass → give up to a human) and the
+merge then bypassed the binding verdict on green CI. Governance was fixed in
+\#314 (verdict-gate, CI-green guard) and the planner-side catch in #319/#320
+(Custodian D12/DC10 gates). This document covers the remaining gap: making the
+**fix loop itself** strong enough to actually *resolve* a CONCERNS verdict
+instead of conceding early.
+
+## The binding invariant (non-negotiable)
+
+> Self-heal means **resolve the concern**, never **bypass it to reach green CI**.
+
+That is precisely how #313 shipped, and #314 exists to prevent it. Everything
+below stays **behind** the binding verdict:
+
+- **LGTM is the only merge path.** Nothing in the ladder merges a PR. A PR
+  leaves the loop merged only when a fresh self-review returns LGTM.
+- The CI-green retraction guard (`_concerns_on_this_head`, #314) is untouched.
+  The ladder never reads CI status as permission to merge over a concern.
+- The ladder adds **rungs of increasing resolving power** between "first fix
+  pass" and "give up to a human". It changes how *hard the system tries*, not
+  *what counts as resolved*.
+
+## What was wrong with the binary loop
+
+`_phase1` on a CONCERNS verdict did exactly one thing per attempt: hand
+`_run_fix_pass` the reviewer's prose summary plus "resolve ALL of them, run the
+tests and linters." Two structural weaknesses:
+
+1. **The acceptance bar was wrong.** The fix worker was told tests/linters
+   passing is the goal. But #313's defect was a symbol that was unit-tested in
+   isolation and never wired into production — tests *passed* while the
+   integration was absent. "Tests pass" is necessary, not sufficient.
+
+2. **The escalation was binary and premature.** On the first no-progress repeat
+   (same PR head, fix pass pushed nothing) the loop escalated straight to a
+   human. It never applied *more* resolving power — more context, a narrower
+   per-concern scope — before conceding. A single shallow pass that couldn't
+   resolve a multi-part concern ended the autonomous track immediately.
+
+## The ladder
+
+Each fix attempt runs at a **strategy level**. Level rises only when a pass
+fails to make progress (pushed nothing) or fails to converge (pushed, but a
+fresh review raises the same concern). A human is the **top** of the ladder,
+not the second rung.
+
+| Level | Strategy | What changes vs the level below |
+|------|----------|---------------------------------|
+| L0 | Standard fix pass | Structured, enumerated concerns + anti-no-op acceptance bar (Phase 1) |
+| L1 | Enriched context | + the full PR diff + an explicit "the previous pass changed nothing / did not resolve X — take a different approach" |
+| L2 | Decompose | One narrowly-scoped fix pass **per concern** instead of one pass for all — narrower scope, higher resolve rate |
+| L3 (terminal) | Human / rescope | Escalate to a human; on fix-cap exhaustion, close + re-queue carrying the **unresolved** concerns so the fresh attempt is scoped to them |
+
+The level is tracked in watcher state (`fix_strategy_level`) and bounded by
+`ReviewerSettings.max_fix_strategy_level` (default 2 — L0..L2 autonomous, then
+human). Every rung still ends in a fresh self-review; only LGTM merges.
+
+## Acceptance bar handed to every fix pass
+
+The fix worker is told, explicitly:
+
+- Resolve **each** enumerated concern; a no-op pass is a failure.
+- Tests and linters passing is **necessary but not sufficient**. If a concern
+  is "X is defined/tested but never called in production", you must connect X
+  to its production call path and show where it is invoked — you must **not**
+  resolve it by adding another test.
+- Before finishing, run the repository's own incomplete-integration gate
+  (`custodian-multi --only D12,DC10 --include-deprecated --fail-on-findings`)
+  and clear any finding it reports. This is the same deterministic gate CI
+  runs; clearing it locally keeps the loop from converging on a state CI will
+  reject.
+
+## Roadmap (phases)
+
+- **Phase 0 — this document.** Design, invariant, ladder, acceptance bar.
+- **Phase 1 — Structured concern delivery + anti-no-op acceptance bar.**
+  Parse the reviewer summary into an enumerated concern list; rewrite the fix
+  goal with the acceptance bar above. No state-machine change → low risk.
+- **Phase 2 — The ladder.** Add `fix_strategy_level`; on no-progress /
+  non-convergence climb a rung (enrich context, then decompose per concern)
+  instead of escalating to a human; escalate to a human only at the top rung.
+- **Phase 3 — Rescope on exhaustion.** When the fix cap is hit and the PR is
+  closed + re-queued, carry the still-unresolved concerns into the re-queued
+  task so the next attempt is scoped to what actually remained, not a blank
+  retry.
+
+Each phase ships as its own green-gated PR. None of them touches the merge
+gate; all of them keep LGTM as the sole merge path.
+
+## Test coverage the build must keep / add
+
+- Keep: `test_phase1_concerns_dispatches_fix_pass_below_cap`,
+  `test_run_fix_pass_noop_returns_false`,
+  `test_phase1_concerns_closes_and_requeues_at_fix_cap`,
+  `test_wo3_no_progress_after_retraction_*` (the binding-invariant guards).
+- Change: `test_phase1_repeated_concerns_after_noop_fix_escalates` — a single
+  no-progress repeat now climbs a rung; the human escalation asserts at ladder
+  top instead.
+- Add: a structured-concerns parse test; a ladder-climb test (no-progress
+  bumps `fix_strategy_level` and re-dispatches, does not escalate); a
+  ladder-top test (escalates to human only when the level is maxed); a
+  rescope test (re-queued task carries unresolved concerns).

--- a/docs/design/SELF_HEAL_LADDER.md
+++ b/docs/design/SELF_HEAL_LADDER.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Self-Heal Ladder for CONCERNS verdicts
 
 **Status:** built — Phases 0–3 shipped (see roadmap below)

--- a/docs/specs/reviewer-pr-state-machine.md
+++ b/docs/specs/reviewer-pr-state-machine.md
@@ -49,6 +49,12 @@ described in `docs/design/lifecycle.md`.
    (up to `reviewer.max_self_review_loops`, default 2), then re-check
 6. Unresolved after max loops → escalate to Phase 2
 
+> The `CONCERNS` → fix loop is hardened by the
+> [Self-Heal Ladder](../design/SELF_HEAL_LADDER.md): the fix pass receives the
+> concerns structured + an anti-no-op acceptance bar, and a no-progress repeat
+> climbs rungs of escalating resolving power before conceding to a human. LGTM
+> stays the only merge path — self-heal resolves the concern, never bypasses it.
+
 ### Phase 2 — Human review
 
 1. Post escalation comment: `<!-- operations-center:bot -->` + concerns summary

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -290,6 +290,14 @@ class ReviewerSettings(BaseModel):
     # exhaustion the PR is closed and the issue re-queued for a fresh attempt —
     # never merged half-finished.
     max_fix_attempts: int = 6
+    # Self-Heal Ladder: how many rungs of escalating resolving power to climb
+    # before conceding a no-progress CONCERNS PR to a human. On each no-progress
+    # repeat the fix pass is re-dispatched with MORE power (L1 enriched context,
+    # L2 decompose to one concern per pass) instead of escalating immediately;
+    # a human is the top of the ladder, not the second rung. 0 disables the
+    # ladder (revert to the old immediate-escalation behavior). See
+    # docs/design/SELF_HEAL_LADDER.md.
+    max_fix_strategy_level: int = 2
     # Unused — human_review phase removed. Kept for config-file compatibility.
     max_human_review_loops: int = 3
     human_review_timeout_seconds: int = 86400

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -164,6 +164,93 @@ def _normalize_concerns_summary(summary: str) -> str:
     return " ".join(str(summary).split())
 
 
+# A line that begins an enumerated review concern: a bullet (-, *, +) or an
+# "N." / "N)" ordinal marker. Used to split a reviewer summary into individually
+# addressable concerns. See docs/design/SELF_HEAL_LADDER.md.
+_CONCERN_BULLET_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+(.*)$")
+
+
+def _structure_concerns(summary: str) -> list[str]:
+    """Split a freeform reviewer summary into individually-addressable concerns.
+
+    Most reviewer summaries enumerate concerns as a bulleted or numbered list.
+    Returning one string per concern lets the fix pass be told to resolve EACH
+    (and, at the decompose rung, be dispatched one pass per concern). Falls back
+    to paragraph splitting, then to the whole summary as a single concern —
+    never returns an empty list for non-empty input."""
+    text = str(summary or "").strip()
+    if not text:
+        return []
+    items: list[str] = []
+    current: list[str] = []
+    saw_bullet = False
+    for line in text.splitlines():
+        m = _CONCERN_BULLET_RE.match(line)
+        if m:
+            saw_bullet = True
+            if current:
+                items.append("\n".join(current).strip())
+            current = [m.group(1)]
+        elif current:
+            current.append(line.strip())  # continuation of the current item
+    if current:
+        items.append("\n".join(current).strip())
+    if saw_bullet:
+        out = [it for it in items if it]
+        if out:
+            return out
+    # No list markers — split on blank-line paragraphs, else the whole text.
+    paras = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    return paras if len(paras) > 1 else [text]
+
+
+# The acceptance bar handed to EVERY fix pass. "Tests pass" is necessary but NOT
+# sufficient: #313 shipped a symbol that was unit-tested in isolation and never
+# wired into production. The bar is RESOLVING the concern — proven by the
+# production call path — not by another green test. See SELF_HEAL_LADDER.md.
+_FIX_ACCEPTANCE_BAR = (
+    "## How each concern must be resolved\n\n"
+    "- Resolve EVERY concern listed above. A pass that changes nothing, or that "
+    "only addresses the concerns you find easy, is a failed pass.\n"
+    "- Passing tests and linters is NECESSARY BUT NOT SUFFICIENT. If a concern is "
+    "that something is defined, declared, or tested but never called/wired in "
+    "production, you MUST connect it to its production call path and point to "
+    "where it is invoked. Do NOT resolve such a concern by adding another test — "
+    "that is exactly the defect the reviewer flagged.\n"
+    "- Before finishing, run the repository's incomplete-integration gate and "
+    "clear anything it reports:\n"
+    "    custodian-multi --repos . --only D12,DC10 --include-deprecated --fail-on-findings\n"
+    "  A D12 finding means a public symbol is tested but never wired into "
+    "production; a DC10 finding means a doc claims an integration is complete "
+    "while the wiring is deferred. Either means a concern is not actually "
+    "resolved — fix the code/doc until the gate is clean.\n"
+    "- Push to the existing branch (do NOT open a new pull request) so the open "
+    "PR updates in place."
+)
+
+
+def _build_fix_goal(concerns: str, *, extra_context: str = "") -> str:
+    """Construct the fix-pass goal: enumerated concerns + the anti-no-op
+    acceptance bar, plus optional ladder enrichment (``extra_context``)."""
+    items = _structure_concerns(concerns)
+    if len(items) > 1:
+        enumerated = "\n".join(f"{i}. {c}" for i, c in enumerate(items, 1))
+        concern_block = (
+            "A self-review of the currently open pull request raised "
+            f"{len(items)} concerns:\n\n{enumerated}"
+        )
+    else:
+        body = items[0] if items else str(concerns)
+        concern_block = (
+            "A self-review of the currently open pull request raised the "
+            f"following concern:\n\n{body}"
+        )
+    parts = [concern_block, _FIX_ACCEPTANCE_BAR]
+    if extra_context.strip():
+        parts.append(extra_context.strip())
+    return "\n\n".join(parts)
+
+
 def _new_state(repo_key: str, pr_number: int) -> dict:
     now = datetime.now(UTC).isoformat()
     return {
@@ -874,20 +961,20 @@ def _run_fix_pass(
     settings,
     *,
     state_key: str,
+    extra_context: str = "",
 ) -> bool:
     """Dispatch a worker pass that resolves review concerns on the PR's own
     branch and pushes (updating the open PR). Returns True only if the pass
     actually pushed changes to the branch — a no-op pass (worker couldn't
     resolve anything) returns False so the caller can log it; the next review
-    cycle re-evaluates the actual diff regardless."""
-    goal_text = (
-        "A self-review of the currently open pull request raised the concerns "
-        "below. Resolve ALL of them by editing the code on the current branch, "
-        "then commit and push. Do NOT open a new pull request — push to the "
-        "existing branch so the open PR updates in place. Before finishing, run "
-        "the repository's tests and linters and make sure they pass.\n\n"
-        f"## Review concerns to resolve\n\n{concerns}"
-    )
+    cycle re-evaluates the actual diff regardless.
+
+    The goal enumerates the concerns and carries the anti-no-op acceptance bar
+    (tests passing is necessary but not sufficient; a tested-but-unwired symbol
+    must be wired, not re-tested). ``extra_context`` carries the Self-Heal
+    Ladder's per-rung enrichment (e.g. the PR diff, or "the previous pass
+    changed nothing — take a different approach")."""
+    goal_text = _build_fix_goal(concerns, extra_context=extra_context)
     try:
         outcome = _run_pipeline(
             oc_root,

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1176,6 +1176,7 @@ def _close_and_requeue(
     *,
     reason: str,
     detail: str,
+    concerns: str = "",
 ) -> None:
     """Close a PR WITHOUT merging and re-queue its issue for a fresh attempt.
 
@@ -1183,7 +1184,11 @@ def _close_and_requeue(
     merged half-finished. Re-queue happens FIRST — the PR is only closed once
     the issue is safely back in the queue, so a Plane outage can't lose the
     work. With no Plane task to re-queue, the PR is left open + escalated rather
-    than closed into the void."""
+    than closed into the void.
+
+    ``concerns`` carries the still-unresolved review concerns onto the re-queued
+    task so the fresh attempt is scoped to what actually remained (Self-Heal
+    Ladder Phase 3) instead of starting blind."""
     pr_number = state["pr_number"]
     plane_task_id = state.get("plane_task_id")
 
@@ -1206,7 +1211,9 @@ def _close_and_requeue(
         return
 
     # Re-queue first; only close if it succeeded.
-    if not _requeue_plane_task(settings, plane_task_id, pr_number=pr_number, reason=reason):
+    if not _requeue_plane_task(
+        settings, plane_task_id, pr_number=pr_number, reason=reason, concerns=concerns
+    ):
         logger.warning(
             "pr_review_watcher: re-queue failed for PR #%d — leaving PR open, will retry",
             pr_number,
@@ -1295,13 +1302,31 @@ def _close_and_requeue(
     state_path.unlink(missing_ok=True)
 
 
-def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason: str) -> bool:
+def _requeue_plane_task(
+    settings, plane_task_id: str, *, pr_number: int, reason: str, concerns: str = ""
+) -> bool:
     """Send the issue back to the queue for a fresh attempt, bounded by
     ``_MAX_REQUEUES`` (its own dedicated label); once exhausted, leave it
     Blocked for a human. Returns True if the issue was handled (re-queued or
     blocked), False on failure (e.g. Plane unreachable) so the caller can keep
-    the PR open and retry."""
+    the PR open and retry.
+
+    ``concerns`` (the still-unresolved review concerns) is appended to the
+    re-queue/blocked comment so the next attempt is scoped to what actually
+    remained — the closed PR's branch is gone, but its lesson is not."""
     from operations_center.entrypoints.board_worker.labels import STATE_BLOCKED, STATE_READY
+
+    # Structured, enumerated concerns for the next attempt to address — the same
+    # parse the fix pass uses, so the carry-forward reads consistently.
+    scope_block = ""
+    items = _structure_concerns(concerns)
+    if items:
+        enumerated = "\n".join(f"{i}. {c}" for i, c in enumerate(items, 1))
+        scope_block = (
+            "\n\n**Unresolved review concerns to address in the next attempt** "
+            "(the previous PR could not resolve these — scope the fresh attempt to "
+            f"them, do not start blind):\n\n{enumerated}"
+        )
 
     try:
         client = _plane_client(settings)
@@ -1324,7 +1349,7 @@ def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason:
             client.comment_issue(
                 plane_task_id,
                 f"PR #{pr_number} closed ({reason}); re-queue limit "
-                f"({_MAX_REQUEUES}) reached — blocked for human review.",
+                f"({_MAX_REQUEUES}) reached — blocked for human review.{scope_block}",
             )
             logger.warning("pr_review_watcher: task=%s hit re-queue limit — Blocked", plane_task_id)
         else:
@@ -1335,7 +1360,7 @@ def _requeue_plane_task(settings, plane_task_id: str, *, pr_number: int, reason:
             client.comment_issue(
                 plane_task_id,
                 f"PR #{pr_number} closed ({reason}); re-queued for a fresh attempt "
-                f"(#{attempts + 1} of {_MAX_REQUEUES}).",
+                f"(#{attempts + 1} of {_MAX_REQUEUES}).{scope_block}",
             )
             logger.info(
                 "pr_review_watcher: re-queued task=%s to Ready (attempt %d)",
@@ -2324,6 +2349,7 @@ def _phase1(
             settings,
             reason="fix_attempts_exhausted",
             detail=detail,
+            concerns=summary,
         )
         return
 

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -251,6 +251,47 @@ def _build_fix_goal(concerns: str, *, extra_context: str = "") -> str:
     return "\n\n".join(parts)
 
 
+# How much of the PR diff to fold into the L1 enrichment for orientation. The
+# fix worker clones the branch and can run `git diff` itself, so this is a
+# pointer, not the source of truth — keep it bounded so the prompt stays small.
+_LADDER_DIFF_CAP = 8_000
+
+
+def _ladder_enrichment(level: int, *, pr_diff: str = "") -> str:
+    """Per-rung enrichment handed to ``_run_fix_pass`` as ``extra_context``.
+
+    Level 0 is the standard pass (no enrichment). Each higher rung adds
+    resolving power instead of conceding to a human:
+
+    - **L1** — the previous pass changed nothing; do not repeat it. Fold in a
+      bounded slice of the PR diff for orientation.
+    - **L2+** — decompose: resolve ONE concern per pass (narrower scope, higher
+      resolve rate); the rest are picked up on following passes.
+
+    See docs/design/SELF_HEAL_LADDER.md."""
+    if level <= 0:
+        return ""
+    parts = [
+        "## Earlier passes did not resolve these concerns",
+        "A previous automated fix pass on this same branch changed nothing (or "
+        "left the concerns above unresolved). Do NOT repeat the same approach — "
+        "read the actual code paths involved and take a concretely different one.",
+    ]
+    if level >= 2:
+        parts.append(
+            "Resolving every concern at once has failed. This pass, pick the "
+            "SINGLE most important still-unresolved concern and fully resolve "
+            "just that one — wire it end to end and show the call path. The "
+            "remaining concerns are handled on the following passes."
+        )
+    diff = (pr_diff or "").strip()
+    if diff:
+        if len(diff) > _LADDER_DIFF_CAP:
+            diff = diff[:_LADDER_DIFF_CAP] + "\n...[diff truncated for orientation]"
+        parts.append("## The PR diff under review (for orientation)\n\n```diff\n" + diff + "\n```")
+    return "\n\n".join(parts)
+
+
 def _new_state(repo_key: str, pr_number: int) -> dict:
     now = datetime.now(UTC).isoformat()
     return {
@@ -1610,6 +1651,7 @@ def _phase1(
         state.pop("last_concerns_summary", None)
         state.pop("last_concerns_head_sha", None)
         state.pop("last_fix_pass_pushed", None)
+        state.pop("fix_strategy_level", None)  # new code → start back at L0
         logger.info(
             "pr_review_watcher: PR #%d head changed after concerns; resetting fix state",
             pr_number,
@@ -2208,25 +2250,47 @@ def _phase1(
                 except Exception:
                     pass  # CI check failed — fall through to normal escalation
 
-        detail = (
-            "The previous automated fix pass pushed no changes; a fresh self-review on the "
-            "same PR head still finds concerns. Further autonomous retries would repeat "
-            "without changing the branch.\n\nLatest concerns:\n\n"
-            f"{summary}"
-        )
-        state["escalated_head_sha"] = current_head_sha or state.get("escalated_head_sha")
-        _escalate_needs_human(
-            state,
-            state_path,
-            gh_client,
-            owner,
-            repo,
-            settings,
-            reason="fix_pass_no_progress",
-            detail=detail,
-            current_head_sha=current_head_sha,
-        )
-        return
+        # Self-Heal Ladder: a no-progress repeat does NOT immediately concede to
+        # a human. Climb a rung — re-dispatch the fix pass with MORE resolving
+        # power (L1 enriched context, L2 decompose to one concern per pass) — and
+        # escalate only when the ladder tops out. Binding invariant holds: this
+        # changes how hard the system TRIES, never what counts as resolved; LGTM
+        # is still the only merge path. (max_fix_strategy_level=0 → old immediate
+        # escalation.)
+        current_level = int(state.get("fix_strategy_level", 0))
+        next_level = current_level + 1
+        if next_level <= reviewer.max_fix_strategy_level:
+            state["fix_strategy_level"] = next_level
+            logger.info(
+                "pr_review_watcher: PR #%d no-progress — climbing Self-Heal Ladder to "
+                "L%d/%d (re-dispatching with more resolving power, not escalating)",
+                pr_number,
+                next_level,
+                reviewer.max_fix_strategy_level,
+            )
+            _save_state(state_path, state)
+            # Fall through to the dispatch below, which reads fix_strategy_level.
+        else:
+            detail = (
+                "The automated fix passes exhausted the Self-Heal Ladder (reached "
+                f"L{current_level}/{reviewer.max_fix_strategy_level}) without changing "
+                "the branch; a fresh self-review on the same PR head still finds "
+                "concerns. Further autonomous retries would repeat without progress.\n\n"
+                f"Latest concerns:\n\n{summary}"
+            )
+            state["escalated_head_sha"] = current_head_sha or state.get("escalated_head_sha")
+            _escalate_needs_human(
+                state,
+                state_path,
+                gh_client,
+                owner,
+                repo,
+                settings,
+                reason="fix_pass_no_progress",
+                detail=detail,
+                current_head_sha=current_head_sha,
+            )
+            return
 
     # CONCERNS — never merge. Dispatch a fix pass that resolves the concerns on
     # the PR's own branch (updating the PR), then re-review next cycle. After
@@ -2314,11 +2378,17 @@ def _phase1(
     state.pop("last_fix_pass_pushed", None)
     _save_state(state_path, state)
 
+    # Self-Heal Ladder rung: L0 is the standard pass; higher rungs (set when a
+    # no-progress repeat climbed the ladder above) enrich the dispatch with more
+    # resolving power instead of conceding to a human.
+    fix_level = int(state.get("fix_strategy_level", 0))
+    extra_context = _ladder_enrichment(fix_level, pr_diff=diff)
     logger.info(
-        "pr_review_watcher: PR #%d CONCERNS — dispatching fix pass %d/%d on branch %s",
+        "pr_review_watcher: PR #%d CONCERNS — dispatching fix pass %d/%d (ladder L%d) on branch %s",
         pr_number,
         state["fix_attempts"],
         reviewer.max_fix_attempts,
+        fix_level,
         head_ref,
     )
     record_decision_outcome(
@@ -2336,6 +2406,7 @@ def _phase1(
         summary,
         settings,
         state_key=state_key,
+        extra_context=extra_context,
     )
     state["last_concerns_summary"] = normalized_summary
     state["last_fix_pass_pushed"] = pushed

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -1018,6 +1018,38 @@ def test_requeue_plane_task_below_cap_goes_ready(tmp_path: Path) -> None:
     assert "reviewer-requeue-count: 1" in labels
 
 
+def test_requeue_plane_task_carries_unresolved_concerns(tmp_path: Path) -> None:
+    """Self-Heal Ladder Phase 3: the re-queue comment carries the still-unresolved
+    concerns (enumerated) so the fresh attempt is scoped, not blind."""
+    mock_client = MagicMock()
+    mock_client.fetch_issue.return_value = {"id": "t1", "labels": []}
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        watcher._requeue_plane_task(
+            SETTINGS,
+            "t1",
+            pr_number=PR_NUMBER,
+            reason="fix_attempts_exhausted",
+            concerns="- get_health never wired\n- missing None guard",
+        )
+
+    body = mock_client.comment_issue.call_args[0][1]
+    assert "Unresolved review concerns to address in the next attempt" in body
+    assert "1. get_health never wired" in body
+    assert "2. missing None guard" in body
+
+
+def test_requeue_plane_task_no_concerns_omits_scope_block(tmp_path: Path) -> None:
+    mock_client = MagicMock()
+    mock_client.fetch_issue.return_value = {"id": "t1", "labels": []}
+
+    with patch.object(watcher, "_plane_client", return_value=mock_client):
+        watcher._requeue_plane_task(SETTINGS, "t1", pr_number=PR_NUMBER, reason="x")
+
+    body = mock_client.comment_issue.call_args[0][1]
+    assert "Unresolved review concerns" not in body
+
+
 def test_requeue_plane_task_at_cap_goes_blocked(tmp_path: Path) -> None:
     mock_client = MagicMock()
     mock_client.fetch_issue.return_value = {

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -1018,6 +1018,68 @@ def test_run_fix_pass_noop_returns_false(tmp_path: Path) -> None:
     assert pushed is False
 
 
+# ── Self-Heal Ladder Phase 1: structured concerns + anti-no-op acceptance bar ──
+
+
+def test_structure_concerns_splits_bulleted_list() -> None:
+    summary = "Problems found:\n- get_health() never called\n- missing error handling\n* no tests"
+    out = watcher._structure_concerns(summary)
+    assert out == ["get_health() never called", "missing error handling", "no tests"]
+
+
+def test_structure_concerns_splits_numbered_list_with_continuations() -> None:
+    summary = "1. First concern\n   spanning two lines\n2. Second concern"
+    out = watcher._structure_concerns(summary)
+    assert out == ["First concern\nspanning two lines", "Second concern"]
+
+
+def test_structure_concerns_falls_back_to_paragraphs_then_whole() -> None:
+    assert watcher._structure_concerns("para one\n\npara two") == ["para one", "para two"]
+    assert watcher._structure_concerns("single blob of prose") == ["single blob of prose"]
+    assert watcher._structure_concerns("   ") == []
+
+
+def test_build_fix_goal_enumerates_and_carries_acceptance_bar() -> None:
+    goal = watcher._build_fix_goal("- wire up X\n- handle the None case")
+    # Concerns are enumerated...
+    assert "2 concerns" in goal
+    assert "1. wire up X" in goal
+    assert "2. handle the None case" in goal
+    # ...and the anti-no-op bar (the #313 lesson) is present.
+    assert "NECESSARY BUT NOT SUFFICIENT" in goal
+    assert "never called/wired in production" in goal
+    assert "Do NOT resolve such a concern by adding another test" in goal
+    assert "--only D12,DC10" in goal
+
+
+def test_build_fix_goal_single_concern_and_extra_context() -> None:
+    goal = watcher._build_fix_goal("just one thing", extra_context="PREVIOUS PASS CHANGED NOTHING")
+    assert "following concern" in goal
+    assert "just one thing" in goal
+    assert "PREVIOUS PASS CHANGED NOTHING" in goal
+
+
+def test_run_fix_pass_builds_structured_goal(tmp_path: Path) -> None:
+    # The dispatched goal must carry the structured concerns + acceptance bar,
+    # and the ladder's extra_context when supplied.
+    outcome = {"result": {"success": True, "branch_pushed": True}}
+    with patch.object(watcher, "_run_pipeline", return_value=outcome) as mock_pipe:
+        watcher._run_fix_pass(
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            REPO_KEY,
+            "goal/1",
+            "- wire up the collector\n- add the None guard",
+            SETTINGS,
+            state_key="k",
+            extra_context="LADDER L1 ENRICHMENT",
+        )
+    goal_text = mock_pipe.call_args.args[3]
+    assert "1. wire up the collector" in goal_text
+    assert "NECESSARY BUT NOT SUFFICIENT" in goal_text
+    assert "LADDER L1 ENRICHMENT" in goal_text
+
+
 def test_merge_and_done_keeps_state_on_merge_failure(tmp_path: Path) -> None:
     state, sp = _make_state(tmp_path, plane_task_id=None)
     gh = _make_gh()

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -30,6 +30,7 @@ REVIEWER_CFG = MagicMock(
     allowed_reviewer_logins=[],
     max_self_review_loops=2,
     max_fix_attempts=2,
+    max_fix_strategy_level=2,
     bot_comment_marker="<!-- operations-center:bot -->",
 )
 
@@ -245,12 +246,99 @@ def test_phase1_concerns_records_no_progress_signature(tmp_path: Path) -> None:
     assert loaded["last_concerns_summary"] == "issues"
 
 
-def test_phase1_repeated_concerns_after_noop_fix_escalates(tmp_path: Path) -> None:
+def test_phase1_repeated_concerns_after_noop_fix_climbs_ladder(tmp_path: Path) -> None:
+    """Self-Heal Ladder: a no-progress repeat at L0 climbs to L1 and re-dispatches
+    the fix pass with more resolving power — it does NOT escalate to a human
+    (that is the top of the ladder, not the second rung)."""
     state, sp = _make_state(
         tmp_path,
         phase="self_review",
         self_review_loops=1,
         fix_attempts=1,
+        last_fix_pass_pushed=False,
+        last_concerns_head_sha="abc123",
+        last_concerns_summary="same issues",
+    )
+    gh = _make_gh()
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "same issues"},
+        ),
+        patch.object(watcher, "_run_fix_pass", return_value=False) as mock_fix,
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state,
+            sp,
+            _pr_data(head_sha="abc123"),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            SETTINGS,
+        )
+
+    mock_escalate.assert_not_called()
+    mock_fix.assert_called_once()
+    # The dispatched fix pass carried the L1 enrichment (extra_context).
+    assert "changed nothing" in (mock_fix.call_args.kwargs.get("extra_context", "")).lower()
+    loaded = watcher._load_state(sp)
+    assert loaded["fix_strategy_level"] == 1
+
+
+def test_phase1_no_progress_climbs_ladder_regardless_of_concern_wording(tmp_path: Path) -> None:
+    """No-progress is detected by the unchanged head, not concern text — so the
+    ladder climbs even when the LLM rewords the concern between loops."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=1,
+        fix_attempts=1,
+        last_fix_pass_pushed=False,
+        last_concerns_head_sha="abc123",
+        last_concerns_summary="old concern wording from prior loop",
+    )
+    gh = _make_gh()
+
+    with (
+        patch.object(
+            watcher,
+            "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "slightly different wording same issue"},
+        ),
+        patch.object(watcher, "_run_fix_pass", return_value=False) as mock_fix,
+        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
+    ):
+        watcher._phase1(
+            state,
+            sp,
+            _pr_data(head_sha="abc123"),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            SETTINGS,
+        )
+
+    mock_escalate.assert_not_called()
+    mock_fix.assert_called_once()
+    assert watcher._load_state(sp)["fix_strategy_level"] == 1
+
+
+def test_phase1_no_progress_escalates_only_at_ladder_top(tmp_path: Path) -> None:
+    """When the ladder is already at max_fix_strategy_level, a further no-progress
+    repeat escalates to a human — the terminal rung."""
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=1,
+        fix_attempts=1,  # below max_fix_attempts(2) so the cap isn't what fires
+        fix_strategy_level=2,  # already at max (REVIEWER_CFG.max_fix_strategy_level)
         last_fix_pass_pushed=False,
         last_concerns_head_sha="abc123",
         last_concerns_summary="same issues",
@@ -280,45 +368,8 @@ def test_phase1_repeated_concerns_after_noop_fix_escalates(tmp_path: Path) -> No
 
     mock_fix.assert_not_called()
     mock_escalate.assert_called_once()
+    assert mock_escalate.call_args.kwargs["reason"] == "fix_pass_no_progress"
     assert state["escalated_head_sha"] == "abc123"
-
-
-def test_phase1_repeated_concerns_different_text_still_escalates(tmp_path: Path) -> None:
-    """No-progress escalation fires even when LLM produces different concern text."""
-    state, sp = _make_state(
-        tmp_path,
-        phase="self_review",
-        self_review_loops=1,
-        fix_attempts=1,
-        last_fix_pass_pushed=False,
-        last_concerns_head_sha="abc123",
-        last_concerns_summary="old concern wording from prior loop",
-    )
-    gh = _make_gh()
-
-    with (
-        patch.object(
-            watcher,
-            "_run_direct_review",
-            return_value={"result": "CONCERNS", "summary": "slightly different wording same issue"},
-        ),
-        patch.object(watcher, "_run_fix_pass") as mock_fix,
-        patch.object(watcher, "_escalate_needs_human") as mock_escalate,
-    ):
-        watcher._phase1(
-            state,
-            sp,
-            _pr_data(head_sha="abc123"),
-            gh,
-            "owner",
-            "repo",
-            tmp_path,
-            tmp_path / "cfg.yaml",
-            SETTINGS,
-        )
-
-    mock_fix.assert_not_called()
-    mock_escalate.assert_called_once()
 
 
 def test_phase1_fix_pass_preserves_external_escalation(tmp_path: Path) -> None:
@@ -2235,6 +2286,7 @@ def test_wo3_no_progress_after_retraction_ci_red_still_escalates(tmp_path: Path)
         tmp_path,
         phase="self_review",
         fix_attempts=1,
+        fix_strategy_level=2,  # ladder already at top → red CI must escalate, not merge
         last_fix_pass_pushed=False,
         last_concerns_head_sha="sha1",
         ci_green_retraction_count=watcher._MAX_CI_GREEN_RETRACTIONS,


### PR DESCRIPTION
## What & why

PR #313 shipped broken because the reviewer's CONCERNS→fix loop was **binary and shallow**: one fix pass on an unstructured prose blob, then escalate straight to a human on the first no-progress repeat — with "tests pass" as the (wrong) acceptance bar. #314 fixed governance and #319/#320 added the planner-side D12/DC10 gates. This PR closes the last gap: making the **fix loop itself** strong enough to actually *resolve* a binding verdict.

**Binding invariant (held throughout):** self-heal **resolves** the concern, never **bypasses** it to reach green CI (the #313 failure mode). LGTM stays the only merge path; the #314 CI-green guard is untouched. Nothing here adds a way to merge over a concern — it only changes how hard the system tries before conceding.

Design + roadmap: `docs/design/SELF_HEAL_LADDER.md`.

## The ladder

| Level | Strategy |
|------|----------|
| L0 | Structured, enumerated concerns + anti-no-op acceptance bar |
| L1 | + PR-diff orientation + "previous pass changed nothing — different approach" |
| L2 | Decompose: resolve one concern per pass |
| L3 (terminal) | Human; on fix-cap exhaustion, close + re-queue carrying the **unresolved** concerns |

## Phases (one commit each)

- **P0** — design doc + binding invariant + roadmap.
- **P1** — `_structure_concerns()` + `_build_fix_goal()` + `_FIX_ACCEPTANCE_BAR`: "tests passing is necessary but NOT sufficient; a tested-but-unwired symbol must be wired to its production call path, not re-tested" + clear the D12/DC10 gate locally.
- **P2** — `fix_strategy_level` + `ReviewerSettings.max_fix_strategy_level` (default 2; 0 = old behavior); on no-progress climb a rung with `_ladder_enrichment()` instead of escalating; human only at the top.
- **P3** — `_close_and_requeue(concerns=…)` → `_requeue_plane_task()` carries the still-unresolved concerns (enumerated) onto the re-queued task so the next attempt is scoped, not blind.

## Tests

11 new tests (structured-concerns parse, goal builder, ladder climb/regardless-of-wording/escalate-at-top, rescope carry-forward); the two old immediate-escalation tests replaced by ladder equivalents; WO-3 ci-red test updated to ladder-top. **Watcher suite 112 + reviewer integration 80 green; D12/DC10 gate + ty clean.**

Binding-invariant guards kept intact: `test_wo3_no_progress_after_retraction_*`, `test_phase1_concerns_closes_and_requeues_at_fix_cap`, LGTM-only merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)