### PR TITLE
fix(sbx): make the sandbox ~/.claude writable (read-only home broke the agent)

### DIFF
--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -48,6 +48,11 @@ from urllib.parse import urlparse
 # HOME subdirectories that hold host credentials — NEVER bound into the sandbox.
 _SECRET_HOME_DIRS = (".ssh", ".gnupg", ".aws", ".config/gh", ".config/gcloud")
 
+# The only ~/.claude entries bound read-only into the agent's (otherwise writable)
+# sandbox ~/.claude: the subscription credential + settings. Everything else the
+# agent writes itself (session state), so the dir must be writable.
+_CLAUDE_AUTH_FILES = (".credentials.json", "settings.json")
+
 # System directories the toolchain needs at runtime (read-only).
 _RO_SYSTEM_DIRS = ("/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc")
 
@@ -217,9 +222,10 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     # $OC_WHEELHOUSE) and the tiktoken encoding cache (offline token accounting).
     add(env.get("OC_WHEELHOUSE"))
     add(env.get("TIKTOKEN_CACHE_DIR"))
-    # Claude subscription auth — required or the agent refuses.
-    home = env.get("HOME") or os.path.expanduser("~")
-    add(os.path.join(home, ".claude"))
+    # NOTE: ~/.claude is intentionally NOT ro-bound at the real path here — the
+    # agent uses $HOME=/sandbox-home and build_sandbox_argv re-seeds a WRITABLE
+    # ~/.claude there (auth files ro). Binding the real dir read-only would just
+    # re-create the "read-only filesystem" trap for the agent's state writes.
     return binds
 
 
@@ -264,10 +270,19 @@ def build_sandbox_argv(
         if any(src == s or src.startswith(s + os.sep) for s in secret_paths):
             continue
         argv += ["--ro-bind", src, src]
-    # Re-seed the Claude auth dir INTO the tmpfs home (where the agent looks).
-    claude_auth = _real(os.path.join(env.get("HOME") or os.path.expanduser("~"), ".claude"))
-    if claude_auth:
-        argv += ["--ro-bind", claude_auth, f"{home}/.claude"]
+    # Re-seed Claude state into the tmpfs home as a WRITABLE ~/.claude. The agent
+    # writes session state there during a task (projects/, todos/, file-history/,
+    # history.jsonl, …); ro-binding the whole dir made every such write fail
+    # "read-only filesystem", so the agent couldn't do real work and the commit
+    # stage found nothing to commit. Only the auth + settings are bound read-only;
+    # the rest the agent creates fresh in the tmpfs (discarded with the sandbox).
+    claude_dir = _real(os.path.join(env.get("HOME") or os.path.expanduser("~"), ".claude"))
+    if claude_dir:
+        argv += ["--tmpfs", f"{home}/.claude"]
+        for fname in _CLAUDE_AUTH_FILES:
+            src = _real(os.path.join(claude_dir, fname))
+            if src:
+                argv += ["--ro-bind", src, f"{home}/.claude/{fname}"]
     # The one writable real path: the per-task ephemeral dir (workspace, the
     # plan bundle, the config copy, the result file — all under it). oc_root
     # itself is NOT bound, so .env secrets and the .git token stay outside.

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -68,6 +68,27 @@ class TestArgvContract:
         assert "/.aws" not in joined
         assert "/.gnupg" not in joined
 
+    def test_claude_home_is_writable_with_auth_ro(self, tmp_path: Path):
+        # ~/.claude must be a WRITABLE tmpfs in the sandbox (the agent writes its
+        # session state there); only the auth/settings are bound read-only.
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        (home / ".claude" / ".credentials.json").write_text("{}")
+        (home / ".claude" / "settings.json").write_text("{}")
+        # a big state dir that must NOT be whole-dir ro-bound
+        (home / ".claude" / "projects").mkdir()
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=ws, env={"HOME": str(home)})
+        joined = " ".join(argv)
+        # /sandbox-home/.claude is a tmpfs (writable), not a whole-dir ro-bind
+        assert "--tmpfs /sandbox-home/.claude" in joined
+        assert f"--ro-bind {home / '.claude'} /sandbox-home/.claude " not in joined + " "
+        # only the auth files are ro-bound, into the tmpfs
+        creds = home / ".claude" / ".credentials.json"
+        assert f"--ro-bind {creds} /sandbox-home/.claude/.credentials.json" in joined
+        assert "/sandbox-home/.claude/settings.json" in joined
+
     def test_workspace_is_the_only_writable_bind(self, tmp_path: Path):
         ws = tmp_path / "ws"
         ws.mkdir()


### PR DESCRIPTION
## THE root cause

Sandboxed tasks were failing at stage 5 "Commit changes and prepare PR" with a **read-only filesystem** error (surfaced by TeamExecutor #13/#14). Root cause: the sandbox ro-bound the **entire `~/.claude`** (1.8 GB) read-only to protect the subscription auth — but the claude agent **writes its working state there** during a task (`projects/`, `todos/`, `file-history/`, `history.jsonl`, shell snapshots). Every such write hit "read-only filesystem", so the agent couldn't do real work and the commit stage found nothing to commit.

Reproduced directly: `touch ~/.claude/projects/x` inside the sandbox → `Read-only file system`.

## Fix

`~/.claude` in the sandbox is now a **writable tmpfs**, with only the auth files (`.credentials.json`, `settings.json`) bound **read-only** into it:
- agent **reads** its credential (ro — can't be overwritten or tampered),
- agent **writes** all session state to the tmpfs (discarded when the sandbox tears down).

Also dropped the redundant real-path `~/.claude` ro-bind (the agent uses `$HOME=/sandbox-home`; binding the real dir read-only just re-created the same trap and wasted a 1.8 GB mount).

## Validation

Through the real `build_sandbox_argv`: `~/.claude/projects` + `file-history` are now **writable**; `.credentials.json` is **readable but read-only** (`CREDS_RO_GOOD`). 1 new test; **34 sandbox tests pass**; ruff + ty clean; audit clean.

This is the final sandbox-completeness fix — with it, the agent can actually make + commit + push changes inside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)