### PR TITLE
fix(board-worker): forward CL_ANCHOR to the executor (unblocks agent stages)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-19 — fix: forward CL_ANCHOR to the executor (ContextGuard refusal regression)
+
+With the baseline blocker fixed (#346), tasks reached the agent stages and revealed
+the NEXT layer (via the #345 diagnostics — planner stage surfaced it): "I'm unable
+to access the codebase because the ContextGuard requires `CL_ANCHOR` to be set …
+run `eval $(cl session start <manifest>)` first". OC's CLAUDE.md ContextGuard
+requires every Claude session targeting OC to be anchored; without CL_ANCHOR the
+agent returns a PROSE refusal instead of a JSON plan → planner stage fails → run
+dies. operations-center.sh deliberately sets CL_ANCHOR on the fleet, but
+`build_allowlist_env` (#340) STRIPPED it (not in `_ENV_PASSTHROUGH`) — re-breaking
+the #311 CL_ANCHOR unblock, same regression class as the #344 PATH bug. Fix: add
+`CL_ANCHOR`/`CL_HOME`/`CL_SESSION_ID` to the passthrough (only forwarded if present)
+so the executor agent stays anchored and cl_dispatch_wrap hydrate/capture isn't
+silently disabled. Verified: CL_ANCHOR forwarded; 13 env-allowlist tests pass.
+Deployed direct to the live checkout + restart.
+
 ## 2026-06-19 — goal/persist-exec-diagnostics Stage 2: Run test suite to verify no regressions ✅
 
 **STAGE 2 COMPLETE: All tests passing, integration verified**

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -102,6 +102,17 @@ _ENV_PASSTHROUGH = (
     "ANTHROPIC_BASE_URL",
     "OLLAMA_API_BASE",
     "OLLAMA_HOST",
+    # ContextLifecycle anchoring. OC's CLAUDE.md ContextGuard REQUIRES CL_ANCHOR:
+    # an agent dispatched into the OC clone without it returns a prose refusal
+    # ("CL_ANCHOR is not set… run `eval $(cl session start …)`") instead of a JSON
+    # plan, so the planner stage fails and the whole run dies. operations-center.sh
+    # deliberately sets CL_ANCHOR for the fleet; this forwards it (and the cl
+    # session context) to the executor subprocess so the agent stays anchored and
+    # cl_dispatch_wrap()'s hydrate/capture is not silently disabled. Dropping it was
+    # a Phase-0 over-minimization (regressed the #311 CL_ANCHOR unblock).
+    "CL_ANCHOR",
+    "CL_HOME",
+    "CL_SESSION_ID",
 )
 
 # Never forwarded, even if a caller adds them to `passthrough`. The worker provably

--- a/tests/unit/entrypoints/board_worker/test_env_allowlist.py
+++ b/tests/unit/entrypoints/board_worker/test_env_allowlist.py
@@ -136,6 +136,23 @@ class TestEnvAllowlistPreservesFunction:
             assert env["HOME"] == "/home/dev"
             assert env["XDG_CACHE_HOME"] == "/home/dev/.cache"
 
+    def test_preserves_cl_anchor(self, tmp_path: Path) -> None:
+        """CL_ANCHOR must survive: OC's ContextGuard refuses the agent (prose, not
+        JSON) without it, failing the planner stage and the whole run."""
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "CL_ANCHOR": "/home/dev/Documents/GitHub/PlatformManifest",
+                "CL_HOME": "/home/dev/Documents/GitHub/ContextLifecycle",
+                "CL_SESSION_ID": "sess-123",
+            },
+            clear=True,
+        ):
+            env = build_allowlist_env(tmp_path)
+            assert env["CL_ANCHOR"] == "/home/dev/Documents/GitHub/PlatformManifest"
+            assert env["CL_HOME"] == "/home/dev/Documents/GitHub/ContextLifecycle"
+            assert env["CL_SESSION_ID"] == "sess-123"
+
     def test_preserves_model_creds(self, tmp_path: Path) -> None:
         """Model access must survive or the worker cannot run/fix (self-healing)."""
         with mock.patch.dict(


### PR DESCRIPTION
## Summary
Next layer after #346. With baseline validation fixed, tasks reached the agent stages and the **#345 diagnostics** surfaced the real failure: the planner stage received a **prose refusal** instead of a JSON plan —
`I'm unable to access the codebase because the ContextGuard requires CL_ANCHOR to be set ... run eval $(cl session start <manifest>) first`.

## Root cause
OC's `CLAUDE.md` ContextGuard requires every Claude session targeting OC to be anchored. `operations-center.sh` deliberately sets `CL_ANCHOR` on the fleet, but `build_allowlist_env` (#340) **stripped it** (not in `_ENV_PASSTHROUGH`) — so the executor subprocess and the agent it spawns lost it → prose refusal → planner stage fails → run dies. Same regression class as the #344 PATH bug; re-broke the prior #311 CL_ANCHOR unblock.

## Fix
Add `CL_ANCHOR`/`CL_HOME`/`CL_SESSION_ID` to the passthrough (forwarded only when present), so the agent stays anchored and `cl_dispatch_wrap` hydrate/capture isn't silently disabled.

## Verification
CL_ANCHOR forwarded (verified live); 13 env-allowlist tests pass; ruff clean; pre-push audit 0 findings. Deployed directly to the live fleet.