### PR TITLE
feat(sbx): controller-tier egress-boundary probe (D-OP-2)

### DIFF
--- a/src/operations_center/entrypoints/maintenance/egress_probe.py
+++ b/src/operations_center/entrypoints/maintenance/egress_probe.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
 """Controller-tier egress-proxy health probe (Harness Trust-Hardening, D-OP-2).
 
 The sandboxed executor reaches the network only through the L7/SNI allowlist

--- a/src/operations_center/entrypoints/maintenance/egress_probe.py
+++ b/src/operations_center/entrypoints/maintenance/egress_probe.py
@@ -1,0 +1,206 @@
+"""Controller-tier egress-proxy health probe (Harness Trust-Hardening, D-OP-2).
+
+The sandboxed executor reaches the network only through the L7/SNI allowlist
+egress proxy (``OC_EGRESS_PROXY``). That proxy is the load-bearing network
+boundary, so its enforcement must be *actively* asserted rather than assumed.
+
+This maintenance task runs at controller tier (outside the sandbox, where the
+proxy config and direct loopback access live) and issues two synthetic probes
+each cycle:
+
+* an **allowlisted** destination (``github.com``) — expected to tunnel through;
+* a **denied** destination (``example.com``) — expected to be refused (403).
+
+It then classifies the outcome:
+
+* both as expected → ``ok`` (boundary healthy);
+* allowlisted destination **refused** → *rot*: the proxy is broken or its
+  allowlist regressed, silently strangling the fleet's legitimate egress;
+* denied destination **allowed** → *breach*: the allowlist is not being
+  enforced, so the containment boundary is open.
+
+Either fault auto-opens a fix task on the board (deduplicated by title so a
+persistent fault does not spam the backlog). If the proxy itself is unreachable
+the probe returns ``skipped`` — fail-open by design (§0.1 degrade-never-halt):
+a restarting/absent proxy is a supervisor concern, not boundary rot.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING, Any, Literal
+
+from operations_center.maintenance.contracts import MaintenanceResult
+
+if TYPE_CHECKING:
+    from operations_center.adapters.plane.client import PlaneClient
+    from operations_center.maintenance.contracts import MaintenanceContext
+
+DEFAULT_INTERVAL_SECONDS = 300
+_PROXY_ENV = "OC_EGRESS_PROXY"
+_ALLOW_HOST = "github.com"
+_DENY_HOST = "example.com"
+_FIX_TITLE_PREFIX = "[egress-probe] proxy boundary fault"
+_FIX_LABELS = ("kind:improve", "repo:OperationsCenter", "source:egress-probe")
+_TERMINAL_STATES = {"done", "cancelled", "canceled"}
+
+# Outcome of a single synthetic probe through the proxy.
+ProbeOutcome = Literal["allowed", "denied", "proxy_down"]
+
+
+def _http_probe(proxy: str, host: str, *, timeout: float = 8.0) -> ProbeOutcome:
+    """Probe ``host`` through ``proxy``; classify the proxy's verdict.
+
+    ``allowed``    — the proxy tunnelled the CONNECT (any HTTP response came back).
+    ``denied``     — the proxy refused the host (403 / ProxyError on CONNECT).
+    ``proxy_down`` — the proxy endpoint itself was unreachable (fail-open signal).
+    """
+    import httpx
+
+    try:
+        with httpx.Client(proxy=proxy, timeout=timeout, verify=True) as client:
+            client.get(f"https://{host}/")
+        return "allowed"
+    except httpx.ProxyError:
+        # The proxy actively refused the tunnel (allowlist DENY → 403).
+        return "denied"
+    except httpx.ConnectError as exc:
+        # Distinguish "cannot reach the proxy" (down) from a refused upstream.
+        text = str(exc).lower()
+        if "proxy" in text or "refused" in text or "127.0.0.1" in text:
+            return "proxy_down"
+        return "denied"
+    except httpx.HTTPError:
+        # Any other transport-level failure: treat as a denied/unusable path.
+        return "denied"
+
+
+class EgressProbeTask:
+    """Active synthetic probe asserting the egress boundary still enforces."""
+
+    name = "egress_probe"
+
+    def __init__(
+        self,
+        settings: Any,
+        *,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+        enabled: bool = True,
+        allow_host: str = _ALLOW_HOST,
+        deny_host: str = _DENY_HOST,
+        probe_fn: Any = None,
+        plane_client: PlaneClient | None = None,
+    ) -> None:
+        self._settings = settings
+        self.interval_seconds = interval_seconds
+        self.enabled = enabled
+        self._allow_host = allow_host
+        self._deny_host = deny_host
+        self._probe = probe_fn or _http_probe
+        self._plane_client = plane_client
+
+    def _make_plane_client(self) -> PlaneClient:
+        if self._plane_client is not None:
+            return self._plane_client
+        from operations_center.adapters.plane.client import PlaneClient
+
+        p = self._settings.plane
+        return PlaneClient(
+            base_url=p.base_url,
+            api_token=self._settings.plane_token(),
+            workspace_slug=p.workspace_slug,
+            project_id=p.project_id,
+        )
+
+    def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
+        started = time.monotonic()
+        proxy = os.environ.get(_PROXY_ENV)
+        if not proxy:
+            return self._result(
+                "skipped", started, {"reason": f"{_PROXY_ENV} not configured"}
+            )
+
+        allow = self._probe(proxy, self._allow_host)
+        if allow == "proxy_down":
+            # Fail-open: the proxy is unreachable (restarting/absent). Not rot —
+            # the supervisor owns liveness; do not raise a boundary fault.
+            return self._result(
+                "skipped", started, {"reason": "egress proxy unreachable", "proxy": proxy}
+            )
+        deny = self._probe(proxy, self._deny_host)
+
+        rot = allow == "denied"  # an allowlisted destination is being refused
+        breach = deny == "allowed"  # a denied destination is being let through
+        details: dict[str, object] = {
+            "proxy": proxy,
+            "allow_host": self._allow_host,
+            "allow_result": allow,
+            "deny_host": self._deny_host,
+            "deny_result": deny,
+        }
+
+        if not (rot or breach):
+            return self._result("ok", started, details)
+
+        faults = []
+        if rot:
+            faults.append(
+                f"allowlisted host {self._allow_host} was DENIED by the egress proxy"
+            )
+        if breach:
+            faults.append(
+                f"denied host {self._deny_host} was ALLOWED through the egress proxy"
+            )
+        details["faults"] = faults
+        details["fix_task"] = self._open_fix_task(ctx, faults)
+        return self._result("failed", started, details, error="; ".join(faults))
+
+    def _open_fix_task(self, ctx: MaintenanceContext, faults: list[str]) -> str:
+        """Open (or reuse) a board fix task for the boundary fault."""
+        client = ctx.resources.get("plane_client") or self._make_plane_client()
+        try:
+            for issue in client.list_issues():
+                name = str(issue.get("name", ""))
+                if not name.startswith(_FIX_TITLE_PREFIX):
+                    continue
+                state = issue.get("state")
+                state_name = (
+                    state.get("name", "") if isinstance(state, dict) else str(state or "")
+                )
+                if state_name.strip().lower() not in _TERMINAL_STATES:
+                    return f"exists:{issue.get('id')}"
+
+            body = (
+                "The controller-tier egress probe detected a fault in the "
+                "sandbox network boundary (OC_EGRESS_PROXY):\n\n"
+                + "\n".join(f"- {f}" for f in faults)
+                + "\n\nThe egress proxy is the load-bearing containment boundary "
+                "for the sandboxed executor. Investigate the proxy service "
+                "(oc-egress-proxy.service) and its allowlist, then resolve the "
+                "regression. Auto-filed by EgressProbeTask (D-OP-2)."
+            )
+            created = client.create_issue(
+                name=f"{_FIX_TITLE_PREFIX}: {faults[0]}"[:200],
+                description=body,
+                label_names=list(_FIX_LABELS),
+            )
+            return f"created:{created.get('id')}"
+        except Exception as exc:  # noqa: BLE001 — never let task-filing halt the loop
+            return f"file_failed:{exc}"
+
+    def _result(
+        self,
+        status: Literal["ok", "skipped", "failed"],
+        started: float,
+        details: dict[str, object],
+        *,
+        error: str | None = None,
+    ) -> MaintenanceResult:
+        return MaintenanceResult(
+            name=self.name,
+            status=status,
+            duration_seconds=time.monotonic() - started,
+            details=details,
+            error=error,
+        )

