### PR TITLE
feat(observer): wire FlakyTestReporter into the live pytest plugin

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -6969,3 +6969,18 @@ fix is to drop the backticks on that one cross-repo symbol. Reworded line 64.
 Audit now down to the sole environmental B2 (boundary artifact, materialized from
 secret in CI). NOTE: the audit gate is advisory (main unprotected, reviewer
 LGTM-merges over it) — a governance gap worth a follow-up.
+
+## 2026-06-18 — COMPLETE FlakyTestReporter: wire it into the live plugin
+
+Observer-plane #313 remediation — COMPLETE (wire), not delete. FlakyTestReporter
+(observer/flaky_test_reporter.py) is the full flaky-reporting engine (categories,
+per-test metrics, markdown tables, trend analysis) built+tested in #247 but never
+called in production — the live pytest_flaky_plugin reimplemented a simpler
+analysis and never used it. Wired it: pytest_sessionfinish now feeds the
+session's outcomes to FlakyTestReporter (_emit_reporter_report), which persists
+results in its JSONL format and writes latest-flaky-report.md. Best-effort
+(try/except) so reporting can never break a test session. 2 tests (wire produces
+report + persists; failure is swallowed). Pruned format_flaky_tests_markdown +
+save_test_results from audit.d12_baseline (now wired → D12 gate confirms 0
+findings). Follow-up: cross-session trend load (needs FlakyTestResult.from_dict +
+a history loader) to light up query_trend_analysis.

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -59,7 +59,6 @@ audit:
     - filter_by_extraction_status
     - filter_by_test_name
     - find_violations
-    - format_flaky_tests_markdown
     - format_flaky_tests_table
     - format_report_text
     - generate_alerts
@@ -145,7 +144,6 @@ audit:
     - save_session_report
     - save_session_results
     - save_snapshot
-    - save_test_results
     - scrub_sample
     - should_alert_on_failure_rate
     - should_alert_on_flaky_count

--- a/src/operations_center/observer/pytest_flaky_plugin.py
+++ b/src/operations_center/observer/pytest_flaky_plugin.py
@@ -143,6 +143,44 @@ class FlakyTestDetectionPlugin:
         # Save to storage
         self._save_session_report(session_report)
 
