### PR TITLE
feat(sbx): pre-provision tiktoken encoding cache for offline token accounting

### DIFF
--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from ._subprocess import build_allowlist_env, git_token_passthrough, run_executor
 from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv_python
-from .wheelhouse import wheelhouse_env
+from .wheelhouse import provision_env
 from ._text import desc_text, extract_goal, task_type_from_kind
 from .labels import GITHUB_DIR, add_label, label_value
 from .outcomes import (
@@ -99,7 +99,7 @@ def dispatch_issue(
     oc_root = Path(__file__).resolve().parents[4]
     python = venv_python(oc_root)
     env = build_allowlist_env(oc_root, passthrough=git_token_passthrough(settings, repo_cfg))
-    env.update(wheelhouse_env(repo_key, repo_path, python_bin=python))  # offline deps
+    env.update(provision_env(repo_key, repo_path, python_bin=python))  # offline deps
     short_id = task_id[:8]
 
     logger.info(

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -212,10 +212,11 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     # ContextLifecycle home (cl) + the anchor manifest (.context tree).
     add(env.get("CL_HOME"))
     add(env.get("CL_ANCHOR"))
-    # Pre-provisioned wheelhouse (host-built) so the in-sandbox dev-install runs
-    # offline — no pypi egress needed. Bound at its real path so the install's
-    # --find-links $OC_WHEELHOUSE resolves identically inside the sandbox.
+    # Pre-provisioned host caches, bound at their real paths so the executor needs
+    # no pypi/CDN egress: the wheelhouse (offline dev-install via --find-links
+    # $OC_WHEELHOUSE) and the tiktoken encoding cache (offline token accounting).
     add(env.get("OC_WHEELHOUSE"))
+    add(env.get("TIKTOKEN_CACHE_DIR"))
     # Claude subscription auth — required or the agent refuses.
     home = env.get("HOME") or os.path.expanduser("~")
     add(os.path.join(home, ".claude"))

--- a/src/operations_center/entrypoints/board_worker/wheelhouse.py
+++ b/src/operations_center/entrypoints/board_worker/wheelhouse.py
@@ -50,6 +50,13 @@ _CACHE_ROOT = Path.home() / ".cache" / "oc-wheelhouse"
 # must be present as wheels too).
 _EXTRA_BUILD_REQS = ("setuptools", "wheel", "pip")
 
+# tiktoken downloads its BPE encoding files from openaipublic.blob.core.windows.net
+# on first use — a host the egress allowlist denies — so the executor's token
+# accounting fails in the sandbox. Pre-populate the encodings into a host cache
+# bound into the sandbox (TIKTOKEN_CACHE_DIR) so they resolve offline.
+_TIKTOKEN_CACHE = Path.home() / ".cache" / "oc-tiktoken"
+_TIKTOKEN_ENCODINGS = ("cl100k_base", "o200k_base", "p50k_base", "r50k_base")
+
 
 def wheelhouse_dir(repo_key: str) -> Path:
     """The wheelhouse directory for a repo (stable path, bound into the sandbox)."""
@@ -124,20 +131,58 @@ def ensure_wheelhouse(
         return None
 
 
-def wheelhouse_env(
+def ensure_tiktoken_cache(python_bin: str) -> Path | None:
+    """Pre-populate tiktoken's encoding cache on the host so the sandboxed
+    executor's token accounting works offline. Idempotent: a non-empty cache is a
+    no-op; otherwise it loads the encodings once (online) in a subprocess with
+    ``TIKTOKEN_CACHE_DIR`` pointed at the cache. ``None`` on failure (fail-open)."""
+    cache = _TIKTOKEN_CACHE
+    if cache.is_dir() and any(cache.glob("*")):
+        return cache
+    try:
+        cache.mkdir(parents=True, exist_ok=True)
+        code = (
+            "import tiktoken\n"
+            f"for e in {list(_TIKTOKEN_ENCODINGS)!r}:\n"
+            "    try: tiktoken.get_encoding(e)\n"
+            "    except Exception: pass\n"
+        )
+        subprocess.run(
+            [python_bin, "-c", code],
+            env={**os.environ, "TIKTOKEN_CACHE_DIR": str(cache)},
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except Exception as exc:  # noqa: BLE001 — provisioning is best-effort, never fatal
+        logger.warning("tiktoken cache provision failed — %s", exc)
+    return cache if cache.is_dir() and any(cache.glob("*")) else None
+
+
+def provision_env(
     repo_key: str, repo_local_path: str | None, *, python_bin: str
 ) -> dict[str, str]:
-    """``{"OC_WHEELHOUSE": <dir>}`` to merge into the executor env when the bwrap
-    sandbox is enabled and provisioning succeeds, else ``{}`` (fail-open).
-
-    Self-contained so dispatch wires it in one line: reads ``OC_BWRAP_SANDBOX``
-    (provisioning is only needed when the executor is sandboxed) and runs the
-    host-side :func:`ensure_wheelhouse`.
+    """Host-side pre-provisioning env to merge into the executor env when the
+    bwrap sandbox is on (else ``{}``, fail-open). Wires the offline wheelhouse
+    (``OC_WHEELHOUSE``) and the tiktoken encoding cache (``TIKTOKEN_CACHE_DIR``) —
+    both bound into the sandbox — so the executor needs no pypi / CDN egress.
     """
     if os.environ.get("OC_BWRAP_SANDBOX") != "1":
         return {}
+    out: dict[str, str] = {}
     wh = ensure_wheelhouse(repo_key, repo_local_path, python_bin=python_bin)
-    return {"OC_WHEELHOUSE": str(wh)} if wh is not None else {}
+    if wh is not None:
+        out["OC_WHEELHOUSE"] = str(wh)
+    tk = ensure_tiktoken_cache(python_bin)
+    if tk is not None:
+        out["TIKTOKEN_CACHE_DIR"] = str(tk)
+    return out
 
 
-__all__ = ["ensure_wheelhouse", "wheelhouse_dir", "wheelhouse_env"]
+__all__ = [
+    "ensure_tiktoken_cache",
+    "ensure_wheelhouse",
+    "provision_env",
+    "wheelhouse_dir",
+]

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -337,3 +337,12 @@ class TestWheelhouseBind:
             ["x"], oc_root=tmp_path, rw_root=tmp_path, env={"HOME": str(tmp_path)}
         )
         assert "OC_WHEELHOUSE" not in " ".join(argv)
+
+    def test_tiktoken_cache_bound_and_setenv(self, tmp_path: Path):
+        tk = tmp_path / "tiktoken"
+        tk.mkdir()
+        env = {"HOME": str(tmp_path / "home"), "TIKTOKEN_CACHE_DIR": str(tk)}
+        argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=tmp_path, env=env)
+        joined = " ".join(argv)
+        assert f"--ro-bind {tk} {tk}" in joined
+        assert f"--setenv TIKTOKEN_CACHE_DIR {tk}" in joined

--- a/tests/unit/entrypoints/board_worker/test_wheelhouse.py
+++ b/tests/unit/entrypoints/board_worker/test_wheelhouse.py
@@ -81,3 +81,54 @@ def test_fail_open_on_build_error(tmp_path, monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", _boom)
     assert wh.ensure_wheelhouse("Repo", str(repo), python_bin="python3") is None
+
+
+def test_tiktoken_cache_noop_when_populated(tmp_path, monkeypatch):
+    cache = tmp_path / "tk"
+    cache.mkdir()
+    (cache / "enc").write_text("x")
+    monkeypatch.setattr(wh, "_TIKTOKEN_CACHE", cache)
+
+    def _fail(*a, **k):
+        raise AssertionError("should not repopulate a non-empty cache")
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+    assert wh.ensure_tiktoken_cache("python3") == cache
+
+
+def test_tiktoken_cache_populates_when_empty(tmp_path, monkeypatch):
+    cache = tmp_path / "tk"
+    monkeypatch.setattr(wh, "_TIKTOKEN_CACHE", cache)
+    calls = []
+
+    def _run(cmd, **k):
+        calls.append(cmd)
+        (cache / "enc").write_text("x")  # simulate tiktoken download
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    out = wh.ensure_tiktoken_cache("/v/bin/python")
+    assert out == cache
+    assert calls and "TIKTOKEN" not in str(calls[0])  # cmd is just python -c
+    assert "tiktoken" in calls[0][-1]
+
+
+def test_tiktoken_cache_fail_open(tmp_path, monkeypatch):
+    cache = tmp_path / "tk"
+    monkeypatch.setattr(wh, "_TIKTOKEN_CACHE", cache)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(OSError("no net")))
+    assert wh.ensure_tiktoken_cache("python3") is None
+
+
+def test_provision_env_empty_when_sandbox_off(monkeypatch):
+    monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+    assert wh.provision_env("Repo", "/x", python_bin="python3") == {}
+
+
+def test_provision_env_merges_wheelhouse_and_tiktoken(monkeypatch, tmp_path):
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    monkeypatch.setattr(wh, "ensure_wheelhouse", lambda *a, **k: tmp_path / "wh")
+    monkeypatch.setattr(wh, "ensure_tiktoken_cache", lambda *a, **k: tmp_path / "tk")
+    out = wh.provision_env("Repo", "/x", python_bin="python3")
+    assert out["OC_WHEELHOUSE"] == str(tmp_path / "wh")
+    assert out["TIKTOKEN_CACHE_DIR"] == str(tmp_path / "tk")


### PR DESCRIPTION
## The final cascade layer

A real goal task ran the **full pipeline** under the sandbox — clone (HTTPS+token), offline wheelhouse install, baseline validation, **62 model calls** — and failed only at the very end (in the executor's token accounting, `diff_stat: null`) when **tiktoken** tried to download `cl100k_base.tiktoken` from `openaipublic.blob.core.windows.net`, which the egress allowlist denies (403). Same class as the pypi block.

Per your call (**pre-provision each, keep containment tight** — not allowlist the CDN):

- **`wheelhouse.py`** — `ensure_tiktoken_cache()` pre-loads the standard encodings once on the host (idempotent subprocess with `TIKTOKEN_CACHE_DIR` set) into `~/.cache/oc-tiktoken`. `wheelhouse_env` → **`provision_env`** now returns both `OC_WHEELHOUSE` and `TIKTOKEN_CACHE_DIR`. Fail-open.
- **`sandbox.py`** — ro-binds `$TIKTOKEN_CACHE_DIR` at its real path.
- **`dispatch.py`** — calls `provision_env` (one line).

## Validation

With the CDN blocked via the egress proxy, tiktoken loads `cl100k_base` **offline** from the pre-populated cache (n_vocab=100277). 6 new tests; **44 board_worker tests pass**; ruff + ty clean; D12/DC10 clean.

## Deploy note

After merge: run `ensure_tiktoken_cache` once on the host (or it self-populates on first dispatch) + restart the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)