### PR TITLE
fix(sbx): make git@github clone/push work inside the bwrap sandbox

### DIFF
--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -36,6 +36,7 @@ PATH/CL_ANCHOR regressions). Turning it on is an explicit, observed step.
 
 from __future__ import annotations
 
+import base64
 import os
 import shutil
 import socket
@@ -50,6 +51,10 @@ _SECRET_HOME_DIRS = (".ssh", ".gnupg", ".aws", ".config/gh", ".config/gcloud")
 _RO_SYSTEM_DIRS = ("/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc")
 
 _SANDBOX_HOME = "/sandbox-home"
+
+# Env vars that may carry the github token forwarded into the executor env
+# (config token_env=GITHUB_TOKEN; GIT_TOKEN mirrors it). First non-empty wins.
+_GIT_TOKEN_ENVS = ("GITHUB_TOKEN", "GIT_TOKEN")
 
 # SBX Phase 3 (D-SBX-2): when set to the egress proxy URL in the fleet env, the
 # sandbox routes HTTPS egress through the L7/SNI allowlist proxy. Unset => no
@@ -110,6 +115,35 @@ def _proxy_env(url: str, *, existing_no_proxy: str = "") -> dict[str, str]:
         "https_proxy": url,
         "NO_PROXY": no_proxy,
         "no_proxy": no_proxy,
+    }
+
+
+def _git_auth_env(env: dict) -> dict[str, str]:
+    """PURE: ``GIT_CONFIG_*`` vars that let git reach github over HTTPS with the
+    forwarded token, rewriting SSH remotes.
+
+    Why this is needed: the sandbox never binds ``~/.ssh`` (a ``_SECRET_HOME_DIR``)
+    and its tmpfs ``$HOME`` has no keys, so a ``git@github.com:`` clone/fetch/push
+    inside the sandbox fails ("Could not read from remote repository"). This routes
+    those operations through ``https://github.com/`` with an ``Authorization``
+    header built from the token instead. Injected via ``GIT_CONFIG_COUNT`` env
+    (read by every git invocation), so it covers clone, fetch and push uniformly,
+    is **never written to ``.git/config``** (the workspace token-leak verification
+    still passes), and leaves ``remote.origin.url`` as the original SSH URL.
+
+    Returns ``{}`` when no token is present — fail-open to the prior SSH path (the
+    un-sandboxed executor, which has ``~/.ssh``, is unaffected since this only
+    enters the sandbox env)."""
+    token = next((env[k] for k in _GIT_TOKEN_ENVS if env.get(k)), None)
+    if not token:
+        return {}
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "url.https://github.com/.insteadOf",
+        "GIT_CONFIG_VALUE_0": "git@github.com:",
+        "GIT_CONFIG_KEY_1": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_1": f"Authorization: Basic {basic}",
     }
 
 
