### PR TITLE
feat(sbx): Layer 3 — cgroup resource limits on the sandboxed executor

### DIFF
--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -20,6 +20,16 @@ from .sandbox import maybe_sandbox
 # turned on and observed (the staged rollout the trust-hardening §0.1 requires).
 _SANDBOX_ENV_FLAG = "OC_BWRAP_SANDBOX"
 
+# SBX Layer 3 (resource limits): gated on this flag. Wraps the executor in a
+# transient systemd-user cgroup scope with memory/pids/cpu caps + a wall-timeout
+# backstop, so a runaway/stuck sandboxed run can't exhaust the host. Defaults are
+# generous (cap runaways, don't throttle legit work) and env-overridable.
+_RLIMIT_ENV_FLAG = "OC_SANDBOX_RLIMITS"
+# systemd-run --user needs the user-bus vars; the minimized executor env drops
+# them, so we re-add ONLY these for the systemd-run hop (bwrap --clearenv keeps
+# them out of the sandbox).
+_USER_BUS_ENV = ("XDG_RUNTIME_DIR", "DBUS_SESSION_BUS_ADDRESS")
+
 logger = logging.getLogger(__name__)
 
 # Keep the persisted diagnostics bounded — enough to diagnose, not unbounded.
@@ -255,6 +265,29 @@ def persist_failure_diagnostics(
         return None
 
 
+def resource_limit_argv(cmd: Sequence[str], *, enabled: bool) -> list:
+    """Prepend a transient ``systemd-run --user --scope`` with cgroup caps
+    (memory/pids/cpu) + a ``RuntimeMaxSec`` wall-timeout, so a runaway or wedged
+    sandboxed executor can't exhaust the host. Gated on ``OC_SANDBOX_RLIMITS=1``,
+    **fail-open**: if disabled or ``systemd-run`` is unavailable it returns the
+    command unchanged (degrade, never halt — §0.1). Caps are env-overridable and
+    default generous (cap runaways, don't throttle legit work)."""
+    if not enabled or shutil.which("systemd-run") is None:
+        return list(cmd)
+    mem = os.environ.get("OC_RLIMIT_MEM", "8G")
+    tasks = os.environ.get("OC_RLIMIT_TASKS", "512")
+    cpu = os.environ.get("OC_RLIMIT_CPU_PCT", "400%")
+    wall = os.environ.get("OC_RLIMIT_WALL_SEC", "7200")
+    return [
+        "systemd-run", "--user", "--scope", "--quiet", "--collect",
+        "-p", f"MemoryMax={mem}",
+        "-p", f"TasksMax={tasks}",
+        "-p", f"CPUQuota={cpu}",
+        "-p", f"RuntimeMaxSec={wall}",
+        *cmd,
+    ]
+
+
 def run_executor(
     cmd: Sequence[str],
     *,
@@ -263,15 +296,24 @@ def run_executor(
     workspace: Path,
     env: dict,
 ) -> subprocess.CompletedProcess:
-    """Spawn the executor subprocess, optionally inside the bwrap sandbox.
+    """Spawn the executor subprocess, optionally inside the bwrap sandbox and a
+    resource-limited cgroup scope.
 
-    Centralizes the SBX Phase 2 wrap so dispatch's spawn sites stay one-liners.
-    The sandbox is gated on ``OC_BWRAP_SANDBOX=1`` and is fail-open: when off,
-    unavailable, or unconstructable it runs the command exactly as before. The
+    Centralizes the SBX wraps so dispatch's spawn sites stay one-liners. Both are
+    gated + fail-open: the bwrap sandbox on ``OC_BWRAP_SANDBOX=1`` (off/unavailable
+    => runs as before); the Layer-3 cgroup caps on ``OC_SANDBOX_RLIMITS=1``. The
     outer ``env`` is still passed (harmless: bwrap ``--clearenv`` + ``--setenv``
     re-establishes a controlled env inside; un-sandboxed it is the real env)."""
     enabled = os.environ.get(_SANDBOX_ENV_FLAG) == "1"
     run_cmd = maybe_sandbox(
         cmd, oc_root=oc_root, rw_root=rw_root, env=env, enabled=enabled, chdir=workspace
     )
-    return subprocess.run(run_cmd, cwd=oc_root, env=env, capture_output=True, text=True)
+    rlimits = os.environ.get(_RLIMIT_ENV_FLAG) == "1"
+    run_cmd = resource_limit_argv(run_cmd, enabled=rlimits)
+    run_env = env
+    if rlimits and run_cmd and run_cmd[0].endswith("systemd-run"):
+        # systemd-run --user needs the user-bus vars the minimized env drops;
+        # re-add ONLY those for the outer hop. bwrap --clearenv keeps them out of
+        # the sandbox; un-sandboxed they are harmless (not secrets).
+        run_env = {**env, **{k: os.environ[k] for k in _USER_BUS_ENV if k in os.environ}}
+    return subprocess.run(run_cmd, cwd=oc_root, env=run_env, capture_output=True, text=True)

--- a/tests/unit/entrypoints/board_worker/test_env_allowlist.py
+++ b/tests/unit/entrypoints/board_worker/test_env_allowlist.py
@@ -186,3 +186,34 @@ class TestEnvAllowlistPreservesFunction:
             env = build_allowlist_env(tmp_path, passthrough=("SOME_TOKEN",))
             assert "SOME_TOKEN" not in env
             assert "HOME" not in env  # not present → not added
+
+
+class TestResourceLimitArgv:
+    """SBX Layer 3: cgroup resource caps via systemd-run, gated + fail-open."""
+
+    def test_disabled_returns_unchanged(self):
+        assert sub.resource_limit_argv(["bwrap", "x"], enabled=False) == ["bwrap", "x"]
+
+    def test_no_systemd_run_returns_unchanged(self):
+        with mock.patch.object(sub.shutil, "which", return_value=None):
+            assert sub.resource_limit_argv(["bwrap", "x"], enabled=True) == ["bwrap", "x"]
+
+    def test_enabled_wraps_in_systemd_run_scope_with_caps(self, monkeypatch):
+        monkeypatch.setattr(sub.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+        monkeypatch.delenv("OC_RLIMIT_MEM", raising=False)
+        out = sub.resource_limit_argv(["bwrap", "x"], enabled=True)
+        assert out[0].endswith("systemd-run")
+        assert "--scope" in out and "--collect" in out
+        joined = " ".join(out)
+        assert "MemoryMax=8G" in joined  # default cap
+        assert "TasksMax=512" in joined
+        assert "RuntimeMaxSec=7200" in joined  # wall-timeout backstop
+        assert out[-2:] == ["bwrap", "x"]  # inner command appended
+
+    def test_caps_are_env_overridable(self, monkeypatch):
+        monkeypatch.setattr(sub.shutil, "which", lambda _n: "/usr/bin/systemd-run")
+        monkeypatch.setenv("OC_RLIMIT_MEM", "2G")
+        monkeypatch.setenv("OC_RLIMIT_WALL_SEC", "300")
+        joined = " ".join(sub.resource_limit_argv(["x"], enabled=True))
+        assert "MemoryMax=2G" in joined
+        assert "RuntimeMaxSec=300" in joined


### PR DESCRIPTION
## Closes the SBX Layer-3 gap (Phase 3)

The spec's **Layer 3 — resource limits (CPU + mem + pids + wall-timeout)** was unimplemented. `run_executor` wraps the (already-bwrapped) command in a transient **`systemd-run --user --scope`** with `MemoryMax`/`TasksMax`/`CPUQuota` + a **`RuntimeMaxSec` wall-timeout** backstop. cgroup caps apply to bwrap and its whole subtree, so a runaway or wedged sandboxed run can't exhaust the host (`run_executor` itself has no outer timeout — we observed tasks stuck 30–50 min).

- **`resource_limit_argv(cmd, enabled)`** — systemd-run prefix; gated on `OC_SANDBOX_RLIMITS=1`, **fail-open** (disabled or `systemd-run` absent → command unchanged, §0.1). Caps env-overridable (`OC_RLIMIT_MEM=8G`, `_TASKS=512`, `_CPU_PCT=400%`, `_WALL_SEC=7200`) — generous defaults: cap runaways, don't throttle legit work.
- `run_executor` re-adds only `XDG_RUNTIME_DIR` + `DBUS_SESSION_BUS_ADDRESS` for the systemd-run hop (the minimized env drops them and `--user` needs the user bus); bwrap `--clearenv` keeps them out of the sandbox.

## Validation

Real run executes inside the scope+bwrap with env intact (`SECRET` re-`--setenv`'d correctly); the scope sets `memory.max`; fail-open verified (off / no systemd-run → unchanged). 4 new tests; ruff + ty clean; audit clean.

Off-by-default + fail-open → staged rollout (enable with `OC_SANDBOX_RLIMITS=1`), same as the bwrap/egress rollouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)