### PR TITLE
fix(tests): use sys.executable in doc-accuracy subprocess calls (unblocks the whole improve/goal pipeline)

### DIFF
--- a/tests/unit/test_documentation_accuracy.py
+++ b/tests/unit/test_documentation_accuracy.py
@@ -17,6 +17,7 @@ Tests ensure:
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -47,7 +48,7 @@ class TestDocumentationMarkers:
     def test_marker_configuration_in_pytest(self):
         """All markers are configured in pytest configuration."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "--markers"],
+            [sys.executable, "-m", "pytest", "--markers"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -220,7 +221,7 @@ class TestTestCommandExecutability:
     def test_pytest_help_executes(self):
         """Basic pytest help command executes successfully."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "--help"],
+            [sys.executable, "-m", "pytest", "--help"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -230,7 +231,7 @@ class TestTestCommandExecutability:
     def test_pytest_collect_only_succeeds(self):
         """pytest can collect tests without execution."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/unit", "--collect-only", "-q"],
+            [sys.executable, "-m", "pytest", "tests/unit", "--collect-only", "-q"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -241,7 +242,7 @@ class TestTestCommandExecutability:
     def test_pytest_dry_run_integration_tests(self):
         """pytest can collect integration tests."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/integration", "--collect-only", "-q"],
+            [sys.executable, "-m", "pytest", "tests/integration", "--collect-only", "-q"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -251,7 +252,7 @@ class TestTestCommandExecutability:
     def test_pytest_markers_filter_works(self):
         """Pytest marker filters work correctly."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/", "-m", "perf", "--collect-only", "-q"],
+            [sys.executable, "-m", "pytest", "tests/", "-m", "perf", "--collect-only", "-q"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -378,7 +379,7 @@ class TestTestCountValidation:
     def test_significant_number_of_unit_tests_exist(self):
         """A significant number of unit tests exist (documented as ~7,200)."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/unit", "--collect-only", "-q"],
+            [sys.executable, "-m", "pytest", "tests/unit", "--collect-only", "-q"],
             capture_output=True,
             text=True,
             timeout=60,
@@ -393,7 +394,7 @@ class TestTestCountValidation:
     def test_integration_tests_exist(self):
         """Integration tests exist in the project."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/integration", "--collect-only", "-q"],
+            [sys.executable, "-m", "pytest", "tests/integration", "--collect-only", "-q"],
             capture_output=True,
             text=True,
             timeout=60,


### PR DESCRIPTION
## Summary
Root-caused via the failure-diagnostics capture added in #345. **Every improve/goal task** was failing `N of N stages failed` because the executor's **baseline-validation gate** (`.venv/bin/pytest -q`, run on the fresh workspace clone) exited 1 — and the single failing test was `tests/unit/test_documentation_accuracy.py::test_marker_configuration_in_pytest`.

## Root cause
That test (and 6 siblings) shells out with **bare** `["python", "-m", "pytest", ...]`. In the workspace environment, `python` on PATH has **no pytest**, so stdout is empty → `assert 'integration' in ''`. CI passes only because there bare `python` *is* the pytest-equipped interpreter. That one failure exited pytest 1 → baseline validation failed → the executor refused to proceed on every task.

## Fix
`import sys` + replace all 7 bare-`python` subprocess calls with `sys.executable` (the interpreter actually running the test, which always has pytest).

## Verification
- The file: 48/48 pass (was 1 failing).
- **Full tree: 9377 passed / 0 failed** → baseline validation now passes, unblocking the pipeline.
- ruff/ty clean; pre-push audit 0 findings.

Must land in main (baseline validation clones main). Closes the recurring #264/#265 failures.