### PR TITLE
feat(sbx): Phase 3 (2/n) — localhost cloud-key-injecting proxy (D-OP-1)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,15 @@
+## 2026-06-20 — feat: SBX Phase 3 (2/n) — localhost cloud-key-injecting proxy (D-OP-1)
+
+New `entrypoints/key_proxy/`: `injector.py` (pure `inject_auth` — Anthropic
+x-api-key / OpenAI Bearer; strips any client-supplied auth + hop-by-hop headers)
+and `main.py` (asyncio reverse proxy streaming via httpx). The sandboxed agent
+points its model base URL at this loopback proxy and carries NO key; the host-held
+key is injected here, so the cloud key never enters the sandbox env. Standalone/
+inert; fails open to ollama-local (D-OP-1). 7 tests incl an end-to-end (host-only
+key reaches a mock upstream; sandbox-side request carried none; response streams
+back). ruff/ty clean. Remaining Phase-3: bwrap --unshare-net + proxy env wiring,
+controller-tier liveness probe -> cooldown.
+
 ## 2026-06-20 — fix: SPDX header on new pr_review_watcher test package init (License headers gate)
 
 The new tests/unit/entrypoints/pr_review_watcher/__init__.py was created empty —

--- a/src/operations_center/entrypoints/key_proxy/__init__.py
+++ b/src/operations_center/entrypoints/key_proxy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/src/operations_center/entrypoints/key_proxy/injector.py
+++ b/src/operations_center/entrypoints/key_proxy/injector.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Cloud-key injection policy (SBX Phase 3, D-OP-1 = HYBRID).
+
+Pure, side-effect-free core of the localhost key-injecting proxy: given a provider
+and the per-request client headers, produce the upstream headers with the API key
+injected — so the key lives ONLY on the host (in the proxy) and is **absent from
+the sandbox env**. The sandbox points e.g. ``ANTHROPIC_BASE_URL`` at the loopback
+proxy and carries no key; this module decides which auth header to set per
+provider and strips any client-supplied auth (the sandbox must not be able to
+smuggle its own).
+
+Kept separate so the policy is unit-testable without sockets. The fleet never
+halts on the key proxy: the bwrap launcher fails open to the ollama-local floor,
+and a dead proxy presents as a worker_backend cooldown (D-OP-1).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# provider → (upstream base URL, auth header name, value template).
+PROVIDERS: dict[str, tuple[str, str, str]] = {
+    "anthropic": ("https://api.anthropic.com", "x-api-key", "{key}"),
+    "openai": ("https://api.openai.com", "authorization", "Bearer {key}"),
+}
+
+# Client headers that must never be forwarded as-is — the host re-establishes auth,
+# and hop-by-hop headers don't survive a proxy hop.
+_STRIP = frozenset(
+    {
+        "authorization",
+        "x-api-key",
+        "host",
+        "proxy-connection",
+        "connection",
+        "keep-alive",
+        "transfer-encoding",
+        "te",
+        "trailer",
+        "upgrade",
+    }
+)
+
+
+def upstream_base(provider: str) -> str:
+    """The real endpoint for ``provider``. Raises KeyError on unknown provider."""
+    return PROVIDERS[provider][0]
+
+
+def inject_auth(
+    client_headers: Mapping[str, str],
+    *,
+    provider: str,
+    key: str,
+) -> dict[str, str]:
+    """Return upstream headers: the client's headers minus any auth/hop-by-hop
+    ones, plus the provider's auth header carrying the host-held ``key``.
+
+    The injected key NEVER came from the client (sandbox) — it is supplied by the
+    host proxy. A client that tries to send its own ``authorization``/``x-api-key``
+    has it stripped, then overwritten.
+    """
+    if provider not in PROVIDERS:
+        raise KeyError(f"unknown provider {provider!r}")
+    _, header_name, template = PROVIDERS[provider]
+    out: dict[str, str] = {}
+    for name, value in client_headers.items():
+        if name.lower() in _STRIP:
+            continue
+        out[name] = value
+    out[header_name] = template.format(key=key)
+    return out
+
+
+__all__ = ["PROVIDERS", "inject_auth", "upstream_base"]

