### PR TITLE
fix(sbx): bind editable-installed sibling-repo deps into the sandbox

### DIFF
--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -37,6 +37,7 @@ PATH/CL_ANCHOR regressions). Turning it on is an explicit, observed step.
 from __future__ import annotations
 
 import base64
+import json
 import os
 import shutil
 import socket
@@ -157,6 +158,36 @@ def _real(p: str | None) -> str | None:
         return None
 
 
+def _editable_install_dirs(oc_root: Path) -> list[str]:
+    """Source dirs of editable-installed dependencies that live OUTSIDE oc_root.
+
+    The OC venv installs sibling repos (TeamExecutor, DAGExecutor) as editable
+    (PEP 660), so their ``.dist-info/direct_url.json`` records the real source
+    path (e.g. /home/dev/Documents/GitHub/TeamExecutor). Those back
+    ``import team_executor`` / ``import dag_executor`` — the executor backends.
+    Without binding them the sandboxed executor fails ``No module named ...`` at
+    its very first stage (only surfaces once clone works). oc_root's own editable
+    install is skipped (already bound via ``oc_root/src``). Discovered (not
+    hardcoded) so new editable deps are picked up automatically."""
+    dirs: list[str] = []
+    oc_real = _real(str(oc_root))
+    for du in (oc_root / ".venv").glob("lib/python*/site-packages/*.dist-info/direct_url.json"):
+        try:
+            meta = json.loads(du.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not meta.get("dir_info", {}).get("editable"):
+            continue
+        url = meta.get("url", "")
+        rp = _real(url[len("file://") :] if url.startswith("file://") else url)
+        if not rp or rp in dirs:
+            continue
+        if oc_real and (rp == oc_real or rp.startswith(oc_real + os.sep)):
+            continue  # oc_root is already bound
+        dirs.append(rp)
+    return dirs
+
+
 def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     """Read-only host paths the executor toolchain needs. Derived from the
     resolved binaries + env so it tracks where things actually live."""
@@ -170,6 +201,9 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     # The OC source tree (PYTHONPATH) + its venv (python/pytest/ruff).
     add(str(oc_root / "src"))
     add(str(oc_root / ".venv"))
+    # Editable-installed sibling-repo deps (team_executor, dag_executor, …).
+    for d in _editable_install_dirs(oc_root):
+        add(d)
     # Agent CLIs + their install dirs.
     for tool in ("claude", "cl", "uv", "aider", "node", "npm"):
         found = shutil.which(tool)

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -13,6 +13,7 @@ is unavailable (CI containers); the unit tests pin the argv contract offline.
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -271,3 +272,48 @@ class TestGitHttpsTokenAuth:
         ws.mkdir()
         argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=ws, env={"HOME": str(tmp_path)})
         assert "GIT_CONFIG_COUNT" not in " ".join(argv)
+
+
+class TestEditableInstallBinds:
+    """SBX Phase 2: editable-installed sibling-repo deps (team_executor,
+    dag_executor) must be ro-bound or the sandboxed executor can't import them."""
+
+    def _make_editable(self, oc_root: Path, name: str, src: Path, *, editable: bool) -> None:
+        site = oc_root / ".venv" / "lib" / "python3.12" / "site-packages"
+        di = site / f"{name}-0.1.0.dist-info"
+        di.mkdir(parents=True, exist_ok=True)
+        (di / "direct_url.json").write_text(
+            json.dumps({"url": f"file://{src}", "dir_info": {"editable": editable}}),
+            encoding="utf-8",
+        )
+
+    def test_discovers_editable_dirs_outside_oc_root(self, tmp_path: Path):
+        oc_root = tmp_path / "oc"
+        (oc_root / "src").mkdir(parents=True)
+        sibling = tmp_path / "Sibling"
+        sibling.mkdir()
+        self._make_editable(oc_root, "sibling_pkg", sibling, editable=True)
+        dirs = sbx._editable_install_dirs(oc_root)
+        assert str(sibling) in dirs
+
+    def test_skips_non_editable_and_oc_root_self(self, tmp_path: Path):
+        oc_root = tmp_path / "oc"
+        (oc_root / "src").mkdir(parents=True)
+        wheel = tmp_path / "Wheel"
+        wheel.mkdir()
+        self._make_editable(oc_root, "wheel_pkg", wheel, editable=False)  # not editable
+        self._make_editable(oc_root, "operations_center", oc_root, editable=True)  # self
+        dirs = sbx._editable_install_dirs(oc_root)
+        assert str(wheel) not in dirs
+        assert str(oc_root) not in dirs
+
+    def test_toolchain_binds_include_editable_dirs(self, tmp_path: Path):
+        oc_root = tmp_path / "oc"
+        (oc_root / "src").mkdir(parents=True)
+        sibling = tmp_path / "TeamExecutor"
+        sibling.mkdir()
+        self._make_editable(oc_root, "team_executor", sibling, editable=True)
+        argv = build_sandbox_argv(
+            ["x"], oc_root=oc_root, rw_root=tmp_path, env={"HOME": str(tmp_path)}
+        )
+        assert str(sibling) in " ".join(argv)


### PR DESCRIPTION
## The bug (next sandbox-completeness layer after #359)

Once #359 fixed git clone in the sandbox, the executor got further and hit: `team_executor not installed: No module named 'team_executor'`.

Root cause: the OC venv installs sibling repos as **editable** (PEP 660) — `team_executor` → `/home/dev/Documents/GitHub/TeamExecutor`, `dag_executor` → `.../DAGExecutor`. Their `.dist-info/direct_url.json` points at those **out-of-tree source dirs**, which the sandbox never bound (it bound only `oc_root/src` + `oc_root/.venv`). So `import team_executor` fails inside the sandbox → the executor backend adapter dies at its first stage.

## The fix

`_editable_install_dirs(oc_root)` discovers editable installs from the venv's `direct_url.json` (skipping non-editable wheels and oc_root's own install, which is already bound) and `_toolchain_ro_binds` ro-binds them. **Discovered, not hardcoded** — new editable deps are picked up automatically.

## Validation

Through the production `build_sandbox_argv` against the live venv: discovers `[TeamExecutor, DAGExecutor]`, and `import team_executor, dag_executor` inside the sandbox now returns **rc=0** (was `ModuleNotFoundError`). 3 new unit tests; **30 sandbox tests pass**, ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)