### PR TITLE
fix(reviewer): apply a docs-only rubric so doc PRs aren't over-flagged

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-06-18 — fix: reviewer applies a docs-only rubric (stop over-flagging doc PRs)
+
+Root fix for the #334 over-flagging (the loop-bug #335 only bounded it). When a
+PR's diff is documentation-only (every changed file is `.md/.markdown/.rst/.txt`
+or under `docs/`), `_phase1` injects a doc rubric telling the self-review to
+review for internal consistency / accuracy / broken refs / clarity and NOT to
+raise "unverifiable in-diff / lacks CI evidence / references work outside this
+diff" concerns — a doc legitimately points to CI runs, secrets, sibling PRs it
+can't contain. Mixed (doc+code) and config-only (e.g. `.console/reconcile.yaml`)
+diffs still get full review. Helpers `_is_doc_path` / `_files_from_diff` /
+`_diff_is_docs_only`; rubric `_DOC_ONLY_REVIEW_RUBRIC`. Tests: classification +
+rubric injected for docs-only, omitted for code. Reviewer suite 123 pass.
+
 ## 2026-06-18 — docs: mark the three backbone follow-ups resolved (minimal)
 
 Replaced the stale "Backbone notes" section (which still described B2 as red, the

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -817,6 +817,52 @@ def _attempt_auto_rebase(repo_cfg, head_ref: str, settings, pr_number: int) -> s
         return "error"
 
 
+_DOC_PATH_SUFFIXES = (".md", ".markdown", ".rst", ".txt")
+
+
+def _is_doc_path(path: str) -> bool:
+    """True for documentation files — any doc extension, or anything under docs/."""
+    p = path.strip().lower()
+    return bool(p) and (p.endswith(_DOC_PATH_SUFFIXES) or p.startswith("docs/") or "/docs/" in p)
+
+
+def _files_from_diff(diff: str) -> list[str]:
+    """Extract changed file paths from a unified diff's ``diff --git a/X b/Y`` headers."""
+    files: list[str] = []
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split(" b/", 1)
+            if len(parts) == 2 and parts[1].strip():
+                files.append(parts[1].strip())
+    return files
+
+
+def _diff_is_docs_only(files) -> bool:
+    """True when every changed file is documentation (and there is at least one).
+
+    A docs-only diff gets a review rubric that does NOT demand in-diff proof of
+    facts a document legitimately references but cannot contain (CI runs, secrets,
+    sibling/other-repo PRs) — the over-flagging that looped #334.
+    """
+    fs = [f for f in (files or []) if f]
+    return bool(fs) and all(_is_doc_path(f) for f in fs)
+
+
+# Review rubric injected when the diff is documentation-only — see _diff_is_docs_only.
+_DOC_ONLY_REVIEW_RUBRIC = (
+    "\n\n## This diff is DOCUMENTATION-ONLY — apply the docs rubric\n"
+    "Every changed file is documentation. Review it for **internal consistency, "
+    "accuracy against the repository's actual state, broken cross-references, and "
+    "clarity**. Documentation legitimately summarizes and points to work that lives "
+    "OUTSIDE this diff (CI runs, secrets, sibling PRs, other repos). Therefore you "
+    "MUST NOT raise CONCERNS of the form 'unverifiable in the diff', 'lacks CI "
+    "output / test evidence', 'claims changes not shown here', or 'references work "
+    "outside this diff' — demanding in-diff proof of an external fact is NOT a valid "
+    "concern for a docs PR. Raise CONCERNS only for statements that CONTRADICT the "
+    "repository's actual state, broken/dead references, or genuinely incoherent prose."
+)
+
+
 _REVIEWER_VERDICT_STATUS_CONTEXT = "reviewer-verdict"
 
 
@@ -2059,7 +2105,11 @@ def _phase1(
             + _file_lines
         )
     else:
+        _pr_files = _files_from_diff(diff)
         diff_excerpt = diff
+    # A documentation-only diff gets a rubric that doesn't demand in-diff proof of
+    # facts a doc legitimately references but can't contain (the #334 over-flagging).
+    docs_only = _diff_is_docs_only(_pr_files)
     title = pr_data.get("title", "")
 
     # Load optional campaign spec and Custodian findings for spec-aware review
@@ -2074,6 +2124,7 @@ def _phase1(
     custodian_section = (
         f"\n\n## Custodian static analysis\n\n{custodian_text}" if custodian_text else ""
     )
+    doc_rubric = _DOC_ONLY_REVIEW_RUBRIC if docs_only else ""
 
     goal_text = (
         "## TASK TYPE: Read-only code review\n"
@@ -2082,7 +2133,8 @@ def _phase1(
         f"PR #{pr_number}: {title}\n\n"
         f"```diff\n{diff_excerpt}\n```"
         f"{spec_section}"
-        f"{custodian_section}\n\n"
+        f"{custodian_section}"
+        f"{doc_rubric}\n\n"
         f"**Review checklist** (raise CONCERNS for any failure):\n"
         f"1. If a campaign spec is provided above, verify the diff implements EXACTLY what the spec\n"
         f"   requires — correct filenames, member names, member count, exports, tests, version bumps.\n"

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -2086,6 +2086,7 @@ def _phase1(
             pr_number,
         )
 
+    _pr_files = _files_from_diff(diff)
     if len(diff) > _DIFF_LIMIT:
         # Fetch the complete file list so the reviewer can verify implementation
         # completeness even when the diff body is truncated. Without this, the
@@ -2105,7 +2106,6 @@ def _phase1(
             + _file_lines
         )
     else:
-        _pr_files = _files_from_diff(diff)
         diff_excerpt = diff
     # A documentation-only diff gets a rubric that doesn't demand in-diff proof of
     # facts a doc legitimately references but can't contain (the #334 over-flagging).

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -2638,3 +2638,73 @@ def test_phase1_external_push_resets_budget(tmp_path: Path) -> None:
     loaded = watcher._load_state(sp)
     # Reset to 0, then dispatch incremented to 1 (fresh start).
     assert loaded["fix_attempts"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Doc-only review rubric: a documentation-only diff must NOT be flagged for
+# "unverifiable in-diff" facts a doc legitimately references (the #334 churn).
+# ---------------------------------------------------------------------------
+def test_is_doc_path_classification():
+    assert watcher._is_doc_path("docs/design/X.md")
+    assert watcher._is_doc_path(".console/log.md")
+    assert watcher._is_doc_path("README.rst")
+    assert watcher._is_doc_path("docs/diagram.png")  # anything under docs/
+    assert not watcher._is_doc_path("src/foo.py")
+    assert not watcher._is_doc_path(".console/reconcile.yaml")  # config, not docs
+
+
+def test_diff_is_docs_only():
+    assert watcher._diff_is_docs_only(["docs/X.md", ".console/log.md"])
+    assert not watcher._diff_is_docs_only(["docs/X.md", "src/foo.py"])  # mixed
+    assert not watcher._diff_is_docs_only([".custodian/config.yaml"])  # config
+    assert not watcher._diff_is_docs_only([])  # nothing changed
+
+
+def test_files_from_diff_parses_git_headers():
+    diff = "diff --git a/docs/X.md b/docs/X.md\n+hi\ndiff --git a/src/y.py b/src/y.py\n+x"
+    assert watcher._files_from_diff(diff) == ["docs/X.md", "src/y.py"]
+
+
+def test_phase1_docs_only_diff_injects_doc_rubric(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=0, fix_attempts=0)
+    gh = _make_gh()
+    gh.get_pr_diff.return_value = "diff --git a/docs/design/D.md b/docs/design/D.md\n+pointer to #330"
+    captured = {}
+
+    def _capture(_oc_root, goal_text, _state_key):
+        captured["goal"] = goal_text
+        return {"result": "LGTM", "summary": "ok"}
+
+    with (
+        patch.object(watcher, "_run_direct_review", side_effect=_capture),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", SETTINGS,
+        )
+
+    assert "DOCUMENTATION-ONLY" in captured["goal"]
+    assert "demanding in-diff proof of an external fact is NOT a valid" in captured["goal"]
+
+
+def test_phase1_code_diff_omits_doc_rubric(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review", self_review_loops=0, fix_attempts=0)
+    gh = _make_gh()
+    gh.get_pr_diff.return_value = "diff --git a/src/foo.py b/src/foo.py\n+x = 1"
+    captured = {}
+
+    def _capture(_oc_root, goal_text, _state_key):
+        captured["goal"] = goal_text
+        return {"result": "LGTM", "summary": "ok"}
+
+    with (
+        patch.object(watcher, "_run_direct_review", side_effect=_capture),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="abc"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", SETTINGS,
+        )
+
+    assert "DOCUMENTATION-ONLY" not in captured["goal"]


### PR DESCRIPTION
The **root** fix for the over-flagging that looped #334 — the escalation-budget
fix (#335) only bounded the symptom; this stops the reviewer raising the
false-positive in the first place.

When a PR's diff is **documentation-only** (every changed file is
`.md/.markdown/.rst/.txt` or under `docs/`), the self-review prompt now carries a
docs rubric: review for internal consistency, accuracy against the repo, broken
references, and clarity — and **do NOT** raise concerns that a statement is
"unverifiable in the diff", "lacks CI/test evidence", or "references work outside
this diff". A document legitimately points to work it can't contain (CI runs,
secrets, sibling/other-repo PRs); demanding in-diff proof of those isn't a valid
concern for a docs PR.

**Scoped tightly:** mixed (doc+code) and config-only diffs (e.g.
`.console/reconcile.yaml`) still get the full review rubric — only all-docs diffs
are right-sized.

Helpers `_is_doc_path` / `_files_from_diff` / `_diff_is_docs_only`; rubric
`_DOC_ONLY_REVIEW_RUBRIC`. Tests cover classification, detection, and that
`_phase1` injects the rubric for docs-only and omits it for code. Reviewer suite
**123 pass**; audit clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)