### PR TITLE
feat(sbx): Phase 2 — sandbox the reviewer's executor (close coverage gap)

### DIFF
--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -56,6 +56,11 @@ from operations_center.close_invariants import (
     branch_delete_allowed_after_close,
     close_without_receipt_allowed,
 )
+from operations_center.entrypoints.board_worker._subprocess import (
+    build_allowlist_env,
+    git_token_passthrough,
+)
+from operations_center.entrypoints.board_worker.sandbox import maybe_sandbox
 from operations_center.reviewer.instrumentation import (
     get_instrumenter,
     record_decision_outcome,
@@ -368,6 +373,13 @@ def _build_env(oc_root: Path) -> dict:
     env = dict(os.environ)
     env["PYTHONPATH"] = str(oc_root / "src")
     return env
+
+
+def _sandbox_enabled() -> bool:
+    """True when the bwrap sandbox is enabled for worker subprocesses. Mirrors
+    board_worker._subprocess's gate (OC_BWRAP_SANDBOX=1) so the reviewer's
+    executor is contained on exactly the same switch as board_worker dispatch."""
+    return os.environ.get("OC_BWRAP_SANDBOX") == "1"
 
 
 class OCSourceTreeUncleanError(RuntimeError):
@@ -683,15 +695,41 @@ def _run_pipeline(
             "--source",
             source,
         ]
+        # SBX Phase 2: wrap the executor in the bwrap sandbox. The reviewer runs
+        # the LEAST-trusted code on the trusted host — arbitrary PR branches, incl.
+        # the fix-pass loop's own output — and shells out to claude, so it is the
+        # highest-value executor to contain, yet board_worker dispatch sandboxed
+        # it while this path did not. Gated on OC_BWRAP_SANDBOX: when OFF the exec
+        # is byte-for-byte unchanged (full env, no bwrap) so the critical merge
+        # path cannot regress; when ON it runs in bwrap with board_worker's
+        # battle-tested MINIMIZED env (build_allowlist_env strips the Plane token,
+        # sibling-repo tokens and host secrets — the reviewer's _build_env leaks
+        # the full os.environ, so without this the sandbox would just --setenv the
+        # crown-jewel tokens back in). Fail-open at every layer (§0.1): a missing
+        # bwrap degrades maybe_sandbox to the unwrapped cmd, never a halt.
+        if _sandbox_enabled():
+            exec_env = build_allowlist_env(
+                oc_root, passthrough=git_token_passthrough(settings, repo_cfg)
+            )
+            run_exec_cmd = maybe_sandbox(
+                exec_cmd,
+                oc_root=oc_root,
+                rw_root=tmp,
+                env=exec_env,
+                enabled=True,
+                chdir=workspace,
+            )
+        else:
+            exec_env, run_exec_cmd = env, exec_cmd
         # Use Popen + start_new_session so the entire process group (including
         # grandchildren like pytest-spawned claude subprocesses) can be killed on
         # timeout.  subprocess.run with capture_output=True only kills the direct
         # child on TimeoutExpired; grandchildren keep the pipe open and
         # communicate() blocks indefinitely.
         _exec_popen = subprocess.Popen(
-            exec_cmd,
+            run_exec_cmd,
             cwd=oc_root,
-            env=env,
+            env=exec_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -2832,3 +2832,71 @@ def test_phase1_code_diff_omits_doc_rubric(tmp_path: Path) -> None:
         )
 
     assert "DOCUMENTATION-ONLY" not in captured["goal"]
+
+
+# ── SBX Phase 2: reviewer executor sandboxing ────────────────────────────────
+
+
+def test_sandbox_enabled_reads_flag(monkeypatch) -> None:
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    assert watcher._sandbox_enabled() is True
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
+    assert watcher._sandbox_enabled() is False
+    monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+    assert watcher._sandbox_enabled() is False
+
+
+def _pipeline_settings() -> MagicMock:
+    # token_env None on both repo + global git so git_token_passthrough -> ()
+    # (a MagicMock token_env would be truthy and break build_allowlist_env).
+    repo_cfg = MagicMock(clone_url="u", default_branch="main", token_env=None)
+    return MagicMock(
+        repos={REPO_KEY: repo_cfg},
+        git=MagicMock(token_env=None),
+        plane=MagicMock(project_id="proj"),
+    )
+
+
+def _patched_pipeline_run(monkeypatch, tmp_path: Path):
+    """Common harness: clean tree, stubbed planning that emits an empty bundle,
+    and a captured Popen whose process completes rc=0 with no output. Returns the
+    Popen mock so the caller can assert on the spawned argv."""
+    (tmp_path / "cfg.yaml").write_text("x: 1\n")
+    plan_cp = watcher.subprocess.CompletedProcess([], 0, stdout="{}", stderr="")
+    popen = MagicMock()
+    popen.return_value.communicate.return_value = ("", "")
+    popen.return_value.returncode = 0
+    monkeypatch.setattr(watcher, "_oc_source_conflict_markers", lambda *a, **k: [])
+    monkeypatch.setattr(watcher.subprocess, "run", lambda *a, **k: plan_cp)
+    monkeypatch.setattr(watcher.subprocess, "Popen", popen)
+    return popen
+
+
+def test_run_pipeline_sandboxes_exec_when_enabled(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    popen = _patched_pipeline_run(monkeypatch, tmp_path)
+    sentinel = ["bwrap", "WRAPPED", "execute.main"]
+    with patch.object(watcher, "maybe_sandbox", return_value=sentinel) as msbx:
+        watcher._run_pipeline(
+            tmp_path, tmp_path / "cfg.yaml", REPO_KEY, "goal", _pipeline_settings(),
+            source="reviewer_self", state_key=STATE_KEY, branch_suffix="abc",
+        )
+    # exec wrapped via maybe_sandbox with enabled=True, and Popen got the wrap
+    msbx.assert_called_once()
+    assert msbx.call_args.kwargs["enabled"] is True
+    assert popen.call_args.args[0] == sentinel
+
+
+def test_run_pipeline_no_sandbox_when_disabled(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+    popen = _patched_pipeline_run(monkeypatch, tmp_path)
+    with patch.object(watcher, "maybe_sandbox") as msbx:
+        watcher._run_pipeline(
+            tmp_path, tmp_path / "cfg.yaml", REPO_KEY, "goal", _pipeline_settings(),
+            source="reviewer_self", state_key=STATE_KEY, branch_suffix="abc",
+        )
+    # flag off -> no sandbox wrap, Popen gets the raw execute.main command
+    msbx.assert_not_called()
+    spawned = popen.call_args.args[0]
+    assert spawned[1] == "-m"
+    assert spawned[2] == "operations_center.entrypoints.execute.main"


### PR DESCRIPTION
## What

Closes a Phase-2 coverage gap found while wiring Phase 3 (#356): **board_worker dispatch sandboxes `execute.main`, but the reviewer did not.** `pr_review_watcher._run_pipeline` spawned the executor via a raw `subprocess.Popen(exec_cmd, …)` with no `maybe_sandbox` wrap, so every review/fix-pass executor ran un-sandboxed.

## Why it's the important one

The reviewer runs the **least-trusted** code on the trusted host — arbitrary PR branches, including the fix-pass loop's own generated output — and shells out to `claude`. That's exactly the threat the bwrap sandbox exists to contain, so the reviewer is the highest-value executor to sandbox, yet it was the one left out. (Confirmed live: #356's own fix-pass executor ran with no `bwrap` parent.)

## Change

- Wrap `exec_cmd` in `maybe_sandbox` (`rw_root` = the per-review tempdir, `chdir` = workspace).
- New `_sandbox_enabled()` gates on `OC_BWRAP_SANDBOX` (mirrors board_worker). **When OFF, the exec is byte-for-byte unchanged** (full env, no bwrap) so the critical merge path can't regress; **when ON** it runs in bwrap with board_worker's battle-tested **minimized env** (`build_allowlist_env`).
- The minimized env is load-bearing: the reviewer's `_build_env` returns the full `os.environ`, so a naive wrap would just `--setenv` the Plane / sibling-repo / host tokens straight back *into* the sandbox. Using `build_allowlist_env` (which board_worker already runs in prod) is what makes the containment real — it also closes the reviewer's latent Phase-0 env-minimization gap.

## Fail-open (§0.1)

Every layer degrades safely: missing bwrap → `maybe_sandbox` returns the unwrapped cmd; flag off → unchanged. Never halts the reviewer (which is itself the self-heal path — a halt here is the bootstrap-deadlock case).

## Scope note

`plan_cmd` (worker.main planning) is intentionally left unwrapped — it calls the model with the goal text (the INJ axis, handled in Phase 1) but does **not** execute untrusted repo code, which is the SBX threat. Egress confinement (#356) composes automatically: once both land, the reviewer's sandboxed exec gets `HTTPS_PROXY` too.

## Tests

3 new (`_sandbox_enabled` flag read; exec wrapped + `enabled=True` when on; raw `execute.main` when off). **Reviewer suite: 128 passed** locally — note these live at `tests/test_pr_review_watcher.py` (repo root) and are **not run in CI** (`pytest tests/unit` only), so the local run is the gate. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)