### PR TITLE
fix(sbx): put the workspace .venv/bin on PATH so the agent can run pytest/ruff

### DIFF
--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -290,8 +290,16 @@ def build_sandbox_argv(
     # Controlled env (already minimized by build_allowlist_env), HOME re-pointed
     # at the sandbox tmpfs home so secrets under the real HOME are unreachable.
     # Add the git HTTPS-token config so git@github remotes work without ~/.ssh
-    # (absent in the sandbox); no-op when no token is present.
-    setenv = {**env, **_git_auth_env(env)}
+    # (absent in the sandbox); no-op when no token is present. Also prepend the
+    # task workspace's .venv/bin to PATH so the agent can run `pytest`/`ruff`
+    # directly — the repo's dev tools live there (created by the bootstrap), and
+    # without this bare `pytest` is "command not found" and the agent reports it
+    # "cannot run tests" and the verify stage fails. The dir need not exist yet at
+    # build time (PATH is resolved at exec time, after the bootstrap creates it).
+    workspace = chdir if chdir is not None else rw_root
+    venv_bin = f"{workspace}/.venv/bin"
+    path_env = {"PATH": f"{venv_bin}:{env['PATH']}"} if env.get("PATH") else {}
+    setenv = {**env, **_git_auth_env(env), **path_env}
     for k, v in setenv.items():
         if v is None:
             continue

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -118,6 +118,17 @@ class TestArgvContract:
         )
         assert argv[-3:] == ["python", "-m", "x"]
 
+    def test_workspace_venv_bin_prepended_to_path(self, tmp_path: Path):
+        # The agent must run bare `pytest`/`ruff`; the workspace .venv/bin is
+        # prepended to PATH (resolved at exec time, after the bootstrap makes it).
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(
+            ["x"], oc_root=tmp_path, rw_root=tmp_path, env=_env(tmp_path), chdir=ws
+        )
+        path_val = argv[argv.index("PATH") + 1]
+        assert path_val.startswith(f"{ws}/.venv/bin:")
+
 
 class TestFailOpen:
     def test_disabled_returns_unchanged(self, tmp_path: Path):


### PR DESCRIPTION
## The layer (after #363)

With the read-only `~/.claude` fixed (#363), tasks advanced to **stage 3 "Run test suite and code quality checks"** and failed: the worker reported it *"cannot execute pytest, ruff … due to environment constraints"* and the verifier rejected it (*"Tests must be executed, not inferred"*).

**Root cause (confirmed):** the repo's dev tools live in the per-task workspace `.venv/bin` (created by the bootstrap, offline-installed via the wheelhouse), but that dir was **not on PATH**. So a bare `pytest`/`ruff` is "command not found" — and the budget team's weak implementer (haiku, effort low) gives up instead of discovering `.venv/bin/pytest`. Verified in the sandbox: `which pytest` → not found, only `.venv/bin/pytest` exists; the tools run fine when invoked explicitly.

## Fix

`build_sandbox_argv` prepends `<workspace>/.venv/bin` (the chdir target) to PATH. The dir needn't exist at build time — PATH resolves at exec time, after the bootstrap creates the venv. No-op when there's no workspace venv.

## Validation

Bare `pytest` now resolves to the workspace venv (`BARE_PYTEST_WORKS`). 1 new test; **35 sandbox tests pass**; ruff + ty clean; audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)