@@ -201,7 +235,10 @@ def build_sandbox_argv(
     argv += ["--bind", str(rw_root), str(rw_root)]
     # Controlled env (already minimized by build_allowlist_env), HOME re-pointed
     # at the sandbox tmpfs home so secrets under the real HOME are unreachable.
-    for k, v in env.items():
+    # Add the git HTTPS-token config so git@github remotes work without ~/.ssh
+    # (absent in the sandbox); no-op when no token is present.
+    setenv = {**env, **_git_auth_env(env)}
+    for k, v in setenv.items():
         if v is None:
             continue
         argv += ["--setenv", k, str(v)]

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -226,3 +226,48 @@ class TestEgressProxyWiring:
     def test_proxy_reachable_false_on_closed_port(self):
         # Nothing listens on this port -> reachable is False (real socket probe).
         assert sbx._proxy_reachable("http://127.0.0.1:1", timeout=0.2) is False
+
+
+class TestGitHttpsTokenAuth:
+    """SBX Phase 2: git@github clones work in the sandbox (no ~/.ssh) via an
+    HTTPS+token rewrite injected as GIT_CONFIG_* env."""
+
+    def test_no_token_returns_empty(self):
+        assert sbx._git_auth_env({}) == {}
+        assert sbx._git_auth_env({"GITHUB_TOKEN": ""}) == {}
+
+    def test_builds_insteadof_and_extraheader_from_github_token(self):
+        import base64
+
+        out = sbx._git_auth_env({"GITHUB_TOKEN": "tok123"})
+        assert out["GIT_CONFIG_COUNT"] == "2"
+        assert out["GIT_CONFIG_KEY_0"] == "url.https://github.com/.insteadOf"
+        assert out["GIT_CONFIG_VALUE_0"] == "git@github.com:"
+        assert out["GIT_CONFIG_KEY_1"] == "http.https://github.com/.extraheader"
+        expected = base64.b64encode(b"x-access-token:tok123").decode()
+        assert out["GIT_CONFIG_VALUE_1"] == f"Authorization: Basic {expected}"
+
+    def test_falls_back_to_git_token(self):
+        out = sbx._git_auth_env({"GIT_TOKEN": "abc"})
+        assert out.get("GIT_CONFIG_COUNT") == "2"
+
+    def test_github_token_preferred_over_git_token(self):
+        out = sbx._git_auth_env({"GITHUB_TOKEN": "primary", "GIT_TOKEN": "secondary"})
+        import base64
+
+        assert base64.b64encode(b"x-access-token:primary").decode() in out["GIT_CONFIG_VALUE_1"]
+
+    def test_build_sandbox_argv_setenvs_git_config_when_token_present(self, tmp_path: Path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        env = {"HOME": str(tmp_path / "home"), "GITHUB_TOKEN": "tok"}
+        argv = build_sandbox_argv(["git", "clone", "x"], oc_root=tmp_path, rw_root=ws, env=env)
+        joined = " ".join(argv)
+        assert "--setenv GIT_CONFIG_COUNT 2" in joined
+        assert "url.https://github.com/.insteadOf" in joined
+
+    def test_build_sandbox_argv_no_git_config_without_token(self, tmp_path: Path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=ws, env={"HOME": str(tmp_path)})
+        assert "GIT_CONFIG_COUNT" not in " ".join(argv)


### PR DESCRIPTION
## The bug

The bwrap sandbox (Phase 2) **breaks git-over-SSH**. It never binds `~/.ssh` (a `_SECRET_HOME_DIR`, by design) and its tmpfs `$HOME` has no keys, so a clone of the fleet's `git@github.com:` repos inside the sandbox fails:

```
Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
fatal: Could not read from remote repository.
```

So the sandboxed executor's **workspace-prep clone fails for every task** → `Workspace preparation failed: git clone failed`. This was uncovered when merging #348 let the goal team dispatch — and `goal-f97d7dab` had been failing this way since the sandbox went live this morning (missed because the enable-and-observe confirmed bwrap *spawned* but never that a clone-requiring task *completed*).

## The fix

Inject `GIT_CONFIG_*` into the sandbox env (in `build_sandbox_argv`) when a github token is present:
- `url.https://github.com/.insteadOf` = `git@github.com:` — rewrite SSH remotes to HTTPS
- `http.https://github.com/.extraheader` = `Authorization: Basic <b64(x-access-token:TOKEN)>` — supply the token

Git reads `GIT_CONFIG_COUNT` on **every** invocation, so clone, fetch, and push all route through HTTPS+token transparently (the GitHub Actions pattern). Properties:
- **No `.git/config` leak** — the header lives only in the process env, never persisted; `remote.origin.url` stays the original SSH URL → the workspace token-leak verification still passes.
- **Fail-open** — no token → `{}` → the prior SSH path. Only enters the *sandbox* env, so the un-sandboxed executor (which has `~/.ssh`) is unaffected.
- **No new exposure** — the raw token is already `--setenv`'d into the sandbox (`GITHUB_TOKEN`).

## Validation

- Reproduced the failure and the fix through the **real `maybe_sandbox`/`build_sandbox_argv`**: a `git@github.com:` clone inside the sandbox now returns **rc=0**.
- 6 new unit tests (`_git_auth_env` empty/build/fallback/precedence + argv with/without token); **27 sandbox tests pass**, ruff + ty clean.

## Note

`enable-and-observe` for a sandbox must confirm a **clone-requiring task completes**, not just that bwrap processes spawn — recorded for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)