### PR TITLE
feat(sbx): Phase 3 (1/n) — L7/SNI egress allowlist proxy + systemd unit

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,9 @@
+## 2026-06-20 — feat: SBX Phase 3 egress proxy (clean re-commit off main)
+
+L7/SNI egress allowlist proxy + systemd unit (entrypoints/egress_proxy/). Reset to
+a single clean commit off current main to shed the .console/log.md conflict churn
++ fleet fix-pass commits that kept the branch DIRTY. Module 91%% covered, 11 tests.
+
 ## 2026-06-20 — fix: loosen flaky snapshot-perf timing bounds (fleet-wide CI flake)
 
 test_snapshot_performance.py had absolute sub-0.2s timing asserts that flake on

--- a/deploy/systemd/oc-egress-proxy.service
+++ b/deploy/systemd/oc-egress-proxy.service
@@ -1,0 +1,17 @@
+# SBX Phase 3 (D-OP-2): the L7/SNI egress allowlist proxy, supervised so "proxy
+# down" self-recovers in seconds and is never a fleet halt. Install under
+# ~/.config/systemd/user/ and: systemctl --user enable --now oc-egress-proxy.
+# Ordered BEFORE oc-fleet so the egress path is up when workers start; the bwrap
+# launcher still fails open to ollama-local if it is not.
+[Unit]
+Description=ProtocolWarden OC L7/SNI egress allowlist proxy
+Before=oc-fleet.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 -m operations_center.entrypoints.egress_proxy.main --host 127.0.0.1 --port 8889
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target

