### PR TITLE
Wire board_unblock into the live maintenance loop + PR-merged reconciliation (#268)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-06-19 — operator: wire board_unblock into the live loop + PR-merged reconcile (#268)
+
+The autonomous board-unblock engine (`entrypoints/maintenance/board_unblock.py`,
+Rules 1–10) was complete and tested but **registered nowhere** — runnable only as a
+standalone CLI, zero runs ever, so the controller never investigated stuck/Blocked
+tasks (a D12-class incomplete integration; #267 sat Blocked after its PR #341
+merged, and an operator had to reconcile it by hand). Fix: new sibling task
+`board_unblock_task.py` (`BoardUnblockTask`, a `MaintenanceTask`) that runs the
+existing rules every cycle PLUS a GitHub-aware `reconcile_merged_pr_tasks` — a
+task in In Review/Blocked whose `<role>/<task_id[:8]>` PR actually MERGED is
+transitioned to Done (runs first, so a merged PR wins over the stale-timeout
+heuristics; never re-queues merged work). Wired into the running loop via
+`register_maintenance_tasks` in `spec_hygiene/main.py` (now hosts spec_hygiene +
+ledger + board_unblock). Added `GitHubPRClient.find_pr_by_head`. Honors §0.1: the
+controller now self-heals the board with no human in the loop. 12 new tests + 316
+related pass; ruff/ty clean; pre-push audit 0 findings.
+
 ## 2026-06-19 — goal/0ccb698d Stage 4: Run full test suite and linters, fix any failures ✅
 
 **MILESTONE ACHIEVED: All code verified green, ready for merge**

--- a/src/operations_center/adapters/github_pr.py
+++ b/src/operations_center/adapters/github_pr.py
@@ -395,6 +395,31 @@ class GitHubPRClient:
         resp.raise_for_status()
         return resp.json()
 
+    def find_pr_by_head(self, owner: str, repo: str, head_ref: str) -> dict | None:
+        """Return the most-recently-created PR whose head branch is ``head_ref``
+        (any state: open/closed/merged), or ``None`` if there is none.
+
+        Uses ``GET /pulls?state=all&head={owner}:{head_ref}`` — a precise,
+        single-call lookup (no pagination over all closed PRs). Best-effort:
+        returns ``None`` on any error so a board-reconcile cycle never hardens
+        into a failure because GitHub was momentarily unreachable. A merged PR is
+        identified by a non-null ``merged_at`` on the returned dict.
+        """
+        try:
+            resp = self._request(
+                "GET",
+                f"{self._API}/repos/{owner}/{repo}/pulls",
+                params={"state": "all", "head": f"{owner}:{head_ref}", "per_page": 100},
+            )
+            resp.raise_for_status()
+            prs = resp.json()
+        except Exception:
+            return None
+        if not isinstance(prs, list) or not prs:
+            return None
+        prs.sort(key=lambda p: (p or {}).get("created_at") or "", reverse=True)
+        return prs[0]
+
     def list_pr_files(self, owner: str, repo: str, pr_number: int) -> list[str]:
         """Return the list of filenames changed in a pull request.
 

--- a/src/operations_center/entrypoints/maintenance/board_unblock_task.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock_task.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""BoardUnblockTask — run the autonomous board-unblock engine inside the live
+maintenance loop, so the controller investigates and self-heals stuck/failed
+tasks every cycle with NO human in the loop (HARNESS_TRUST_HARDENING.md §0.1).
+
+The rule engine in ``board_unblock.py`` was complete and tested but registered
+nowhere — runnable only as a standalone CLI, so in practice nothing ever
+unblocked the board. This task wraps that engine (the existing Plane-only Rules
+1–10) and adds one GitHub-aware reconciliation that the pure rules cannot
+express:
+
+    reconcile_merged_pr_tasks — a task left in ``In Review`` or ``Blocked`` whose
+    linked PR (head ``<role>/<task_id[:8]>``) actually MERGED is transitioned to
+    ``Done``. The board_worker can mark a task Blocked on a transient late-stage
+    failure (e.g. backend_error) AFTER its PR has already been reviewed and
+    merged; the stale rules would otherwise re-queue already-merged work. This
+    runs FIRST so a merged PR wins over the timeout heuristics.
+
+Transient `backend_error`/`timeout` Blocked tasks with NO merged PR still
+self-heal through the existing Rule 3 (IMPROVE_UNBLOCK → Backlog after the stale
+window) + backlog promotion; this task does not duplicate that path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import UTC, datetime
+
+from operations_center.adapters.github_pr import GitHubPRClient
+from operations_center.adapters.plane import PlaneClient
+from operations_center.config.settings import Settings
+from operations_center.in_flight_reconcile import state_name as _state_name
+from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceResult
+
+from .board_unblock import (
+    _MEM_SKIP_THRESHOLD_GB,
+    _GOAL_LABEL,
+    _IMPROVE_LABEL,
+    _SPEC_AUTHOR_LABEL,
+    _apply_rules,
+    _has_label,
+    _labels,
+    _mem_available_gb,
+)
+
+logger = logging.getLogger(__name__)
+
+# 10 minutes: tight enough that a stuck task (no-PR In Review, Blocked-but-merged)
+# is reconciled promptly, loose enough not to hammer the GitHub/Plane APIs.
+DEFAULT_INTERVAL_SECONDS = 600
+
+# task-kind label → branch prefix the board_worker uses (branch = prefix/<id8>).
+_LABEL_PREFIX = {
+    _GOAL_LABEL: "goal",
+    _IMPROVE_LABEL: "improve",
+    _SPEC_AUTHOR_LABEL: "spec-author",
+}
+# Order tried when the task-kind label does not pin a single prefix.
+_ALL_PREFIXES = ("goal", "improve", "test", "spec-author")
+
+# Only these (non-terminal) states are candidates for PR-merged reconciliation.
+_RECONCILE_STATES = {"in review", "blocked"}
+
+
+def _repo_key_from_labels(labels: list[str]) -> str | None:
+    for lab in labels:
+        if lab.lower().startswith("repo:"):
+            return lab.split(":", 1)[1].strip()
+    return None
+
+
+def _head_candidates(task_id: str, labels: list[str]) -> list[str]:
+    """Branch heads to probe for a merged PR, most-likely first.
+
+    The board_worker names the branch ``<role>/<task_id[:8]>`` (dispatch.py
+    ``short_id = task_id[:8]``). Prefer the prefix implied by the task-kind
+    label; fall back to the full set (each probe is one cheap, precise API call).
+    """
+    short = str(task_id)[:8]
+    primary = [p for lab, p in _LABEL_PREFIX.items() if _has_label(labels, lab)]
+    ordered = primary + [p for p in _ALL_PREFIXES if p not in primary]
+    return [f"{prefix}/{short}" for prefix in ordered]
+
+
+def reconcile_merged_pr_tasks(
+    issues: list[dict],
+    *,
+    settings: Settings,
+    gh_client: GitHubPRClient,
+) -> list[dict]:
+    """Return Done-transition actions for In-Review/Blocked tasks whose PR merged.
+
+    GitHub-aware companion to ``_apply_rules``. Best-effort per task: any lookup
+    error skips that task (never raises) so the cycle proceeds.
+    """
+    actions: list[dict] = []
+    owner_repo_cache: dict[str, tuple[str, str] | None] = {}
+
+    for issue in issues:
+        state = _state_name(issue)
+        if state.lower() not in _RECONCILE_STATES:
+            continue
+        task_id = str(issue["id"])
+        labels = _labels(issue)
+        repo_key = _repo_key_from_labels(labels)
+        if not repo_key:
+            continue
+
+        if repo_key not in owner_repo_cache:
+            cfg = settings.repos.get(repo_key)
+            try:
+                owner_repo_cache[repo_key] = (
+                    GitHubPRClient.owner_repo_from_clone_url(cfg.clone_url) if cfg else None
+                )
+            except Exception:
+                owner_repo_cache[repo_key] = None
+        owner_repo = owner_repo_cache[repo_key]
+        if not owner_repo:
+            continue
+        owner, repo = owner_repo
+
+        for head in _head_candidates(task_id, labels):
+            try:
+                pr = gh_client.find_pr_by_head(owner, repo, head)
+            except Exception:
+                pr = None
+            if pr and pr.get("merged_at"):
+                actions.append(
+                    {
+                        "task_id": task_id,
+                        "title": str(issue.get("name") or ""),
+                        "rule": "PR_MERGED_RECONCILE",
+                        "from_state": state,
+                        "to_state": "Done",
+                        "reason": (
+                            f"PR #{pr.get('number')} ({head}) merged at "
+                            f"{pr.get('merged_at')} — work landed; reconciling to Done"
+                        ),
+                    }
+                )
+                break  # one merged PR is enough
+
+    return actions
+
+
+def apply_board_actions(client: PlaneClient, actions: list[dict], *, apply: bool) -> list[dict]:
+    """Apply transition actions to Plane (or annotate as dry-run). Mirrors the
+    standalone CLI's apply loop so behaviour is identical in both call paths."""
+    results: list[dict] = []
+    for action in actions:
+        entry = dict(action)
+        if action.get("skipped"):
+            results.append(entry)
+            continue
+        if not apply:
+            entry["action"] = "would_apply"
+        else:
+            try:
+                client.transition_issue(action["task_id"], action["to_state"])
+                client.comment_issue(
+                    action["task_id"],
+                    f"Board unblock (autonomous): {action['rule']} — "
+                    f"{action['reason']}. "
+                    f"Transitioned {action['from_state']} → {action['to_state']}.",
+                )
+                entry["action"] = "applied"
+            except Exception as exc:  # noqa: BLE001 — one bad action must not abort the rest
+                entry["action"] = "error"
+                entry["error"] = str(exc)
+        results.append(entry)
+    return results
+
+
+class BoardUnblockTask:
+    """MaintenanceTask: reconcile merged-PR tasks + run the board-unblock rules."""
+
+    name = "board_unblock"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+        enabled: bool = True,
+        apply: bool = True,
+        stale_blocked_hours: int = 4,
+        stale_running_hours: int = 2,
+        clean_blocked_min_minutes: int = 5,
+        plane_client: PlaneClient | None = None,
+        gh_client: GitHubPRClient | None = None,
+    ) -> None:
+        self._settings = settings
+        self.interval_seconds = interval_seconds
+        self.enabled = enabled
+        self._apply = apply
+        self._stale_blocked_hours = stale_blocked_hours
+        self._stale_running_hours = stale_running_hours
+        self._clean_blocked_min_minutes = clean_blocked_min_minutes
+        self._plane_client = plane_client
+        self._gh_client = gh_client
+
+    def _make_plane_client(self) -> PlaneClient:
+        if self._plane_client is not None:
+            return self._plane_client
+        p = self._settings.plane
+        return PlaneClient(
+            base_url=p.base_url,
+            api_token=self._settings.plane_token(),
+            workspace_slug=p.workspace_slug,
+            project_id=p.project_id,
+        )
+
+    def _make_gh_client(self) -> GitHubPRClient | None:
+        if self._gh_client is not None:
+            return self._gh_client
+        token_env = getattr(getattr(self._settings, "git", None), "token_env", None) or "GITHUB_TOKEN"
+        token = os.environ.get(token_env)
+        return GitHubPRClient(token=token) if token else None
+
+    def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
+        started = time.monotonic()
+        details: dict[str, object] = {"apply": self._apply}
+
+        mem_gb = _mem_available_gb()
+        if mem_gb < _MEM_SKIP_THRESHOLD_GB:
+            return MaintenanceResult(
+                name=self.name,
+                status="skipped",
+                duration_seconds=time.monotonic() - started,
+                details={"reason": f"mem_available {mem_gb:.2f}GB < {_MEM_SKIP_THRESHOLD_GB}GB"},
+            )
+
+        client = ctx.resources.get("plane_client") or self._make_plane_client()
+        owns_client = "plane_client" not in ctx.resources and self._plane_client is None
+        try:
+            issues = client.list_issues()
+        except Exception as exc:  # noqa: BLE001
+            if owns_client:
+                client.close()
+            return MaintenanceResult(
+                name=self.name,
+                status="failed",
+                duration_seconds=time.monotonic() - started,
+                details=details,
+                error=f"plane_fetch_failed: {exc}",
+            )
+
+        now = datetime.now(UTC)
+
+        # 1) GitHub-aware reconciliation first — a merged PR wins over timeouts.
+        reconcile_actions: list[dict] = []
+        gh = self._make_gh_client()
+        if gh is not None:
+            reconcile_actions = reconcile_merged_pr_tasks(
+                issues, settings=self._settings, gh_client=gh
+            )
+        else:
+            details["gh_skipped"] = "no GitHub token available"
+
+        # Tasks reconciled to Done must not also be touched by the stale rules.
+        reconciled_ids = {a["task_id"] for a in reconcile_actions}
+
+        # 2) Existing Plane-only Rules 1–10.
+        rule_actions = [
+            a
+            for a in _apply_rules(
+                issues,
+                now=now,
+                stale_blocked_hours=self._stale_blocked_hours,
+                stale_running_hours=self._stale_running_hours,
+                clean_blocked_min_minutes=self._clean_blocked_min_minutes,
+                mem_available_gb=mem_gb,
+            )
+            if a.get("task_id") not in reconciled_ids
+        ]
+
+        results = apply_board_actions(client, reconcile_actions + rule_actions, apply=self._apply)
+        if owns_client:
+            client.close()
+
+        applied = [r for r in results if r.get("action") == "applied"]
+        details["scanned"] = len(issues)
+        details["reconciled_merged"] = len(reconcile_actions)
+        details["rule_actions"] = len(rule_actions)
+        details["applied"] = len(applied)
+        details["actions"] = results[:50]
+        return MaintenanceResult(
+            name=self.name,
+            status="ok",
+            duration_seconds=time.monotonic() - started,
+            details=details,
+        )
+
+
+__all__ = [
+    "DEFAULT_INTERVAL_SECONDS",
+    "BoardUnblockTask",
+    "apply_board_actions",
+    "reconcile_merged_pr_tasks",
+]

