### PR TITLE
ci(reviewer): gate the reviewer state-machine tests in CI

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -6933,3 +6933,14 @@ matter and linked it from docs/specs/reviewer-pr-state-machine.md (the topical
 reviewer spec). Audit now down to the sole pre-existing [B2] boundary-artifact
 MED finding (environmental — present on origin/main; CI materializes the
 artifact from REPOGRAPH_BOUNDARY_ARTIFACT_B64 secret).
+
+## 2026-06-18 — Close the reviewer-tests-not-in-CI gap (honesty flag #3)
+
+Discovered while shipping the Self-Heal Ladder: CI's "Test (pytest)" job runs
+`pytest tests/unit`, but the reviewer state machine tests live at
+`tests/test_pr_review_watcher.py` (repo ROOT) — so the verdict-gate + ladder +
+governance code (the #313 regression class) was NEVER run in CI. Added a
+dedicated isolated CI job "Reviewer state-machine tests" that runs the file on
+its own (112 tests, no services). Kept separate from tests/unit so it can't
+perturb the environment-sensitive test_documentation_accuracy collection-count
+assertions (6 of which fail locally but pass in CI — pre-existing, unrelated).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,27 @@ jobs:
             coverage.xml
           retention-days: 30
 
+  reviewer:
+    name: Reviewer state-machine tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Run pr_review_watcher tests
+        # The reviewer self-review / verdict-gate / Self-Heal Ladder state machine
+        # lives at tests/test_pr_review_watcher.py (repo ROOT, not tests/unit), so
+        # the main "Test (pytest)" job — which runs `pytest tests/unit` — never
+        # exercised it. This dedicated job gates the governance + self-heal code
+        # (the #313 regression class: never merge over a CONCERNS verdict; resolve
+        # concerns instead of conceding) on every PR. Standalone, no live services.
+        # Isolated from tests/unit so it cannot perturb the doc-accuracy suite's
+        # collection-count assertions.
+        run: pytest -q tests/test_pr_review_watcher.py -p no:flaky-detection
+
   performance:
     name: Performance regression tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

While shipping the Self-Heal Ladder (#321) I found that **CI never ran the reviewer's own tests.** The "Test (pytest)" job runs `pytest tests/unit`, but `tests/test_pr_review_watcher.py` lives at the repo **root** — so the verdict-gate, Self-Heal Ladder, and close/re-queue governance (the entire #313 regression class) had **zero CI coverage**. A green PR check did not mean the merge-governance logic was tested.

## What

A dedicated, isolated CI job **"Reviewer state-machine tests"** that runs `pytest -q tests/test_pr_review_watcher.py` (112 tests, no live services).

Kept **separate** from `tests/unit` on purpose: several `test_documentation_accuracy` tests assert on pytest collection counts, so folding the reviewer file into that invocation would couple them. Isolation avoids that.

## Verification

`pytest tests/test_pr_review_watcher.py` → **112 passed** standalone. YAML validated.

This closes honesty-flag #3 from the #321 follow-up and makes the "#313 won't happen again" guards regression-protected in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)