### PR TITLE
fix(docs): drop cross-repo symbol backticks tripping OC phantom-symbol gate

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -6957,3 +6957,15 @@ WIRE/DELETE/KEEP dispositions, adversarially adjudicated (nothing deferred to a
 human). Phase 1 (enforcement backbone) DONE: Custodian #46 closed the --only
 silent-skip (gate now self-verifying). Phases 2 (WIRE 4 real gaps), 3 (DELETE
 clean dead code), 4 (OC observer plane), 5 (ratchet cleanup) follow via /loop.
+
+## 2026-06-18 — fix-forward: remediation doc tripped OC phantom-symbol gate
+
+#323 merged (fleet reviewer LGTM; main is not branch-protected and the reviewer
+does not gate on the advisory `audit` check) while the custodian-audit job was
+red: my cross-repo roadmap doc backtick-referenced `p95_latency_ms` (a SwitchBoard
+symbol), which OC's K1/OC8 phantom-symbol detectors flag (they only know OC src).
+K1 has no per-file exclude (suppresses via known_values only), so the root-cause
+fix is to drop the backticks on that one cross-repo symbol. Reworded line 64.
+Audit now down to the sole environmental B2 (boundary artifact, materialized from
+secret in CI). NOTE: the audit gate is advisory (main unprotected, reviewer
+LGTM-merges over it) — a governance gap worth a follow-up.

--- a/docs/design/INCOMPLETE_INTEGRATION_REMEDIATION.md
+++ b/docs/design/INCOMPLETE_INTEGRATION_REMEDIATION.md
@@ -61,7 +61,7 @@ no external contract); KEEP = legitimate API/dispatch surface, do not touch.
 |------|------|--------|
 | TeamExecutor | `TeamExecutorRunner` never registered as an RxP runtime → the whole executor is undispatchable | WIRE: add the RxP runtime/entry-point registration |
 | PlatformManifest | `parse_visibility_scope` — `visibility_scope` field shipped in `data/platform_manifest.yaml`, parsed nowhere | WIRE into `load_repo_graph`; surface on the graph |
-| SwitchBoard | `p95_latency_ms` computed but the demote heuristic reads only `mean_latency_ms` (outlier-sensitive) | WIRE p95 into `AdjustmentEngine._evaluate` |
+| SwitchBoard | p95 latency computed but the demote heuristic reads only mean latency (outlier-sensitive) | WIRE p95 into the AdjustmentEngine evaluate path |
 | DAGExecutor | `NodeRunner` Protocol defined but the runner dispatch isn't typed to it (inert) | WIRE: type the runner registry as `dict[NodeType, NodeRunner]` |
 
 ### Phase 3 — DELETE provably-dead superseded code


### PR DESCRIPTION
Fix-forward for the audit regression introduced when #323 merged.

**What happened:** the cross-repo roadmap doc backtick-referenced `p95_latency_ms` (a *SwitchBoard* symbol). OC's K1/OC8 phantom-symbol detectors only know OC's own `src`, so they flagged it — turning the `custodian-audit` job red on main. #323 merged anyway because main isn't branch-protected and the reviewer LGTM-merges over the advisory (non-required) audit check.

**Fix:** K1 has no per-file exclude (it suppresses via `known_values` only), so the clean root-cause fix is to drop the backticks on that one cross-repo symbol reference. Verified with the working detector: audit goes from 3 findings → 1, and the remaining one is the environmental **B2** (boundary artifact, materialized from a secret in CI — green on the prior main runs).

**Governance note (follow-up):** the `audit` gate is currently advisory — main is unprotected and the reviewer doesn't gate on it, so a red audit doesn't block a merge. Making it required is blocked on B2 being made reliable (tracked as backbone item B2/B3 in the remediation roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)