--- a/src/operations_center/entrypoints/key_proxy/main.py
+++ b/src/operations_center/entrypoints/key_proxy/main.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Localhost cloud-key-injecting reverse proxy (SBX Phase 3, D-OP-1 = HYBRID).
+
+The sandboxed agent points its model base URL at this loopback proxy and carries
+**no API key**. The proxy injects the host-held key (``inject_auth``) and streams
+the request through to the real endpoint, streaming the response back — so the
+cloud key never enters the sandbox env. Plain HTTP on loopback is fine (the hop is
+127.0.0.1); the upstream leg is HTTPS via httpx.
+
+Supervised like the egress proxy; the fleet fails open to ollama-local if it's
+down (D-OP-1), so this is never a halt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+
+import httpx
+
+from operations_center.entrypoints.key_proxy.injector import (
+    PROVIDERS,
+    inject_auth,
+    upstream_base,
+)
+
+logger = logging.getLogger("oc_key_proxy")
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8890
+_HOP = b"\r\n\r\n"
+
+
+async def _read_request(reader: asyncio.StreamReader) -> tuple[str, str, dict[str, str], bytes] | None:
+    """Read an HTTP/1.1 request → (method, path, headers, body) or None."""
+    try:
+        head = await asyncio.wait_for(reader.readuntil(_HOP), timeout=30)
+    except Exception:  # noqa: BLE001 — malformed / closed client: drop
+        return None
+    try:
+        lines = head.split(b"\r\n")
+        method, path, _ = lines[0].decode("latin-1").split(" ", 2)
+        headers: dict[str, str] = {}
+        for raw in lines[1:]:
+            if not raw or b":" not in raw:
+                continue
+            k, _, v = raw.decode("latin-1").partition(":")
+            headers[k.strip()] = v.strip()
+        body = b""
+        clen = int(headers.get("Content-Length", "0") or "0")
+        if clen > 0:
+            body = await asyncio.wait_for(reader.readexactly(clen), timeout=60)
+        return method, path, headers, body
+    except Exception:  # noqa: BLE001 — any parse error: drop
+        return None
+
+
+async def _handle(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    provider: str,
+    key: str,
+    client: httpx.AsyncClient,
+) -> None:
+    req = await _read_request(reader)
+    if req is None:
+        _close(writer)
+        return
+    method, path, headers, body = req
+    url = upstream_base(provider) + path
+    up_headers = inject_auth(headers, provider=provider, key=key)
+    try:
+        async with client.stream(method, url, headers=up_headers, content=body) as resp:
+            line = f"HTTP/1.1 {resp.status_code} {resp.reason_phrase}\r\n".encode("latin-1")
+            writer.write(line)
+            for k, v in resp.headers.items():
+                if k.lower() in ("transfer-encoding", "connection"):
+                    continue
+                writer.write(f"{k}: {v}\r\n".encode("latin-1"))
+            writer.write(b"\r\n")
+            await writer.drain()
+            async for chunk in resp.aiter_raw():
+                writer.write(chunk)
+                await writer.drain()
+    except Exception as exc:  # noqa: BLE001 — upstream failure: 502, never crash
+        logger.warning("key-proxy upstream-fail provider=%s — %s", provider, exc)
+        try:
+            writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            await writer.drain()
+        except Exception:  # noqa: BLE001
+            pass
+    _close(writer)
+
+
+def _close(writer: asyncio.StreamWriter) -> None:
+    try:
+        writer.close()
+    except Exception:  # noqa: BLE001 — best-effort teardown
+        pass
+
+
+async def serve(host: str, port: int, *, provider: str, key: str) -> None:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(600.0), http2=False) as client:
+        server = await asyncio.start_server(
+            lambda r, w: _handle(r, w, provider=provider, key=key, client=client),
+            host,
+            port,
+        )
+        addrs = ", ".join(str(s.getsockname()) for s in server.sockets)
+        logger.info("oc-key-proxy provider=%s listening on %s", provider, addrs)
+        async with server:
+            await server.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OC localhost cloud-key-injecting proxy")
+    parser.add_argument("--host", default=_DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=_DEFAULT_PORT)
+    parser.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    parser.add_argument(
+        "--key-env",
+        required=True,
+        help="env var (on the HOST, not the sandbox) holding the API key",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    key = os.environ.get(args.key_env)
+    if not key:
+        raise SystemExit(f"key env {args.key_env!r} is empty — refusing to start keyless")
+    asyncio.run(serve(args.host, args.port, provider=args.provider, key=key))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/entrypoints/key_proxy/__init__.py
+++ b/tests/unit/entrypoints/key_proxy/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tests/unit/entrypoints/key_proxy/test_key_proxy.py
+++ b/tests/unit/entrypoints/key_proxy/test_key_proxy.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the localhost cloud-key-injecting proxy (SBX Phase 3, D-OP-1)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from operations_center.entrypoints.key_proxy import main as kp
+from operations_center.entrypoints.key_proxy.injector import inject_auth, upstream_base
+
+
+class TestInjectAuth:
+    def test_anthropic_uses_x_api_key(self):
+        out = inject_auth({"content-type": "application/json"}, provider="anthropic", key="sk-ant")
+        assert out["x-api-key"] == "sk-ant"
+        assert out["content-type"] == "application/json"
+        assert "authorization" not in {k.lower() for k in out}
+
+    def test_openai_uses_bearer(self):
+        out = inject_auth({}, provider="openai", key="sk-oai")
+        assert out["authorization"] == "Bearer sk-oai"
+
+    def test_strips_client_supplied_auth(self):
+        # the sandbox must not smuggle its own key; it is stripped then overwritten
+        out = inject_auth(
+            {"authorization": "Bearer ATTACKER", "x-api-key": "ATTACKER", "host": "evil"},
+            provider="anthropic",
+            key="real-key",
+        )
+        assert out["x-api-key"] == "real-key"
+        assert "ATTACKER" not in str(out)
+        assert "host" not in {k.lower() for k in out}
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(KeyError):
+            inject_auth({}, provider="nope", key="k")
+
+    def test_upstream_base(self):
+        assert upstream_base("anthropic") == "https://api.anthropic.com"
+        assert upstream_base("openai") == "https://api.openai.com"
+
+
+def test_read_request_parses_method_path_headers_body():
+    async def run():
+        reader = asyncio.StreamReader()
+        reader.feed_data(
+            b"POST /v1/messages HTTP/1.1\r\nContent-Length: 5\r\nX-Foo: bar\r\n\r\nhello"
+        )
+        reader.feed_eof()
+        return await kp._read_request(reader)
+
+    method, path, headers, body = asyncio.run(run())
+    assert method == "POST"
+    assert path == "/v1/messages"
+    assert headers["X-Foo"] == "bar"
+    assert body == b"hello"
+
+
+def test_proxy_injects_key_and_forwards_to_upstream():
+    """End-to-end: the proxy forwards to a mock upstream WITH the injected key,
+    and the sandbox-side request carried none."""
+
+    async def scenario():
+        seen = {}
+
+        async def upstream(reader, writer):
+            head = await reader.readuntil(b"\r\n\r\n")
+            for ln in head.split(b"\r\n"):
+                if b":" in ln:
+                    k, _, v = ln.decode().partition(":")
+                    seen[k.strip().lower()] = v.strip()
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+            await writer.drain()
+            writer.close()
+
+        up_srv = await asyncio.start_server(upstream, "127.0.0.1", 0)
+        uport = up_srv.sockets[0].getsockname()[1]
+
+        with mock.patch.object(kp, "upstream_base", lambda p: f"http://127.0.0.1:{uport}"):
+            import httpx
+
+            async with httpx.AsyncClient() as client:
+                proxy = await asyncio.start_server(
+                    lambda r, w: kp._handle(
+                        r, w, provider="anthropic", key="HOST-ONLY-KEY", client=client
+                    ),
+                    "127.0.0.1",
+                    0,
+                )
+                pport = proxy.sockets[0].getsockname()[1]
+                async with up_srv, proxy:
+                    r, w = await asyncio.open_connection("127.0.0.1", pport)
+                    # sandbox-side request carries NO key
+                    w.write(b"POST /v1/messages HTTP/1.1\r\nContent-Length: 2\r\n\r\nyo")
+                    await w.drain()
+                    resp = await asyncio.wait_for(r.read(256), timeout=5)
+                    w.close()
+        return seen, resp
+
+    seen, resp = asyncio.run(scenario())
+    # the injected key reached upstream...
+    assert seen.get("x-api-key") == "HOST-ONLY-KEY"
+    # ...and the response streamed back
+    assert b"200 OK" in resp and b"hi" in resp


### PR DESCRIPTION
## Summary
Second Phase-3 piece: the **localhost cloud-key-injecting proxy** so the model API key **never enters the sandbox**. The sandboxed agent points its model base URL at this loopback proxy and carries **no key**; the host-held key is injected here.

- `key_proxy/injector.py` — pure `inject_auth` (Anthropic `x-api-key` / OpenAI `Bearer`), **strips any client-supplied auth** (sandbox can't smuggle its own) + hop-by-hop headers.
- `key_proxy/main.py` — asyncio reverse proxy, streams request/response via httpx; refuses to start keyless; 502 on upstream failure (never crashes).

Standalone/inert for now; fails open to the ollama-local floor (D-OP-1). The bwrap `--unshare-net` + proxy-env wiring and the controller-tier liveness-probe → cooldown are the remaining Phase-3 pieces.

## Verification
7 tests incl an **end-to-end**: host-only key reaches a mock upstream, the sandbox-side request carried **none**, response streams back. ruff/ty/audit clean.