### PR TITLE
fix(reviewer): make the escalation-budget guard restart-safe

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-06-18 — fix: budget-guard survives a watcher restart mid-fix
+
+Closes the residual edge in #335 that #337 exposed live: if the review watcher is
+interrupted BETWEEN a fix-push and recording `last_fix_push_sha` (a long fix pass
+killed the process), the SHA is lost and the next poll mistook our own push for an
+external one — resetting the budget (re-opening the #334 loop risk). Added a
+restart-safe fallback driven by state that survives the pre-fix save: when we have
+an active fix cycle (`fix_attempts > 0`) but the pass outcome was never recorded
+(`last_fix_pass_pushed` absent — it's popped at dispatch start, re-set only on
+completion), a head move is our interrupted fix's push → treat as ours, don't
+reset. A poll never observes this mid-dispatch (the dispatch is synchronous), so
+the fallback only fires post-restart. External pushes after a COMPLETED pass still
+reset. Test: restart-mid-fix preserves budget (→2); updated the self/external tests
+to set `last_fix_pass_pushed=True`. Reviewer suite 124 pass.
+
 ## 2026-06-18 — fix: reviewer applies a docs-only rubric (stop over-flagging doc PRs)
 
 Root fix for the #334 over-flagging (the loop-bug #335 only bounded it). When a

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1773,12 +1773,31 @@ def _phase1(
     # #334 non-convergence: 7 self-pushes, fix_attempts stuck at 1, piling on
     # evidence files). last_fix_push_sha is the head our last fix pass produced.
     last_fix_push_sha = str(state.get("last_fix_push_sha") or "").strip()
+    # Restart-safe recognition of our own fix-push. In steady state the head
+    # matches the SHA we recorded after the pass (last_fix_push_sha). But if the
+    # watcher was interrupted BETWEEN the fix-push and that recording — e.g. a
+    # long fix pass kills the process (seen on #337) — last_fix_push_sha is lost
+    # and a naive guard would mistake our own push for an external one and reset
+    # the budget (re-opening the #334 loop). Recover from durable state that
+    # survives the pre-fix save: when we have an active fix cycle
+    # (`fix_attempts > 0`) but the pass outcome was never recorded
+    # (`last_fix_pass_pushed` is popped at dispatch start and only re-set when the
+    # pass completes), a head move is almost certainly that interrupted pass's
+    # push — treat it as ours. (A poll never observes this mid-dispatch: the
+    # dispatch is synchronous within one poll, so the unrecorded state is only
+    # ever seen after a restart.)
+    _fix_dispatch_unrecorded = (
+        state.get("fix_attempts", 0) > 0 and "last_fix_pass_pushed" not in state
+    )
+    _is_our_fix_push = (
+        bool(last_fix_push_sha) and current_head_sha == last_fix_push_sha
+    ) or _fix_dispatch_unrecorded
     if (
         state.get("concerns_comment_id")
         and current_head_sha
         and previous_concerns_head_sha
         and current_head_sha != previous_concerns_head_sha
-        and current_head_sha != last_fix_push_sha
+        and not _is_our_fix_push
     ):
         _retract_flag(
             state, gh_client, owner, repo, resolution="superseded by new push — re-review resumed"

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -2574,7 +2574,8 @@ def test_publish_reviewer_verdict_swallows_errors():
 # ---------------------------------------------------------------------------
 def test_phase1_self_pushed_fix_does_not_reset_budget(tmp_path: Path) -> None:
     # Head moved to H1 because our own previous fix pass pushed it
-    # (last_fix_push_sha == H1) — the budget must keep accumulating.
+    # (last_fix_push_sha == H1, recorded after a completed pass) — the budget must
+    # keep accumulating.
     state, sp = _make_state(
         tmp_path,
         phase="self_review",
@@ -2583,6 +2584,7 @@ def test_phase1_self_pushed_fix_does_not_reset_budget(tmp_path: Path) -> None:
         concerns_comment_id=123,
         last_concerns_head_sha="H0",
         last_fix_push_sha="H1",
+        last_fix_pass_pushed=True,  # prior pass completed + recorded
         last_concerns_summary="same issues",
     )
     gh = _make_gh()
@@ -2608,8 +2610,9 @@ def test_phase1_self_pushed_fix_does_not_reset_budget(tmp_path: Path) -> None:
 
 
 def test_phase1_external_push_resets_budget(tmp_path: Path) -> None:
-    # Head moved to HX by an EXTERNAL push (!= last_fix_push_sha) — genuinely new
-    # work; the budget resets so the human's fix is reviewed fresh.
+    # Head moved to HX by an EXTERNAL push (!= last_fix_push_sha) after a COMPLETED
+    # prior pass (last_fix_pass_pushed recorded) — genuinely new work; the budget
+    # resets so the human's fix is reviewed fresh.
     state, sp = _make_state(
         tmp_path,
         phase="self_review",
@@ -2618,6 +2621,7 @@ def test_phase1_external_push_resets_budget(tmp_path: Path) -> None:
         concerns_comment_id=123,
         last_concerns_head_sha="H0",
         last_fix_push_sha="H1",
+        last_fix_pass_pushed=True,  # prior pass completed → not a mid-fix restart
         last_concerns_summary="same issues",
     )
     gh = _make_gh()
@@ -2638,6 +2642,44 @@ def test_phase1_external_push_resets_budget(tmp_path: Path) -> None:
     loaded = watcher._load_state(sp)
     # Reset to 0, then dispatch incremented to 1 (fresh start).
     assert loaded["fix_attempts"] == 1
+
+
+def test_phase1_restart_mid_fix_does_not_reset_budget(tmp_path: Path) -> None:
+    # The watcher was interrupted BETWEEN our fix-push and recording its SHA, so
+    # both last_fix_push_sha and last_fix_pass_pushed are absent — but we DID
+    # dispatch a fix (fix_attempts=1). The moved head is that interrupted push, not
+    # an external one, so the budget must NOT reset (regression guard for the #337
+    # restart edge that would otherwise re-open the #334 loop).
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        self_review_loops=1,
+        fix_attempts=1,
+        concerns_comment_id=123,
+        last_concerns_head_sha="H0",
+        last_concerns_summary="same issues",
+    )
+    state.pop("last_fix_pass_pushed", None)  # lost to the restart
+    state.pop("last_fix_push_sha", None)
+    watcher._save_state(sp, state)
+    gh = _make_gh()
+    gh.get_pr.return_value = _pr_data(head_sha="H1b")
+
+    with (
+        patch.object(
+            watcher, "_run_direct_review",
+            return_value={"result": "CONCERNS", "summary": "still"},
+        ),
+        patch.object(watcher, "_run_fix_pass", return_value=True),
+    ):
+        watcher._phase1(
+            state, sp, _pr_data(head_sha="H1"), gh, "owner", "repo",
+            tmp_path, tmp_path / "cfg.yaml", SETTINGS,
+        )
+
+    loaded = watcher._load_state(sp)
+    # Preserved (no spurious reset), dispatch incremented to 2.
+    assert loaded["fix_attempts"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the residual edge in #335 that #337 exposed **live**.

#335 stops the fleet's own fix-push from resetting the `fix_attempts` budget by
matching the recorded `last_fix_push_sha`. But that SHA is recorded only **after**
the fix pass returns — so if the watcher is interrupted between the push and the
record (a long fix pass killing the process, as happened on #337), the SHA is lost
and the next poll mistakes our own push for an external one, resetting the budget
and re-opening the #334 infinite-loop risk.

**Fix:** a restart-safe fallback driven by state that survives the pre-fix save —
when there is an active fix cycle (`fix_attempts > 0`) but the pass outcome was
never recorded (`last_fix_pass_pushed` absent; it's popped at dispatch start and
re-set only on completion), a head move is our interrupted fix's push, not
external → don't reset. A poll never observes this mid-dispatch (the dispatch is
synchronous within one poll), so the fallback only fires post-restart. External
pushes after a **completed** pass still reset for a fresh review.

Tests: `test_phase1_restart_mid_fix_does_not_reset_budget` (→ budget preserved);
the self/external-push tests now set `last_fix_pass_pushed=True` to model a
completed prior pass. Reviewer suite **124 pass**; audit clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)