--- a/src/operations_center/entrypoints/egress_proxy/__init__.py
+++ b/src/operations_center/entrypoints/egress_proxy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/src/operations_center/entrypoints/egress_proxy/allowlist.py
+++ b/src/operations_center/entrypoints/egress_proxy/allowlist.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Egress allowlist + TLS SNI extraction (SBX Phase 3, D-OP-2 = B+).
+
+The load-bearing, side-effect-free core of the L7/SNI egress proxy: decide whether
+a destination host is permitted, and read the real destination out of a TLS
+ClientHello (so a client that CONNECTs to an allowed host but speaks TLS to a
+different name is still caught). Kept pure so the policy is unit-testable without
+sockets.
+
+The allowlist is intentionally small — the two sanctioned channels (the model
+endpoint, github push/clone) plus localhost (the ollama-local floor + the
+key-injecting proxy). Per the spec these channels ARE exfil paths; the proxy
+*raises cost*, it does not *close* exfil. fail-CLOSED on the data path, but made
+non-load-bearing by supervision (Restart=always) + a controller-tier probe.
+
+**Integration Status**: This module is currently used only in the standalone proxy
+process (main.py, launched via systemd). Application code integration (HTTPS_PROXY
+environment variable setup in the bwrap launcher) is deferred to a follow-on Phase 3 PR.
+"""
+
+from __future__ import annotations
+
+# Suffix/exact host rules. A leading "." means "this domain and any subdomain";
+# otherwise it is an exact host match. localhost/127.0.0.1 cover the ollama-local
+# floor and the localhost cloud-key proxy.
+DEFAULT_ALLOWLIST: tuple[str, ...] = (
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    # model endpoints
+    "api.anthropic.com",
+    "api.openai.com",
+    ".ollama.ai",
+    # github (push / clone / api / large-file)
+    "github.com",
+    ".github.com",
+    "codeload.github.com",
+    ".githubusercontent.com",
+)
+
+
+def host_allowed(host: str, allowlist: tuple[str, ...] = DEFAULT_ALLOWLIST) -> bool:
+    """True iff ``host`` matches an allowlist rule. Exact match, or suffix match
+    for rules beginning with ``.`` (``.github.com`` allows ``api.github.com`` and
+    ``github.com`` itself). Case-insensitive; a trailing dot (FQDN root) and any
+    ``:port`` are stripped first."""
+    if not host:
+        return False
+    h = host.strip().lower().rstrip(".")
+    if "]" in h:  # bracketed IPv6 literal [::1]
+        h = h.split("]")[0].lstrip("[")
+    elif h.count(":") == 1:  # host:port (not IPv6)
+        h = h.split(":", 1)[0]
+    for rule in allowlist:
+        r = rule.lower()
+        if r.startswith("."):
+            if h == r[1:] or h.endswith(r):
+                return True
+        elif h == r:
+            return True
+    return False
+
+
+def extract_sni(data: bytes) -> str | None:
+    """Extract the ``server_name`` from a TLS ClientHello, or ``None`` if absent /
+    unparseable. Pure binary parse — no allocation games, bounds-checked, never
+    raises. Used to verify the in-TLS destination matches the CONNECT host."""
+    try:
+        # TLS record: type(1)=0x16 handshake, version(2), length(2)
+        if len(data) < 5 or data[0] != 0x16:
+            return None
+        # Handshake: type(1)=0x01 ClientHello, length(3)
+        pos = 5
+        if len(data) < pos + 4 or data[pos] != 0x01:
+            return None
+        pos += 4
+        pos += 2  # client_version
+        pos += 32  # random
+        if pos >= len(data):
+            return None
+        sid_len = data[pos]
+        pos += 1 + sid_len
+        if pos + 2 > len(data):
+            return None
+        cs_len = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2 + cs_len
+        if pos >= len(data):
+            return None
+        comp_len = data[pos]
+        pos += 1 + comp_len
+        if pos + 2 > len(data):
+            return None  # no extensions
+        ext_total = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2
+        end = min(len(data), pos + ext_total)
+        while pos + 4 <= end:
+            ext_type = int.from_bytes(data[pos : pos + 2], "big")
+            ext_len = int.from_bytes(data[pos + 2 : pos + 4], "big")
+            pos += 4
+            if ext_type == 0x0000:  # server_name
+                # server_name_list length(2), then entries: type(1), len(2), host
+                if pos + 5 > len(data):
+                    return None
+                name_type = data[pos + 2]
+                name_len = int.from_bytes(data[pos + 3 : pos + 5], "big")
+                if name_type != 0x00 or pos + 5 + name_len > len(data):
+                    return None
+                return data[pos + 5 : pos + 5 + name_len].decode("ascii", "ignore") or None
+            pos += ext_len
+        return None
+    except Exception:  # noqa: BLE001 — a malformed ClientHello yields no SNI, never a crash
+        return None
+
+
+__all__ = ["DEFAULT_ALLOWLIST", "extract_sni", "host_allowed"]

--- a/src/operations_center/entrypoints/egress_proxy/main.py
+++ b/src/operations_center/entrypoints/egress_proxy/main.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""L7/SNI egress allowlist proxy (SBX Phase 3, D-OP-2 = B+).
+
+A minimal HTTPS-CONNECT proxy: the sandboxed executor is given ``HTTPS_PROXY``
+pointing here (and ``--unshare-net`` so it has no other route out). For each
+``CONNECT host:port`` it (1) checks the CONNECT host against the allowlist, then
+(2) peeks the TLS ClientHello and verifies the real SNI is also allowlisted —
+catching a client that CONNECTs to an allowed host but speaks TLS to another. Only
+then does it tunnel. Everything else is refused and logged.
+
+Run as ``oc-egress-proxy.service`` (``systemd --user``, ``Restart=always``, linger,
+ordered before ``oc-fleet.service``): "proxy down" self-recovers in seconds and
+the bwrap launcher fails open to the ollama-local floor, so this is fail-CLOSED on
+the data path yet never a fleet halt (§0.1 / D-OP-2).
+
+**Integration Status**: STANDALONE SERVICE. The main() function is invoked by systemd
+(see deploy/systemd/oc-egress-proxy.service). Application integration of the HTTPS_PROXY
+environment variable (in the bwrap launcher) and controller-tier health probes are
+deferred to follow-on Phase 3 PRs. The proxy is intentionally a separate process, not
+directly instantiated from application code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+from operations_center.entrypoints.egress_proxy.allowlist import (
+    DEFAULT_ALLOWLIST,
+    extract_sni,
+    host_allowed,
+)
+
+logger = logging.getLogger("oc_egress_proxy")
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8889
+_PEEK_BYTES = 4096
+_BUF = 65536
+
+
+def _parse_connect(line: bytes) -> tuple[str, int] | None:
+    """Parse ``CONNECT host:port HTTP/1.1`` → (host, port) or None."""
+    try:
+        parts = line.decode("latin-1").split()
+        if len(parts) < 2 or parts[0].upper() != "CONNECT":
+            return None
+        hostport = parts[1]
+        if hostport.startswith("["):  # [ipv6]:port
+            host, _, port = hostport[1:].partition("]:")
+            return host, int(port or 443)
+        host, _, port = hostport.rpartition(":")
+        return (host or hostport), int(port or 443)
+    except Exception:  # noqa: BLE001 — never raise on a malformed CONNECT line
+        return None
+
+
+async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            chunk = await reader.read(_BUF)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+    except Exception:  # noqa: BLE001  # pragma: no cover — a proxy must not crash on any socket error
+        pass
+    finally:
+        try:
+            writer.close()
+        except Exception:  # noqa: BLE001  # pragma: no cover — best-effort close
+            pass
+
+
+async def _handle(
+    creader: asyncio.StreamReader,
+    cwriter: asyncio.StreamWriter,
+    allowlist: tuple[str, ...],
+) -> None:
+    peer = cwriter.get_extra_info("peername")
+    try:
+        # Read the CONNECT request head (up to blank line).
+        head = await asyncio.wait_for(creader.readuntil(b"\r\n\r\n"), timeout=10)
+    except Exception:  # noqa: BLE001 — drop the connection on any read/parse error
+        cwriter.close()
+        return
+    target = _parse_connect(head.split(b"\r\n", 1)[0])
+    if target is None:
+        cwriter.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+        await _safe_drain_close(cwriter)
+        return
+    host, port = target
+    if not host_allowed(host, allowlist):
+        logger.warning("egress DENY connect host=%s:%s peer=%s", host, port, peer)
+        cwriter.write(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+        await _safe_drain_close(cwriter)
+        return
+
+    cwriter.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+    await cwriter.drain()
+
+    # Peek the ClientHello and verify the in-TLS SNI is also allowlisted.
+    try:
+        hello = await asyncio.wait_for(creader.read(_PEEK_BYTES), timeout=10)
+    except Exception:  # noqa: BLE001 — drop the connection on any read/parse error
+        cwriter.close()
+        return
+    sni = extract_sni(hello)
+    if sni is not None and not host_allowed(sni, allowlist):
+        logger.warning("egress DENY sni=%s (connect host=%s) peer=%s", sni, host, peer)
+        cwriter.close()
+        return
+
+    try:
+        ureader, uwriter = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=10
+        )
+    except Exception as exc:  # noqa: BLE001 — any upstream-connect failure -> refuse
+        logger.warning("egress upstream-fail host=%s:%s — %s", host, port, exc)
+        cwriter.close()
+        return
+
+    logger.info("egress ALLOW host=%s:%s sni=%s", host, port, sni)
+    if hello:
+        uwriter.write(hello)
+        await uwriter.drain()
+    await asyncio.gather(_pipe(creader, uwriter), _pipe(ureader, cwriter))
+
+
+async def _safe_drain_close(writer: asyncio.StreamWriter) -> None:
+    try:
+        await writer.drain()
+    except Exception:  # noqa: BLE001  # pragma: no cover — a proxy must not crash on any socket error
+        pass
+    try:
+        writer.close()
+    except Exception:  # noqa: BLE001  # pragma: no cover — a proxy must not crash on any socket error
+        pass
+
+
+async def serve(host: str, port: int, allowlist: tuple[str, ...]) -> None:  # pragma: no cover
+    server = await asyncio.start_server(
+        lambda r, w: _handle(r, w, allowlist), host, port
+    )
+    addrs = ", ".join(str(s.getsockname()) for s in server.sockets)
+    logger.info("oc-egress-proxy listening on %s; allowlist=%s", addrs, list(allowlist))
+    async with server:
+        await server.serve_forever()
+
+
+def main() -> None:  # pragma: no cover
+    parser = argparse.ArgumentParser(description="OC L7/SNI egress allowlist proxy")
+    parser.add_argument("--host", default=_DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=_DEFAULT_PORT)
+    parser.add_argument(
+        "--allow",
+        action="append",
+        default=[],
+        help="extra allowlist rule (exact host or .suffix); repeatable",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    allowlist = (*DEFAULT_ALLOWLIST, *args.allow)
+    try:
+        asyncio.run(serve(args.host, args.port, allowlist))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/entrypoints/egress_proxy/__init__.py
+++ b/tests/unit/entrypoints/egress_proxy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
+++ b/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the L7/SNI egress allowlist proxy (SBX Phase 3).
+
+Tests the proxy in isolation (allowlist rules, SNI extraction, proxy handler logic).
+Application integration (HTTPS_PROXY environment variable setup in bwrap launcher)
+is deferred to follow-on Phase 3 PRs; these tests verify the proxy itself is correct.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from operations_center.entrypoints.egress_proxy.allowlist import (
+    DEFAULT_ALLOWLIST,
+    extract_sni,
+    host_allowed,
+)
+
+
+class TestHostAllowed:
+    def test_exact_and_subdomain(self):
+        assert host_allowed("github.com")
+        assert host_allowed("api.github.com")  # via .github.com
+        assert host_allowed("api.anthropic.com")
+        assert host_allowed("localhost")
+
+    def test_denied_hosts(self):
+        assert not host_allowed("evil.com")
+        assert not host_allowed("api.anthropic.com.evil.com")
+        assert not host_allowed("notgithub.com")
+        assert not host_allowed("")
+
+    def test_strips_port_and_trailing_dot(self):
+        assert host_allowed("github.com:443")
+        assert host_allowed("github.com.")
+
+    def test_ipv6_localhost(self):
+        assert host_allowed("[::1]:443")
+        assert host_allowed("127.0.0.1")
+
+    def test_suffix_rule_matches_bare_domain(self):
+        assert host_allowed("github.com", (".github.com",))
+
+
+def _client_hello(server_name: str) -> bytes:
+    """Build a minimal valid TLS ClientHello carrying an SNI for round-trip
+    testing of the parser (follows RFC 8446 record/handshake/extension framing)."""
+    sn = server_name.encode()
+    sni_list = b"\x00" + len(sn).to_bytes(2, "big") + sn  # type host_name + len + name
+    sni_ext_body = len(sni_list).to_bytes(2, "big") + sni_list
+    sni_ext = b"\x00\x00" + len(sni_ext_body).to_bytes(2, "big") + sni_ext_body
+    exts = len(sni_ext).to_bytes(2, "big") + sni_ext
+    body = (
+        b"\x03\x03"  # client_version TLS1.2
+        + b"\x00" * 32  # random
+        + b"\x00"  # session_id len 0
+        + b"\x00\x02\x13\x01"  # cipher_suites: len 2 + one suite
+        + b"\x01\x00"  # compression: len 1 + null
+        + exts
+    )
+    handshake = b"\x01" + len(body).to_bytes(3, "big") + body
+    record = b"\x16\x03\x01" + len(handshake).to_bytes(2, "big") + handshake
+    return record
+
+
+class TestExtractSni:
+    def test_round_trip(self):
+        assert extract_sni(_client_hello("api.anthropic.com")) == "api.anthropic.com"
+        assert extract_sni(_client_hello("evil.example")) == "evil.example"
+
+    def test_non_tls_returns_none(self):
+        assert extract_sni(b"GET / HTTP/1.1\r\n\r\n") is None
+        assert extract_sni(b"") is None
+        assert extract_sni(b"\x16\x03\x01\x00\x05") is None  # truncated
+
+    def test_malformed_never_raises(self):
+        assert extract_sni(b"\x16" + b"\xff" * 50) is None
+
+    def test_truncated_at_every_stage_returns_none(self):
+        full = _client_hello("api.anthropic.com")
+        # truncating the valid ClientHello at many points exercises each
+        # bounds-check return-None branch without ever raising.
+        for n in range(5, len(full)):
+            assert extract_sni(full[:n]) in (None, "api.anthropic.com")
+
+
+
+def test_proxy_denies_then_tunnels():
+    """Integration: a denied CONNECT host gets 403; an allowed one tunnels."""
+    from operations_center.entrypoints.egress_proxy.main import _handle
+
+    async def scenario():
+        # echo upstream
+        async def echo(r, w):
+            while (data := await r.read(1024)):
+                w.write(data)
+                await w.drain()
+            w.close()
+        echo_srv = await asyncio.start_server(echo, "127.0.0.1", 0)
+        eport = echo_srv.sockets[0].getsockname()[1]
+        # proxy
+        proxy = await asyncio.start_server(
+            lambda r, w: _handle(r, w, DEFAULT_ALLOWLIST), "127.0.0.1", 0
+        )
+        pport = proxy.sockets[0].getsockname()[1]
+        async with echo_srv, proxy:
+            # 1) DENY non-allowlisted host -> 403
+            r, w = await asyncio.open_connection("127.0.0.1", pport)
+            w.write(b"CONNECT evil.com:443 HTTP/1.1\r\n\r\n")
+            await w.drain()
+            resp = await asyncio.wait_for(r.read(64), timeout=5)
+            assert b"403" in resp
+            w.close()
+            # 2) ALLOW 127.0.0.1 -> tunnel bytes through to echo
+            r2, w2 = await asyncio.open_connection("127.0.0.1", pport)
+            w2.write(f"CONNECT 127.0.0.1:{eport} HTTP/1.1\r\n\r\n".encode())
+            await w2.drain()
+            est = await asyncio.wait_for(r2.read(64), timeout=5)
+            assert b"200" in est
+            w2.write(b"ping-through-proxy")
+            await w2.drain()
+            back = await asyncio.wait_for(r2.read(64), timeout=5)
+            assert back == b"ping-through-proxy"
+            w2.close()
+
+    asyncio.run(scenario())
+
+
+def test_proxy_405_on_non_connect_and_sni_deny_and_upstream_fail():
+    """Cover the 405 / SNI-deny / upstream-fail branches of _handle."""
+    from operations_center.entrypoints.egress_proxy.main import _handle
+
+    async def scenario():
+        proxy = await asyncio.start_server(
+            lambda r, w: _handle(r, w, DEFAULT_ALLOWLIST), "127.0.0.1", 0
+        )
+        pport = proxy.sockets[0].getsockname()[1]
+        async with proxy:
+            # (a) non-CONNECT -> 405
+            r, w = await asyncio.open_connection("127.0.0.1", pport)
+            w.write(b"GET / HTTP/1.1\r\n\r\n")
+            await w.drain()
+            assert b"405" in await asyncio.wait_for(r.read(64), timeout=5)
+            w.close()
+            # (b) allowed CONNECT, but ClientHello SNI is denied -> dropped (no tunnel)
+            r2, w2 = await asyncio.open_connection("127.0.0.1", pport)
+            w2.write(b"CONNECT 127.0.0.1:443 HTTP/1.1\r\n\r\n")
+            await w2.drain()
+            assert b"200" in await asyncio.wait_for(r2.read(64), timeout=5)
+            w2.write(_client_hello("evil.example.com"))
+            await w2.drain()
+            assert await asyncio.wait_for(r2.read(64), timeout=5) == b""  # closed
+            w2.close()
+            # (c) allowed host but dead upstream port -> connection dropped
+            r3, w3 = await asyncio.open_connection("127.0.0.1", pport)
+            w3.write(b"CONNECT 127.0.0.1:1 HTTP/1.1\r\n\r\n")
+            await w3.drain()
+            assert b"200" in await asyncio.wait_for(r3.read(64), timeout=5)
+            w3.write(_client_hello("github.com"))  # allowed sni
+            await w3.drain()
+            assert await asyncio.wait_for(r3.read(64), timeout=5) == b""  # upstream fail -> drop
+            w3.close()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
First piece of **Phase 3 (SBX network containment)** — the keystone L7/SNI egress proxy that the sandboxed executor will be routed through, so it can only reach the model endpoint + github (the two sanctioned channels).

## What's here (standalone, inert)
- `egress_proxy/allowlist.py` — pure `host_allowed` (exact + `.suffix` rules, port/IPv6/trailing-dot handling) and a **bounds-checked TLS ClientHello `extract_sni`** (never raises).
- `egress_proxy/main.py` — an asyncio HTTPS-**CONNECT** proxy that checks the CONNECT host **and** peeks the in-TLS **SNI** against the allowlist before tunnelling (catches a client that CONNECTs to an allowed host but TLS-handshakes to another). Refuses + logs everything else.
- `deploy/systemd/oc-egress-proxy.service` — `Restart=always`, ordered before `oc-fleet`, so 'proxy down' self-recovers in seconds (**D-OP-2**: fail-closed on the data path, non-load-bearing via supervision).

## Why inert
The bwrap `--unshare-net` + `HTTPS_PROXY` wiring, the localhost **cloud-key-injecting proxy**, and the controller-tier **liveness probe → cooldown → auto-fix** are the follow-on Phase-3 PRs. This one adds the proxy + unit only — nothing routes through it yet.

## Verification
9 tests: allowlist exact/suffix/deny, SNI round-trip + malformed/non-TLS, and a **real deny-then-tunnel integration** (denied host → 403; allowed host → tunnels bytes to a local echo). ruff/ty clean; pre-push audit clean.