--- a/src/operations_center/entrypoints/spec_hygiene/main.py
+++ b/src/operations_center/entrypoints/spec_hygiene/main.py
@@ -35,6 +35,7 @@ from operations_center.maintenance import (
     MaintenanceRegistry,
     MaintenanceResult,
 )
+from operations_center.entrypoints.maintenance.board_unblock_task import BoardUnblockTask
 from operations_center.maintenance.ledger_maintain import LedgerMaintainTask
 from operations_center.spec_author.campaign_builder import CampaignBuilder
 from operations_center.spec_author.models import (
@@ -645,6 +646,28 @@ def _log_maintenance_result(result: MaintenanceResult) -> None:
     )
 
 
+def register_maintenance_tasks(
+    registry: MaintenanceRegistry, settings: Any, client: PlaneClient
+) -> MaintenanceRegistry:
+    """Register every maintenance task the live loop runs.
+
+    Extracted so the wiring is unit-testable (the standalone CLI and the
+    watchdog-side loop share it — ADR 0007 follow-up D). Order is informational;
+    the registry schedules by per-task interval.
+    """
+    registry.register(SpecHygieneTask(settings, client))
+    # Operator-interventions ledger consolidation loop (observe + self-verifying
+    # promote). Runs the controller's half of the ledger so a human only ever
+    # encodes a judgment once; recurrences self-verify. Best-effort by design.
+    registry.register(LedgerMaintainTask(settings))
+    # Autonomous board-unblock engine (Rules 1–10 + PR-merged reconciliation).
+    # Previously runnable only as a standalone CLI, so nothing ever investigated
+    # stuck/Blocked tasks; registering it here makes the controller self-heal the
+    # board every cycle with no human in the loop (HARNESS_TRUST_HARDENING §0.1).
+    registry.register(BoardUnblockTask(settings))
+    return registry
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="spec_hygiene — non-LLM spec/campaign hygiene watcher (ADR 0007)",
@@ -679,12 +702,7 @@ def main() -> None:
     # standalone CLI and the watchdog-side loop share the same wiring
     # (ADR 0007 follow-up D).
     registry = MaintenanceRegistry(state_path=args.maintenance_state)
