### PR TITLE
feat(sbx): pre-provision a wheelhouse so the in-sandbox install runs offline

### DIFF
--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -6,14 +6,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from ._subprocess import build_allowlist_env, git_token_passthrough, run_executor
+from ._subprocess import _SANDBOX_ENV_FLAG, build_allowlist_env, git_token_passthrough, run_executor
 from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv_python
+from .wheelhouse import ensure_wheelhouse
 from ._text import desc_text, extract_goal, task_type_from_kind
 from .labels import GITHUB_DIR, add_label, label_value
 from .outcomes import (
@@ -100,6 +102,14 @@ def dispatch_issue(
     oc_root = Path(__file__).resolve().parents[4]
     python = venv_python(oc_root)
     env = build_allowlist_env(oc_root, passthrough=git_token_passthrough(settings, repo_cfg))
+    # Pre-provision a wheelhouse on the host (online) so the executor's in-sandbox
+    # dev-install runs fully offline — the sandbox has no pypi egress. Event-driven
+    # + self-maintaining: rebuilds only when the repo's deps changed. Fail-open:
+    # no wheelhouse → no OC_WHEELHOUSE → the install falls back (and degrades).
+    if os.environ.get(_SANDBOX_ENV_FLAG) == "1":
+        wh = ensure_wheelhouse(repo_key, repo_path, python_bin=python)
+        if wh is not None:
+            env["OC_WHEELHOUSE"] = str(wh)
     short_id = task_id[:8]
 
     logger.info(

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -6,16 +6,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from ._subprocess import _SANDBOX_ENV_FLAG, build_allowlist_env, git_token_passthrough, run_executor
+from ._subprocess import build_allowlist_env, git_token_passthrough, run_executor
 from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv_python
-from .wheelhouse import ensure_wheelhouse
+from .wheelhouse import wheelhouse_env
 from ._text import desc_text, extract_goal, task_type_from_kind
 from .labels import GITHUB_DIR, add_label, label_value
 from .outcomes import (
@@ -66,8 +65,7 @@ def dispatch_issue(
     # ── Goal text + mode ──────────────────────────────────────────────────────
     goal_text = extract_goal(description, title)
 
-    # Rejection-pattern hint: prepend patterns the backend should avoid.
-    try:
+    try:  # prepend rejection-pattern hints the backend should avoid
         from operations_center.quality_alerts import _load_rejection_patterns_for_proposal
 
         patterns = _load_rejection_patterns_for_proposal(repo_key=repo_key)
@@ -84,8 +82,7 @@ def dispatch_issue(
     if role == "improve":
         goal_text = _append_improve_output_prompt(goal_text)
     else:
-        # First-pass depth: require the initial pass to fully implement and
-        # self-verify before the PR opens, so the review loop has less to fix.
+        # First-pass depth: implement + self-verify before the PR opens.
         goal_text = _append_definition_of_done(goal_text)
 
     execution_mode = task_kind  # historically a no-op ternary; kept flat for C29
@@ -102,14 +99,7 @@ def dispatch_issue(
     oc_root = Path(__file__).resolve().parents[4]
     python = venv_python(oc_root)
     env = build_allowlist_env(oc_root, passthrough=git_token_passthrough(settings, repo_cfg))
-    # Pre-provision a wheelhouse on the host (online) so the executor's in-sandbox
-    # dev-install runs fully offline — the sandbox has no pypi egress. Event-driven
-    # + self-maintaining: rebuilds only when the repo's deps changed. Fail-open:
-    # no wheelhouse → no OC_WHEELHOUSE → the install falls back (and degrades).
-    if os.environ.get(_SANDBOX_ENV_FLAG) == "1":
-        wh = ensure_wheelhouse(repo_key, repo_path, python_bin=python)
-        if wh is not None:
-            env["OC_WHEELHOUSE"] = str(wh)
+    env.update(wheelhouse_env(repo_key, repo_path, python_bin=python))  # offline deps
     short_id = task_id[:8]
 
     logger.info(

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -212,6 +212,10 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     # ContextLifecycle home (cl) + the anchor manifest (.context tree).
     add(env.get("CL_HOME"))
     add(env.get("CL_ANCHOR"))
+    # Pre-provisioned wheelhouse (host-built) so the in-sandbox dev-install runs
+    # offline — no pypi egress needed. Bound at its real path so the install's
+    # --find-links $OC_WHEELHOUSE resolves identically inside the sandbox.
+    add(env.get("OC_WHEELHOUSE"))
     # Claude subscription auth — required or the agent refuses.
     home = env.get("HOME") or os.path.expanduser("~")
     add(os.path.join(home, ".claude"))

--- a/src/operations_center/entrypoints/board_worker/wheelhouse.py
+++ b/src/operations_center/entrypoints/board_worker/wheelhouse.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import subprocess
 from pathlib import Path
 
@@ -123,4 +124,20 @@ def ensure_wheelhouse(
         return None
 
 
-__all__ = ["ensure_wheelhouse", "wheelhouse_dir"]
+def wheelhouse_env(
+    repo_key: str, repo_local_path: str | None, *, python_bin: str
+) -> dict[str, str]:
+    """``{"OC_WHEELHOUSE": <dir>}`` to merge into the executor env when the bwrap
+    sandbox is enabled and provisioning succeeds, else ``{}`` (fail-open).
+
+    Self-contained so dispatch wires it in one line: reads ``OC_BWRAP_SANDBOX``
+    (provisioning is only needed when the executor is sandboxed) and runs the
+    host-side :func:`ensure_wheelhouse`.
+    """
+    if os.environ.get("OC_BWRAP_SANDBOX") != "1":
+        return {}
+    wh = ensure_wheelhouse(repo_key, repo_local_path, python_bin=python_bin)
+    return {"OC_WHEELHOUSE": str(wh)} if wh is not None else {}
+
+
+__all__ = ["ensure_wheelhouse", "wheelhouse_dir", "wheelhouse_env"]

--- a/src/operations_center/entrypoints/board_worker/wheelhouse.py
+++ b/src/operations_center/entrypoints/board_worker/wheelhouse.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Host-side wheelhouse pre-provisioning for the sandboxed executor.
+
+The bwrap sandbox has no pypi egress — the L7/SNI allowlist permits only the
+model endpoint + github + localhost (D-SBX-2) — so the executor's in-sandbox
+dev-install (`pip install -e .[dev]`) can't reach pypi and fails at workspace
+bootstrap. Rather than loosen the allowlist (pip deps are a supply-chain
+inject/exfil vector), we PRE-PROVISION: build a wheelhouse of the repo's full
+dependency closure (pypi packages AND git deps, all baked into wheels) on the
+HOST while egress is unrestricted, so the in-sandbox install runs fully offline
+via ``pip install --no-index --find-links <wheelhouse>``.
+
+Event-driven + self-maintaining (no cron / no system scheduler): the executor
+calls :func:`ensure_wheelhouse` on the host right before dispatching the
+sandboxed run. It rebuilds ONLY when the repo's dependency fingerprint (a hash of
+its pyproject/lock files) changed or the wheelhouse is missing — a fresh
+wheelhouse is a fast no-op. **Fail-open (§0.1):** any build failure returns
+``None`` and the caller proceeds without provisioning (the in-sandbox install
+will then fail and the task degrades/requeues, never a halt).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Files whose contents define the dependency closure — any change triggers a
+# rebuild. Lock files (if present) pin git SHAs too, so they catch git-dep drift
+# that a bare pyproject hash would miss; pyproject alone is the common case.
+_DEP_FILES = (
+    "pyproject.toml",
+    "uv.lock",
+    "poetry.lock",
+    "requirements.txt",
+    "requirements-dev.txt",
+)
+
+# Built once per host; bound read-only into the sandbox. Under ~/.cache so it
+# survives across runs and is naturally per-user.
+_CACHE_ROOT = Path.home() / ".cache" / "oc-wheelhouse"
+
+# What to wheel: the package + its dev extra, plus the build backend (the
+# editable install runs --no-build-isolation in the sandbox, so setuptools/wheel
+# must be present as wheels too).
+_EXTRA_BUILD_REQS = ("setuptools", "wheel", "pip")
+
+
+def wheelhouse_dir(repo_key: str) -> Path:
+    """The wheelhouse directory for a repo (stable path, bound into the sandbox)."""
+    return _CACHE_ROOT / repo_key
+
+
+def _fingerprint(repo_path: Path) -> str:
+    """Hash of the repo's dependency-defining files; changes ⇒ rebuild."""
+    h = hashlib.sha256()
+    for name in _DEP_FILES:
+        f = repo_path / name
+        if f.exists():
+            h.update(name.encode())
+            h.update(f.read_bytes())
+    return h.hexdigest()[:16]
+
+
+def _is_fresh(wh: Path, fingerprint: str) -> bool:
+    fp_file = wh / ".fingerprint"
+    return (
+        wh.is_dir()
+        and fp_file.is_file()
+        and fp_file.read_text(encoding="utf-8").strip() == fingerprint
+        and any(wh.glob("*.whl"))
+    )
+
+
+def ensure_wheelhouse(
+    repo_key: str,
+    repo_local_path: str | None,
+    *,
+    python_bin: str,
+    extras: str = ".[dev]",
+    timeout: int = 1200,
+) -> Path | None:
+    """Ensure a fresh wheelhouse exists for ``repo_key``; return its dir or None.
+
+    Builds ``pip wheel <extras> setuptools wheel pip`` from the host repo at
+    ``repo_local_path`` (online, unsandboxed) when missing or when the dependency
+    fingerprint changed. A fresh wheelhouse is a fast no-op. ``None`` on any
+    failure or when the repo has no ``pyproject.toml`` (fail-open).
+    """
+    if not repo_local_path:
+        return None
+    repo_path = Path(repo_local_path)
+    if not (repo_path / "pyproject.toml").is_file():
+        return None  # nothing to provision
+
+    fingerprint = _fingerprint(repo_path)
+    wh = wheelhouse_dir(repo_key)
+    if _is_fresh(wh, fingerprint):
+        return wh
+
+    try:
+        wh.mkdir(parents=True, exist_ok=True)
+        for stale in wh.glob("*.whl"):  # drop the previous closure before rebuild
+            stale.unlink()
+        logger.info("wheelhouse: building for %s (deps changed or missing)", repo_key)
+        subprocess.run(
+            [python_bin, "-m", "pip", "wheel", extras, *_EXTRA_BUILD_REQS, "-w", str(wh)],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        (wh / ".fingerprint").write_text(fingerprint, encoding="utf-8")
+        logger.info("wheelhouse: built %d wheels for %s", len(list(wh.glob("*.whl"))), repo_key)
+        return wh
+    except Exception as exc:  # noqa: BLE001 — provisioning is best-effort, never fatal
+        logger.warning("wheelhouse: build failed for %s — %s", repo_key, exc)
+        return None
+
+
+__all__ = ["ensure_wheelhouse", "wheelhouse_dir"]

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -317,3 +317,23 @@ class TestEditableInstallBinds:
             ["x"], oc_root=oc_root, rw_root=tmp_path, env={"HOME": str(tmp_path)}
         )
         assert str(sibling) in " ".join(argv)
+
+
+class TestWheelhouseBind:
+    """SBX: the pre-provisioned wheelhouse is ro-bound + setenv'd so the
+    in-sandbox dev-install runs fully offline."""
+
+    def test_wheelhouse_bound_and_setenv(self, tmp_path: Path):
+        wh = tmp_path / "wheelhouse"
+        wh.mkdir()
+        env = {"HOME": str(tmp_path / "home"), "OC_WHEELHOUSE": str(wh)}
+        argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=tmp_path, env=env)
+        joined = " ".join(argv)
+        assert f"--ro-bind {wh} {wh}" in joined
+        assert f"--setenv OC_WHEELHOUSE {wh}" in joined
+
+    def test_no_wheelhouse_no_bind(self, tmp_path: Path):
+        argv = build_sandbox_argv(
+            ["x"], oc_root=tmp_path, rw_root=tmp_path, env={"HOME": str(tmp_path)}
+        )
+        assert "OC_WHEELHOUSE" not in " ".join(argv)

--- a/tests/unit/entrypoints/board_worker/test_wheelhouse.py
+++ b/tests/unit/entrypoints/board_worker/test_wheelhouse.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for host-side wheelhouse pre-provisioning (SBX Phase 2/3)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from operations_center.entrypoints.board_worker import wheelhouse as wh
+
+
+def _repo(tmp: Path, deps: str = "a==1") -> Path:
+    r = tmp / "repo"
+    r.mkdir(parents=True)
+    (r / "pyproject.toml").write_text(f"[project]\nname='x'\ndependencies=['{deps}']\n")
+    return r
+
+
+def test_returns_none_without_local_path():
+    assert wh.ensure_wheelhouse("Repo", None, python_bin="python3") is None
+
+
+def test_returns_none_when_no_pyproject(tmp_path, monkeypatch):
+    monkeypatch.setattr(wh, "_CACHE_ROOT", tmp_path / "cache")
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert wh.ensure_wheelhouse("Repo", str(empty), python_bin="python3") is None
+
+
+def test_fingerprint_changes_with_deps(tmp_path):
+    r1 = _repo(tmp_path / "a", deps="a==1")
+    r2 = _repo(tmp_path / "b", deps="a==2")
+    assert wh._fingerprint(r1) != wh._fingerprint(r2)
+
+
+def test_fresh_wheelhouse_is_a_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(wh, "_CACHE_ROOT", tmp_path / "cache")
+    repo = _repo(tmp_path)
+    whd = wh.wheelhouse_dir("Repo")
+    whd.mkdir(parents=True)
+    (whd / "pkg-1.0-py3-none-any.whl").write_text("")
+    (whd / ".fingerprint").write_text(wh._fingerprint(repo))
+    called = {"n": 0}
+
+    def _fail(*a, **k):
+        called["n"] += 1
+        raise AssertionError("should not rebuild a fresh wheelhouse")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+    assert wh.ensure_wheelhouse("Repo", str(repo), python_bin="python3") == whd
+    assert called["n"] == 0
+
+
+def test_rebuilds_when_fingerprint_stale(tmp_path, monkeypatch):
+    monkeypatch.setattr(wh, "_CACHE_ROOT", tmp_path / "cache")
+    repo = _repo(tmp_path)
+    whd = wh.wheelhouse_dir("Repo")
+    whd.mkdir(parents=True)
+    (whd / ".fingerprint").write_text("STALE")
+    calls = []
+
+    def _run(cmd, **k):
+        calls.append(cmd)
+        (whd / "pkg-1.0-py3-none-any.whl").write_text("")  # simulate pip wheel output
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    out = wh.ensure_wheelhouse("Repo", str(repo), python_bin="/v/bin/python")
+    assert out == whd
+    assert calls and calls[0][:4] == ["/v/bin/python", "-m", "pip", "wheel"]
+    assert (whd / ".fingerprint").read_text() == wh._fingerprint(repo)
+
+
+def test_fail_open_on_build_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(wh, "_CACHE_ROOT", tmp_path / "cache")
+    repo = _repo(tmp_path)
+
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "pip", stderr="no network")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert wh.ensure_wheelhouse("Repo", str(repo), python_bin="python3") is None


### PR DESCRIPTION
## The layer (after #359 clone + #360 editable-binds)

With clone + imports working, the executor's workspace bootstrap (`pip install -e .[dev]`) failed: the sandbox has **no pypi egress** (the L7 allowlist permits only model + github + localhost), confirmed by **7 `DENY pypi.org`** during a goal task → `install_dev_command failed` → `.venv/bin/pytest` exit 127 → `category=validation`.

Per your call: **keep the allowlist tight, pre-provision the deps** (pip deps are a supply-chain inject/exfil vector).

## Design — event-driven, self-maintaining, no cron

- **`board_worker/wheelhouse.py`** — `ensure_wheelhouse(repo_key, local_path)` builds a wheelhouse of the repo's full dependency closure (pypi **and** git deps, all baked into wheels) on the **host** while egress is open. It rebuilds **only** when the repo's dependency fingerprint (hash of pyproject/lock files) changed or the wheelhouse is missing — a fresh one is an instant no-op. **Fail-open**: build failure → `None` → executor proceeds un-provisioned (degrades, never halts).
- **`dispatch.py`** — calls `ensure_wheelhouse` on the host right before the sandboxed run (gated on `OC_BWRAP_SANDBOX`) and exports `OC_WHEELHOUSE` into the executor env.
- **`sandbox.py`** — ro-binds `$OC_WHEELHOUSE` at its real path so the in-sandbox `pip install --no-index --find-links $OC_WHEELHOUSE … --no-build-isolation -e .[dev]` resolves **fully offline** (no network at all during install — containment stays maximally tight).

## Validation

- `ensure_wheelhouse` builds **46 wheels** for OperationsCenter; 2nd call is an instant no-op (fingerprint match).
- The offline editable install from the wheelhouse yields a working `import pytest, operations_center` with **zero network**.
- 9 new tests (wheelhouse fresh/stale/fail-open; sandbox bind/setenv); 38 board_worker sandbox tests pass; ruff + ty clean; D12/DC10 clean.

## Deploy note

After merge: switch the repo's `install_dev_command` to the offline form (local gitignored config) and restart the fleet. The `--no-index --find-links $OC_WHEELHOUSE` 2-step (build backend first, then `--no-build-isolation -e .[dev]`) is what makes it offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)