### PR TITLE
feat(reviewer): INJ Phase 1 hardening — surface failing-check evidence (fix no-op loop)

### DIFF
--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -71,6 +71,7 @@ from operations_center.entrypoints.pr_review_watcher.inj import (
 from operations_center.entrypoints.pr_review_watcher.verdict import (
     CONCERNS,
     compute_verdict,
+    failing_summary,
     verdict_schema_prompt,
 )
 
@@ -540,7 +541,13 @@ def _run_direct_review(
             # can flip a check's enum (re-checkable) but cannot author the verdict.
             checks = raw.get("checks") if isinstance(raw, dict) else None
             result, failing = compute_verdict(checks)
-            summary = (raw.get("summary") if isinstance(raw, dict) else None) or ""
+            # Surface each failing check's evidence so the fix-pass + PR comment are
+            # ACTIONABLE (not an opaque check-id that no-op-loops to exhaustion).
+            # The decision is still code-computed above; this is context only.
+            if result == CONCERNS:
+                summary = failing_summary(checks, failing)
+            else:
+                summary = (raw.get("summary") if isinstance(raw, dict) else None) or ""
             return {"result": result, "failing_checks": failing, "summary": summary}
         # No verdict.json written.
         if proc.returncode != 0:

--- a/src/operations_center/entrypoints/pr_review_watcher/verdict.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/verdict.py
@@ -116,6 +116,31 @@ def compute_verdict(checks: object) -> tuple[str, list[str]]:
     return (LGTM, []) if not failing else (CONCERNS, failing)
 
 
+def failing_summary(checks: object, failing: list[str]) -> str:
+    """A human- and fix-pass-readable summary of the failing checks, surfacing the
+    model's quoted ``evidence_span`` per check.
+
+    This does NOT change the decision (still code-computed in ``compute_verdict``);
+    it only makes a CONCERNS *actionable* instead of an opaque check-id. Without
+    it, the auto-fix worker receives only "code_quality" and no-ops, looping the
+    PR to exhaustion. The evidence_span is bounded model text used purely as
+    review context (and is sanitized before it is reflected to GitHub)."""
+    spans: dict[str, str] = {}
+    if isinstance(checks, list):
+        for entry in checks:
+            if not isinstance(entry, dict):
+                continue
+            d = cast("dict[str, Any]", entry)
+            cid, span = d.get("check_id"), d.get("evidence_span")
+            if isinstance(cid, str) and isinstance(span, str):
+                spans[cid] = span.strip()
+    lines = []
+    for cid in failing:
+        ev = spans.get(cid, "")
+        lines.append(f"- {cid}: {ev[:300]}" if ev else f"- {cid}")
+    return "Failed checks:\n" + "\n".join(lines)
+
+
 def verdict_schema_prompt() -> str:
     """The review-prompt fragment describing the typed verdict the model must
     write. Kept here so the schema and the computation stay in lockstep."""
@@ -151,5 +176,6 @@ __all__ = [
     "ReviewCheck",
     "VALID_STATUS",
     "compute_verdict",
+    "failing_summary",
     "verdict_schema_prompt",
 ]

--- a/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
+++ b/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
@@ -10,6 +10,7 @@ malformed / unknown inputs fail safe to CONCERNS, never an auto-LGTM.
 from __future__ import annotations
 
 from operations_center.entrypoints.pr_review_watcher.verdict import (
+    failing_summary,
     CONCERNS,
     LGTM,
     REVIEW_CHECKS,
@@ -105,3 +106,21 @@ class TestSchemaPromptStaysInLockstep:
             assert c.check_id in prompt
         # must NOT instruct an overall free-text verdict field
         assert '"result"' not in prompt
+
+
+class TestFailingSummary:
+    def test_surfaces_evidence_per_failing_check(self):
+        checks = [
+            {"check_id": "code_quality", "status": "fail", "evidence_span": "line 12: bare except"},
+            {"check_id": "no_tooling_artifacts", "status": "pass", "evidence_span": ""},
+        ]
+        out = failing_summary(checks, ["code_quality"])
+        assert "code_quality" in out
+        assert "bare except" in out
+
+    def test_check_without_evidence_lists_id_only(self):
+        out = failing_summary([{"check_id": "code_quality", "status": "fail"}], ["code_quality"])
+        assert "- code_quality" in out
+
+    def test_malformed_checks_safe(self):
+        assert "Failed checks" in failing_summary(None, ["x"])


### PR DESCRIPTION
## Problem (observed live)
The typed verdict (#349) handed the auto-fix worker only the failing check-*ID* (e.g. `code_quality`) with no specifics, so the fix-pass **no-op'd and looped PRs to exhaustion** — caught in the wild: the Phase-1 verdict gating its own Phase-2/3 follow-on PRs (#351/#352).

## Fix
`verdict.failing_summary(checks, failing)` surfaces each failing check's model **evidence_span**; `_run_direct_review` builds the CONCERNS summary from it, so the fix-goal and PR comment are **actionable**.

The decision is still **code-computed** in `compute_verdict` (unchanged) — this is review *context* only, and it is sanitized before reflecting to GitHub. Deliberately NOT the tempting "ignore unevidenced fails" rule, which would open an injection bypass (inject a fail-without-evidence to suppress a real concern).

## Verification
3 new tests; **139 reviewer tests pass**; ruff/ty/audit clean. Deployed live so in-flight reviews are immediately actionable.