### PR TITLE
chore(deps): bump custodian pin to d6ba8ab (collision-masking fix)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,12 @@
+## 2026-06-18 — chore: bump custodian pin to d6ba8ab (collision fix)
+
+Local `.venv` custodian was pinned at a29648a (pre-#48), and the reviewer fleet
+runs `OC/.venv/bin/custodian-multi` (pr_review_watcher main.py:1424) — so the
+live reviewer was auditing PRs with a custodian that masked colliding-ID
+findings (the R2 phantom). Bumped the pin to Custodian@d6ba8ab (PR #48:
+add_pattern un-masks collisions + content-less B2 message). Reinstall the venv
+after merge so the running fleet picks it up.
+
 ## 2026-06-18 — Stage 4: Run incomplete-integration gate and clear all findings
 
 Ran the custodian-multi incomplete-integration gate to verify B1, B2, D12, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
   "pytest-cov>=6.0",
   "ruff==0.15.13",
   "ty==0.0.40",
-  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@a29648a77adc190be45f5570f9373992c669333c",
+  "custodian @ git+https://github.com/ProtocolWarden/Custodian.git@d6ba8ab245c6f4e79e9f8fffd4e4221bfaf266e8",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Bumps the local custodian pin `a29648a → d6ba8ab` (Custodian #48).

**Why it matters beyond hygiene:** the reviewer fleet runs
`OC/.venv/bin/custodian-multi` (`pr_review_watcher/main.py:1424`) to audit PRs.
The old pin masked findings from colliding detector IDs (the R2 boundary-leak
phantom this campaign uncovered), so the live reviewer's local audit could miss
real findings. CI already installs `custodian@main`; this aligns the local/fleet
install. After merge, the venv is reinstalled so the running fleet picks it up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)