--- a/src/operations_center/entrypoints/spec_hygiene/main.py
+++ b/src/operations_center/entrypoints/spec_hygiene/main.py
@@ -36,6 +36,7 @@ from operations_center.maintenance import (
     MaintenanceResult,
 )
 from operations_center.entrypoints.maintenance.board_unblock_task import BoardUnblockTask
+from operations_center.entrypoints.maintenance.egress_probe import EgressProbeTask
 from operations_center.maintenance.ledger_maintain import LedgerMaintainTask
 from operations_center.spec_author.campaign_builder import CampaignBuilder
 from operations_center.spec_author.models import (
@@ -665,6 +666,12 @@ def register_maintenance_tasks(
     # stuck/Blocked tasks; registering it here makes the controller self-heal the
     # board every cycle with no human in the loop (HARNESS_TRUST_HARDENING §0.1).
     registry.register(BoardUnblockTask(settings))
+    # Controller-tier egress-boundary probe (HARNESS_TRUST_HARDENING D-OP-2).
+    # Actively asserts the sandbox's egress proxy still tunnels allowlisted
+    # destinations and still refuses denied ones; a regression (rot or breach)
+    # auto-opens a fix task. Runs outside the sandbox where the proxy config and
+    # loopback live; skipped (fail-open) when no proxy is configured.
+    registry.register(EgressProbeTask(settings, plane_client=client))
     return registry
 
 

--- a/tests/unit/entrypoints/maintenance/test_egress_probe.py
+++ b/tests/unit/entrypoints/maintenance/test_egress_probe.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
 """Tests for the controller-tier egress-boundary probe (D-OP-2)."""
 
 from __future__ import annotations

--- a/tests/unit/entrypoints/maintenance/test_egress_probe.py
+++ b/tests/unit/entrypoints/maintenance/test_egress_probe.py
@@ -1,0 +1,215 @@
+"""Tests for the controller-tier egress-boundary probe (D-OP-2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from operations_center.entrypoints.maintenance.egress_probe import (
+    EgressProbeTask,
+    _http_probe,
+)
+from operations_center.maintenance.contracts import MaintenanceContext
+
+_PROXY = "http://127.0.0.1:8889"
+
+
+def _ctx(plane_client=None) -> MaintenanceContext:
+    resources = {"plane_client": plane_client} if plane_client is not None else {}
+    return MaintenanceContext(
+        cycle_id="c", now=datetime(2026, 6, 21, tzinfo=UTC), resources=resources
+    )
+
+
+class _FakePlane:
+    """Minimal Plane stub recording created issues + serving existing ones."""
+
+    def __init__(self, existing: list[dict] | None = None) -> None:
+        self.existing = existing or []
+        self.created: list[dict] = []
+
+    def list_issues(self) -> list[dict]:
+        return self.existing
+
+    def create_issue(self, *, name, description, label_names=None):
+        issue = {"id": f"new-{len(self.created)}", "name": name}
+        self.created.append(
+            {"name": name, "description": description, "labels": label_names}
+        )
+        return issue
+
+
+def _probe(mapping: dict[str, str]):
+    """Build a probe_fn returning a fixed outcome per host."""
+
+    def _fn(proxy, host, **_):
+        assert proxy == _PROXY
+        return mapping[host]
+
+    return _fn
+
+
+def test_skipped_when_no_proxy_configured(monkeypatch):
+    monkeypatch.delenv("OC_EGRESS_PROXY", raising=False)
+    task = EgressProbeTask(settings=None, probe_fn=_probe({}))
+    result = task.run_once(_ctx())
+    assert result.status == "skipped"
+    assert "not configured" in result.details["reason"]
+
+
+def test_healthy_boundary_is_ok(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane()
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "allowed", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "ok"
+    assert result.details["allow_result"] == "allowed"
+    assert result.details["deny_result"] == "denied"
+    assert plane.created == []
+
+
+def test_proxy_down_is_skipped_fail_open(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane()
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "proxy_down", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "skipped"
+    assert "unreachable" in result.details["reason"]
+    assert plane.created == []
+
+
+def test_rot_allowlisted_denied_opens_fix_task(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane()
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "denied", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "failed"
+    assert "DENIED" in result.error
+    assert len(plane.created) == 1
+    assert plane.created[0]["name"].startswith("[egress-probe] proxy boundary fault")
+    assert result.details["fix_task"].startswith("created:")
+
+
+def test_breach_denied_allowed_opens_fix_task(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane()
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "allowed", "example.com": "allowed"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "failed"
+    assert "ALLOWED" in result.error
+    assert len(plane.created) == 1
+
+
+def test_existing_open_fault_is_not_duplicated(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane(
+        existing=[
+            {
+                "id": "abc",
+                "name": "[egress-probe] proxy boundary fault: old",
+                "state": {"name": "In Progress"},
+            }
+        ]
+    )
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "denied", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "failed"
+    assert plane.created == []
+    assert result.details["fix_task"] == "exists:abc"
+
+
+def test_terminal_fault_does_not_suppress_new_task(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+    plane = _FakePlane(
+        existing=[
+            {
+                "id": "old",
+                "name": "[egress-probe] proxy boundary fault: resolved",
+                "state": {"name": "Done"},
+            }
+        ]
+    )
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "denied", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(plane))
+    assert result.status == "failed"
+    assert len(plane.created) == 1
+
+
+def test_file_failure_does_not_raise(monkeypatch):
+    monkeypatch.setenv("OC_EGRESS_PROXY", _PROXY)
+
+    class _Broken:
+        def list_issues(self):
+            raise RuntimeError("plane down")
+
+    task = EgressProbeTask(
+        settings=None,
+        probe_fn=_probe({"github.com": "denied", "example.com": "denied"}),
+    )
+    result = task.run_once(_ctx(_Broken()))
+    assert result.status == "failed"
+    assert result.details["fix_task"].startswith("file_failed:")
+
+
+def test_http_probe_classifies_httpx_errors(monkeypatch):
+    import httpx
+
+    calls = {}
+
+    class _Client:
+        def __init__(self, **kw):
+            calls.update(kw)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url):
+            if "deny" in url:
+                raise httpx.ProxyError("403 Forbidden")
+            if "down" in url:
+                raise httpx.ConnectError("All connection attempts to proxy failed")
+            return None
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    assert _http_probe(_PROXY, "allow.test") == "allowed"
+    assert _http_probe(_PROXY, "deny.test") == "denied"
+    assert _http_probe(_PROXY, "down.test") == "proxy_down"
+    assert calls["proxy"] == _PROXY
+
+
+def test_satisfies_maintenance_task_protocol():
+    from operations_center.maintenance.contracts import MaintenanceTask
+
+    task = EgressProbeTask(settings=None)
+    assert isinstance(task, MaintenanceTask)
+    assert task.name == "egress_probe"
+    assert task.interval_seconds > 0
+    assert task.enabled is True
+
+
+def test_registers_in_a_maintenance_registry():
+    from operations_center.maintenance.registry import MaintenanceRegistry
+
+    registry = MaintenanceRegistry()
+    registry.register(EgressProbeTask(settings=None))
+    assert "egress_probe" in {t.name for t in registry.list_tasks()}


### PR DESCRIPTION
## What

Closes the **D-OP-2 controller-tier synthetic probe** item of Phase 3 (SBX network containment) in `HARNESS_TRUST_HARDENING`.

`EgressProbeTask` actively asserts the sandbox's egress proxy still enforces its allowlist, rather than assuming it. The proxy (`OC_EGRESS_PROXY`) is the load-bearing network boundary for the sandboxed executor, so its enforcement is now verified every maintenance cycle at **controller tier** — outside the sandbox, where the proxy config and loopback access live.

## How

Each cycle it issues two synthetic probes through the proxy and classifies the result:

| allowlisted (`github.com`) | denied (`example.com`) | verdict |
|---|---|---|
| tunnels ✅ | refused (403) ✅ | `ok` — boundary healthy |
| **DENIED** | — | `failed` — **rot** (proxy/allowlist regression strangling legit egress) |
| — | **ALLOWED** | `failed` — **breach** (allowlist not enforced; boundary open) |
| proxy unreachable | — | `skipped` — fail-open (§0.1; liveness is a supervisor concern) |

On rot/breach it auto-opens a **deduplicated** board fix task (title-prefix dedup vs non-terminal state) so a persistent fault doesn't spam the backlog. No proxy configured → `skipped`.

Registered in `register_maintenance_tasks` beside the other controller-tier self-heal loops (SpecHygiene, Ledger, BoardUnblock).

## Tests

11 new unit tests: healthy/rot/breach classification, fail-open on proxy-down + no-proxy, dedup vs open task, no-suppress vs terminal-state task, file-failure resilience, httpx error→outcome mapping, and protocol + registry wiring. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)