+        # Drive the richer FlakyTestReporter engine from the same in-session
+        # outcomes so it actually runs in the live path: it persists results in
+        # its own format (building the dataset its trend analysis consumes) and
+        # emits a human-readable markdown report. Best-effort — reporting must
+        # never break a test session.
+        self._emit_reporter_report()
+
+    def _emit_reporter_report(self) -> None:
+        """Feed this session's outcomes to FlakyTestReporter, persist them, and
+        write a markdown flaky report alongside the raw session JSON.
+
+        FlakyTestReporter (observer.flaky_test_reporter) is the full reporting
+        engine — categories, per-test metrics, markdown tables, trend analysis —
+        but had no live caller. This wires it into the pytest plugin so the
+        feature produces output on every run. (Cross-session trend analysis,
+        which needs loading the persisted history back, is a follow-up: the data
+        is now persisted in the reporter's format here.)"""
+        try:
+            from .flaky_test_models import FlakyTestResult
+            from .flaky_test_reporter import FlakyTestReporter
+
+            reporter = FlakyTestReporter.create_local(self.flaky_storage_path)
+            for nodeid, result in self.test_outcomes.items():
+                reporter.track_test(
+                    FlakyTestResult(
+                        nodeid=nodeid,
+                        outcome=str(result.get("outcome", "passed")),
+                        duration=float(result.get("duration") or 0.0),
+                    )
+                )
+            reporter.analyze_session()
+            reporter.save_test_results()
+            report_md = reporter.format_flaky_tests_markdown(include_assertions=False)
+            report_path = self.flaky_storage_path / "latest-flaky-report.md"
+            report_path.write_text(report_md, encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001 — reporting is best-effort
+            self._log.debug("flaky reporter emit skipped: %s", exc)
+
     def _extract_test_name(self, item: pytest.Item) -> str:
         """Extract test function name from pytest Item.
 

--- a/tests/unit/observer/test_pytest_flaky_plugin.py
+++ b/tests/unit/observer/test_pytest_flaky_plugin.py
@@ -106,6 +106,46 @@ def test_sessionfinish_writes_report_with_flaky_candidates(tmp_path: Path) -> No
     assert report["flaky_candidates"][0]["module"] == "tests/a.py"
 
 
+def test_sessionfinish_drives_flaky_test_reporter(tmp_path: Path) -> None:
+    # The richer FlakyTestReporter engine is now wired into the live plugin:
+    # a session emits its markdown report and persists results in the reporter's
+    # JSONL format (in addition to the raw session JSON).
+    storage = tmp_path / "flaky"
+    plugin = FlakyTestDetectionPlugin(str(storage))
+    plugin.pytest_sessionstart(session=SimpleNamespace(name="s"))
+    plugin.pytest_runtest_makereport(_item("tests/a.py::test_ok"), _call_info())
+    exc = SimpleNamespace(value=ValueError("flake"))
+    plugin.pytest_runtest_makereport(_item("tests/a.py::test_bad"), _call_info(excinfo=exc))
+
+    plugin.pytest_sessionfinish(session=SimpleNamespace(name="sess-1"), exitstatus=1)
+
+    # FlakyTestReporter produced its markdown report...
+    report_md = storage / "latest-flaky-report.md"
+    assert report_md.exists()
+    assert report_md.read_text(encoding="utf-8").strip() != ""
+    # ...and persisted results in its own JSONL format (the trend-analysis dataset).
+    assert list(storage.glob("runs/results-*.jsonl"))
+
+
+def test_sessionfinish_reporter_failure_does_not_break_session(tmp_path: Path, monkeypatch) -> None:
+    # Reporting is best-effort: a failure INSIDE the reporter must be swallowed
+    # so it never breaks a test session. Make the reporter blow up and assert
+    # pytest_sessionfinish still completes (and the raw session JSON still saved).
+    storage = tmp_path / "flaky"
+    plugin = FlakyTestDetectionPlugin(str(storage))
+    plugin.pytest_runtest_makereport(_item("tests/a.py::test_ok"), _call_info())
+
+    import operations_center.observer.flaky_test_reporter as ftr
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("reporter exploded")
+
+    monkeypatch.setattr(ftr.FlakyTestReporter, "create_local", classmethod(_boom))
+    plugin.pytest_sessionfinish(session=SimpleNamespace(name="s"), exitstatus=0)  # must not raise
+
+    assert list(storage.glob("runs/*/*-session.json"))  # raw session report still written
+
+
 def test_save_session_report_warning_on_io_error(tmp_path: Path, monkeypatch, caplog) -> None:
     plugin = FlakyTestDetectionPlugin(str(tmp_path / "flaky"))
 


### PR DESCRIPTION
First of the **observer-plane completions** — and a course-correction in action: the operator's direction is **complete genuine features, don't delete them.**

## The #313 gap
`FlakyTestReporter` (the full flaky-reporting engine — categories, per-test metrics, markdown tables, trend analysis) shipped in #247 was **built and fully tested but never called in production**. The live `pytest_flaky_plugin` reimplemented a *simpler* analysis and never used it. Classic claimed-complete-but-inert.

## Completion (not deletion)
`pytest_sessionfinish` now drives `FlakyTestReporter` from the same in-session outcomes (`_emit_reporter_report`): it persists results in the reporter's JSONL format and writes **`latest-flaky-report.md`** alongside the raw session JSON. The call is **best-effort** (`try/except`) so reporting can never break a test session — proven by a test.

## Ratchet
Pruned `format_flaky_tests_markdown` + `save_test_results` from `audit.d12_baseline` — they now have a production caller, and the **D12 gate confirms 0 findings** (the wire is real, not baseline-hidden). The reporter's `query_*`/trend methods remain unwired (stay baselined); lighting up cross-session trend analysis (load the persisted history back) is the documented follow-up.

**Verified:** 2 new tests; observer unit suite 1387 passed; working-detector audit B2-env-only; doctor + D12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)