-    task = SpecHygieneTask(settings, client)
-    registry.register(task)
-    # Operator-interventions ledger consolidation loop (observe + self-verifying
-    # promote). Runs the controller's half of the ledger so a human only ever
-    # encodes a judgment once; recurrences self-verify. Best-effort by design.
-    registry.register(LedgerMaintainTask(settings))
+    register_maintenance_tasks(registry, settings, client)
 
     def _build_ctx() -> MaintenanceContext:
         return MaintenanceContext(
@@ -696,10 +714,10 @@ def main() -> None:
     try:
         if args.once:
             # --once bypasses the interval gate so operators can force a
-            # single cycle on demand.
+            # single cycle of every registered maintenance task on demand.
             ctx = _build_ctx()
-            result = task.run_once(ctx)
-            _log_maintenance_result(result)
+            for registered in registry.list_tasks():
+                _log_maintenance_result(registered.run_once(ctx))
             return
         cycle = 0
         while True:

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_task.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_task.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for BoardUnblockTask + the PR-merged reconciliation.
+
+These pin both halves of the fix for the unwired board-unblock engine:
+  - reconcile_merged_pr_tasks turns a Blocked/In-Review task whose PR MERGED into
+    a Done transition (the #267/#341 fixture), and does NOT touch open/no-PR tasks.
+  - BoardUnblockTask satisfies the MaintenanceTask contract and applies actions
+    via an injected PlaneClient, so registering it in the live loop makes the
+    controller self-heal the board.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest import mock
+
+from operations_center.entrypoints.maintenance.board_unblock_task import (
+    BoardUnblockTask,
+    reconcile_merged_pr_tasks,
+)
+from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceTask
+
+
+def _issue(task_id, *, state, labels, updated_at="2026-06-19T04:00:00+00:00"):
+    return {
+        "id": task_id,
+        "name": f"Task {task_id}",
+        "state": {"name": state},
+        "labels": [{"name": label} for label in labels],
+        "updated_at": updated_at,
+    }
+
+
+def _settings():
+    repo = SimpleNamespace(clone_url="git@github.com:Velascat/OperationsCenter.git")
+    return SimpleNamespace(
+        repos={"OperationsCenter": repo},
+        plane=SimpleNamespace(
+            base_url="http://x", workspace_slug="w", project_id="p"
+        ),
+        git=SimpleNamespace(token_env="GITHUB_TOKEN"),
+        plane_token=lambda: "tok",
+    )
+
+
+_GOAL_LABELS = ["task-kind: goal", "repo: OperationsCenter"]
+
+
+class TestReconcileMergedPrTasks:
+    def test_blocked_task_with_merged_pr_reconciles_to_done(self):
+        """The #267/#341 case: Blocked task, its goal/<id8> PR merged → Done."""
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {
+            "number": 341,
+            "merged_at": "2026-06-19T06:27:17Z",
+        }
+        issue = _issue("0ccb698d-aaaa", state="Blocked", labels=_GOAL_LABELS)
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert len(actions) == 1
+        assert actions[0]["to_state"] == "Done"
+        assert actions[0]["rule"] == "PR_MERGED_RECONCILE"
+        # branch probed is goal/<task_id[:8]>
+        gh.find_pr_by_head.assert_any_call("Velascat", "OperationsCenter", "goal/0ccb698d")
+
+    def test_in_review_task_with_merged_pr_reconciles(self):
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {"number": 340, "merged_at": "2026-06-19T..."}
+        issue = _issue("fc9d7e10-bbbb", state="In Review", labels=_GOAL_LABELS)
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert [a["to_state"] for a in actions] == ["Done"]
+
+    def test_open_pr_is_not_reconciled(self):
+        """A not-yet-merged PR must stay with the reviewer — no Done action."""
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {"number": 999, "merged_at": None}
+        issue = _issue("abc12345", state="In Review", labels=_GOAL_LABELS)
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert actions == []
+
+    def test_no_pr_is_not_reconciled(self):
+        """Phantom completion (#268: In Review, no PR) is left for STALE_IN_REVIEW."""
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = None
+        issue = _issue("72fbc69c", state="In Review", labels=_GOAL_LABELS)
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert actions == []
+
+    def test_terminal_and_other_states_skipped(self):
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {"number": 1, "merged_at": "x"}
+        issues = [
+            _issue("d1", state="Done", labels=_GOAL_LABELS),
+            _issue("r1", state="Running", labels=_GOAL_LABELS),
+            _issue("b1", state="Backlog", labels=_GOAL_LABELS),
+        ]
+        actions = reconcile_merged_pr_tasks(issues, settings=_settings(), gh_client=gh)
+        assert actions == []
+        gh.find_pr_by_head.assert_not_called()
+
+    def test_task_without_repo_label_skipped(self):
+        gh = mock.Mock()
+        issue = _issue("x1", state="Blocked", labels=["task-kind: goal"])
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert actions == []
+        gh.find_pr_by_head.assert_not_called()
+
+    def test_lookup_error_is_swallowed(self):
+        gh = mock.Mock()
+        gh.find_pr_by_head.side_effect = RuntimeError("github down")
+        issue = _issue("e1", state="Blocked", labels=_GOAL_LABELS)
+        actions = reconcile_merged_pr_tasks([issue], settings=_settings(), gh_client=gh)
+        assert actions == []  # never raises
+
+
+class TestBoardUnblockTask:
+    def test_satisfies_maintenance_task_protocol(self):
+        task = BoardUnblockTask(_settings())
+        assert isinstance(task, MaintenanceTask)
+        assert task.name == "board_unblock"
+        assert task.interval_seconds > 0
+        assert task.enabled is True
+
+    def test_run_once_applies_merged_reconcile(self):
+        """End-to-end: a Blocked-but-merged task is transitioned to Done."""
+        plane = mock.Mock()
+        plane.list_issues.return_value = [
+            _issue("0ccb698d-aaaa", state="Blocked", labels=_GOAL_LABELS)
+        ]
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {"number": 341, "merged_at": "2026-06-19T06:27:17Z"}
+        task = BoardUnblockTask(_settings(), plane_client=plane, gh_client=gh, apply=True)
+
+        ctx = MaintenanceContext(cycle_id="c", now=datetime(2026, 6, 19, tzinfo=UTC))
+        result = task.run_once(ctx)
+
+        assert result.status == "ok"
+        assert result.details["reconciled_merged"] == 1
+        assert result.details["applied"] == 1
+        plane.transition_issue.assert_called_once_with("0ccb698d-aaaa", "Done")
+        plane.comment_issue.assert_called_once()
+        plane.close.assert_not_called()  # injected client is not owned
+
+    def test_run_once_dry_run_does_not_transition(self):
+        plane = mock.Mock()
+        plane.list_issues.return_value = [
+            _issue("0ccb698d-aaaa", state="Blocked", labels=_GOAL_LABELS)
+        ]
+        gh = mock.Mock()
+        gh.find_pr_by_head.return_value = {"number": 341, "merged_at": "x"}
+        task = BoardUnblockTask(_settings(), plane_client=plane, gh_client=gh, apply=False)
+        result = task.run_once(MaintenanceContext(cycle_id="c", now=datetime(2026, 6, 19, tzinfo=UTC)))
+        assert result.status == "ok"
+        plane.transition_issue.assert_not_called()
+
+    def test_run_once_plane_failure_is_reported(self):
+        plane = mock.Mock()
+        plane.list_issues.side_effect = RuntimeError("plane down")
+        task = BoardUnblockTask(_settings(), plane_client=plane, gh_client=mock.Mock())
+        result = task.run_once(MaintenanceContext(cycle_id="c", now=datetime(2026, 6, 19, tzinfo=UTC)))
+        assert result.status == "failed"
+        assert "plane down" in (result.error or "")
+
+
+class TestLiveLoopRegistration:
+    """The whole point of #268: board_unblock must be wired into the running
+    loop, not just exist as a CLI. This pins it so it can't silently un-register."""
+
+    def test_board_unblock_registered_in_live_loop(self):
+        from operations_center.entrypoints.spec_hygiene import main as sh
+
+        registry = mock.Mock()
+        registered: list[str] = []
+        registry.register.side_effect = lambda t: registered.append(t.name)
+
+        with (
+            mock.patch.object(sh, "SpecHygieneTask", lambda *a, **k: SimpleNamespace(name="spec_hygiene")),
+            mock.patch.object(sh, "LedgerMaintainTask", lambda *a, **k: SimpleNamespace(name="ledger_maintain")),
+            mock.patch.object(sh, "BoardUnblockTask", lambda *a, **k: SimpleNamespace(name="board_unblock")),
+        ):
+            sh.register_maintenance_tasks(registry, _settings(), mock.Mock())
+
+        assert "board_unblock" in registered
+        assert {"spec_hygiene", "ledger_maintain", "board_unblock"} <= set(registered)


### PR DESCRIPTION
## Summary
Closes board task #268. The autonomous board-unblock engine (`entrypoints/maintenance/board_unblock.py`, Rules 1–10) was complete and tested but **registered nowhere** — runnable only as a standalone CLI, zero runs ever — so the controller never investigated stuck/Blocked tasks. This is a D12-class incomplete integration: task #267 sat `Blocked` after its PR #341 had already merged, and an operator had to reconcile it by hand.

## Changes
- **`BoardUnblockTask`** (new `entrypoints/maintenance/board_unblock_task.py`) — a `MaintenanceTask` that runs the existing Rules 1–10 every cycle **plus** a GitHub-aware `reconcile_merged_pr_tasks`: a task in `In Review`/`Blocked` whose `<role>/<task_id[:8]>` PR actually **MERGED** is transitioned to `Done`. Runs first, so a merged PR wins over the stale-timeout heuristics and merged work is never re-queued.
- **Registered in the live loop** via `register_maintenance_tasks` in `spec_hygiene/main.py` (now hosts spec_hygiene + ledger + board_unblock).
- **`GitHubPRClient.find_pr_by_head`** — precise single-call PR lookup by head branch.

## Self-healing invariant
Honors HARNESS_TRUST_HARDENING.md §0.1 — the controller now self-heals the board (stuck/merged/orphaned tasks) with **no human in the per-correction loop**. Transient `backend_error`/`timeout` Blocked tasks with no merged PR still self-heal via the existing Rule 3 → Backlog → promotion path.

## Verification
12 new tests (reconcile cases + task contract + live-loop registration) + 316 related tests pass; ruff + ty clean; pre-push custodian audit 0 findings.