### PR TITLE
feat(eval): operator offline answer-key signing CLI

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,24 @@
+## 2026-06-21 — Phase 4 (EVAL) operator signing CLI (offline answer-key tool)
+
+Added `operations_center.eval.sign` — the tool the OPERATOR runs OFFLINE to anchor
+the EVAL answer key (the one irreducibly-human step). Declined to generate/hold the
+signing key in-session: a key generated on a fleet-reachable host, by the agent that
+builds the eval, would collapse the un-forgeable anchor the whole design depends on
+(self-dealing + a label-forging key next to the attacker). Built the tooling instead
+so the operator's manual step is one command; key generation + custody stay with them.
+
+- `corpus.write_ledger` — re-chain helper (signing a candidate changes its hash, so
+  the chain after it is recomputed).
+- `sign keygen` — generate an Ed25519 keypair offline; writes the PEM private key,
+  prints the public hex to paste into `operator_pubkey.ed25519`.
+- `sign sign --private <pem> --ledger ...` — converts unsigned candidates into signed
+  graded cases (idempotent; `--case-id` to limit), rewriting the chain.
+
+Verified end-to-end with a THROWAWAY ephemeral key (never committed, shredded after):
+report-only (0 graded) → sign 7 seeds → gate graduates to **blocking**, all pass;
+and a tamper (flip a signed answer in place) is caught — `entry_hash mismatch`,
+RESULT FAIL. 41 eval unit tests; ruff/ty/D12 clean.
+
 ## 2026-06-21 — Phase 4 (EVAL) scaffolding stood up
 
 Built the self-healing agent-quality guard's machinery (everything buildable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,8 +196,9 @@ extend-select = [
 "tools/**/test_*.py" = ["S101"]
 # Root-level verification scripts
 "verify_stage3.py" = ["T201"]
-# EVAL verify CLI prints its integrity report; the seed script is dev tooling.
+# EVAL verify + operator-signing CLIs print; the seed script is dev tooling.
 "src/operations_center/eval/verify.py" = ["T201"]
+"src/operations_center/eval/sign.py" = ["T201"]
 "eval/**/*.py" = ["T201", "BLE001"]
 
 [tool.ty.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ operations-center-reconcile-merged-tasks = "operations_center.entrypoints.mainte
 # identically past a threshold (env/transport, not code), escalate to the
 # operator ledger and suppress re-proposal via the existing rejection store.
 operations-center-detect-convergence-stall = "operations_center.entrypoints.maintenance.detect_convergence_stall:main"
+# EVAL answer-key signing CLI — Ed25519 sign/verify for eval operator workflow.
+operations-center-eval-sign             = "operations_center.eval.sign:main"
 
 [project.entry-points."pytest11"]
 flaky-detection = "operations_center.observer.pytest_flaky_plugin"

--- a/src/operations_center/eval/corpus.py
+++ b/src/operations_center/eval/corpus.py
@@ -190,6 +190,27 @@ def append_case(path: Path, case: Case) -> LedgerEntry:
     return entry
 
 
+def write_ledger(path: Path, cases: list[Case]) -> None:
+    """Rewrite the entire ledger from scratch, re-chaining from genesis.
+
+    Used by the operator signing tool to convert candidates into signed graded
+    entries: adding a signature changes an entry's payload (hence its
+    ``entry_hash``), so every following entry's ``prev_hash`` must be recomputed.
+    The result is a fresh, internally-consistent chain. (Legitimate because the
+    rewrite is operator-authored and CODEOWNERS-gated; an out-of-band edit that
+    forgets to re-chain still reds ``verify_chain``.)"""
+    prev = GENESIS_PREV_HASH
+    lines: list[str] = []
+    for case in cases:
+        entry_hash = compute_entry_hash(case.payload(), prev)
+        record = dict(case.payload())
+        record["prev_hash"] = prev
+        record["entry_hash"] = entry_hash
+        lines.append(json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=False))
+        prev = entry_hash
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
 __all__ = [
     "GENESIS_PREV_HASH",
     "Case",
@@ -202,4 +223,5 @@ __all__ = [
     "gradeable_view",
     "load_ledger",
     "verify_chain",
+    "write_ledger",
 ]

--- a/src/operations_center/eval/sign.py
+++ b/src/operations_center/eval/sign.py
@@ -27,10 +27,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-    Ed25519PrivateKey,
-    Ed25519PublicKey,
-)
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     NoEncryption,
@@ -65,10 +62,6 @@ def load_private_key(path: Path) -> Ed25519PrivateKey:
             raise ValueError("PEM is not an Ed25519 private key")
         return key
     return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(text.split()[0]))
-
-
-def public_key_of(private_key: Ed25519PrivateKey) -> Ed25519PublicKey:
-    return private_key.public_key()
 
 
 def sign_ledger(

--- a/src/operations_center/eval/sign.py
+++ b/src/operations_center/eval/sign.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Operator answer-key signing CLI (HARNESS_TRUST_HARDENING §4.2, D-OP-3).
+
+This is the tool the **operator** runs **offline** to perform the one irreducibly
+human step in the whole trust-hardening spec: anchoring the EVAL answer key. It
+deliberately does NOT live in any fleet/controller code path — nothing automated
+ever calls it, and the private key it consumes must never touch a fleet host.
+
+Two subcommands:
+
+* ``keygen`` — generate a fresh Ed25519 keypair. Writes the PRIVATE key to a file
+  you keep offline, and prints the PUBLIC key hex to paste into
+  ``eval/constitution/operator_pubkey.ed25519``. Run this on an air-gapped / local
+  machine, not on a fleet host.
+* ``sign`` — using your offline private key, convert unsigned candidate cases in
+  the ledger into signed graded cases (re-chaining the ledger). Commit the result;
+  CI then counts them toward the gate.
+
+Security note: the signing key is the entire root of trust for EVAL. If it leaks to
+a fleet host, a compromised agent could forge answer-key labels — exactly the
+attack the design prevents. Keep it offline; its only use is here."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    load_pem_private_key,
+)
+
+from operations_center.eval.corpus import (
+    load_ledger,
+    verify_chain,
+    write_ledger,
+)
+from operations_center.eval.signing import is_graded, sign_case
+
+
+def generate_keypair(private_out: Path) -> str:
+    """Write a new Ed25519 private key (PEM) to ``private_out``; return pubkey hex."""
+    key = Ed25519PrivateKey.generate()
+    private_out.write_bytes(
+        key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    )
+    return key.public_key().public_bytes_raw().hex()
+
+
+def load_private_key(path: Path) -> Ed25519PrivateKey:
+    """Load an Ed25519 private key from a PEM file or a 64-hex-char raw file."""
+    data = path.read_bytes()
+    text = data.decode("utf-8", "ignore").strip()
+    if "BEGIN" in text and "PRIVATE KEY" in text:
+        key = load_pem_private_key(data, password=None)
+        if not isinstance(key, Ed25519PrivateKey):
+            raise ValueError("PEM is not an Ed25519 private key")
+        return key
+    return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(text.split()[0]))
+
+
+def public_key_of(private_key: Ed25519PrivateKey) -> Ed25519PublicKey:
+    return private_key.public_key()
+
+
+def sign_ledger(
+    ledger_path: Path,
+    private_key: Ed25519PrivateKey,
+    *,
+    signer: str,
+    case_ids: set[str] | None = None,
+) -> list[str]:
+    """Sign unsigned candidate cases (all, or just ``case_ids``); rewrite the chain.
+
+    Already-graded cases are left untouched (idempotent). Returns the case_ids that
+    were newly signed."""
+    ledger = load_ledger(ledger_path)
+    verify_chain(ledger)
+    pub = private_key.public_key()
+    newly_signed: list[str] = []
+    out_cases = []
+    for case in ledger.cases():
+        target = case_ids is None or case.case_id in case_ids
+        if target and not is_graded(case, pub):
+            case = sign_case(case, private_key, signer=signer)
+            newly_signed.append(case.case_id)
+        out_cases.append(case)
+    write_ledger(ledger_path, out_cases)
+    return newly_signed
+
+
+def _cmd_keygen(args: argparse.Namespace) -> int:
+    if args.private_out.exists() and not args.force:
+        print(f"refusing to overwrite existing {args.private_out} (use --force)")
+        return 1
+    pubhex = generate_keypair(args.private_out)
+    print(f"private key written to {args.private_out} — KEEP THIS OFFLINE.")
+    print("public key (paste as the sole first line of "
+          "eval/constitution/operator_pubkey.ed25519):")
+    print(pubhex)
+    return 0
+
+
+def _cmd_sign(args: argparse.Namespace) -> int:
+    key = load_private_key(args.private)
+    ids = set(args.case_id) if args.case_id else None
+    signed = sign_ledger(args.ledger, key, signer=args.signer, case_ids=ids)
+    print(f"signed {len(signed)} case(s): {', '.join(signed) if signed else '(none new)'}")
+    print(f"public key hex: {key.public_key().public_bytes_raw().hex()}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="EVAL operator answer-key signing (offline).")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    kg = sub.add_parser("keygen", help="generate an offline Ed25519 keypair")
+    kg.add_argument("--private-out", type=Path, default=Path("operator_priv.pem"))
+    kg.add_argument("--force", action="store_true")
+    kg.set_defaults(func=_cmd_keygen)
+
+    sg = sub.add_parser("sign", help="sign candidate cases with your offline key")
+    sg.add_argument("--private", type=Path, required=True)
+    sg.add_argument("--ledger", type=Path, default=Path("eval/corpus/ledger.jsonl"))
+    sg.add_argument("--signer", default="operator")
+    sg.add_argument("--case-id", action="append", help="limit to these case_ids (repeatable)")
+    sg.set_defaults(func=_cmd_sign)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/eval/test_sign.py
+++ b/tests/unit/eval/test_sign.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Operator signing CLI: keygen, candidate→graded conversion, re-chaining."""
+
+from __future__ import annotations
+
+from operations_center.eval.corpus import (
+    Case,
+    append_case,
+    load_ledger,
+    verify_chain,
+)
+from operations_center.eval.sign import (
+    generate_keypair,
+    load_private_key,
+    main,
+    sign_ledger,
+)
+from operations_center.eval.signing import is_graded, load_public_key
+
+
+def _case(cid: str) -> Case:
+    return Case(
+        case_id=cid,
+        kind="verdict",
+        input={"checks": [{"check_id": "code_quality", "status": "fail"},
+                          {"check_id": "no_tooling_artifacts", "status": "pass"}]},
+        ground_truth={"result": "CONCERNS", "failing": ["code_quality"]},
+    )
+
+
+def test_keygen_roundtrip(tmp_path):
+    priv = tmp_path / "operator_priv.pem"
+    pubhex = generate_keypair(priv)
+    assert priv.exists()
+    assert len(bytes.fromhex(pubhex)) == 32
+    key = load_private_key(priv)
+    assert key.public_key().public_bytes_raw().hex() == pubhex
+
+
+def test_sign_ledger_grades_candidates_and_keeps_chain_valid(tmp_path):
+    priv = tmp_path / "k.pem"
+    pubhex = generate_keypair(priv)
+    key = load_private_key(priv)
+    ledger_path = tmp_path / "ledger.jsonl"
+    append_case(ledger_path, _case("a"))
+    append_case(ledger_path, _case("b"))
+
+    # Before: both candidates.
+    pub = load_public_key_from_hex(tmp_path, pubhex)
+    assert not any(is_graded(c, pub) for c in load_ledger(ledger_path).cases())
+
+    signed = sign_ledger(ledger_path, key, signer="operator")
+    assert set(signed) == {"a", "b"}
+
+    ledger = load_ledger(ledger_path)
+    verify_chain(ledger)  # re-chained correctly
+    assert all(is_graded(c, pub) for c in ledger.cases())
+    assert all(c.signer == "operator" for c in ledger.cases())
+
+
+def test_sign_ledger_is_idempotent(tmp_path):
+    priv = tmp_path / "k.pem"
+    generate_keypair(priv)
+    key = load_private_key(priv)
+    ledger_path = tmp_path / "ledger.jsonl"
+    append_case(ledger_path, _case("a"))
+    assert sign_ledger(ledger_path, key, signer="op") == ["a"]
+    assert sign_ledger(ledger_path, key, signer="op") == []  # already graded
+
+
+def test_sign_ledger_limits_to_case_ids(tmp_path):
+    priv = tmp_path / "k.pem"
+    pubhex = generate_keypair(priv)
+    key = load_private_key(priv)
+    ledger_path = tmp_path / "ledger.jsonl"
+    append_case(ledger_path, _case("a"))
+    append_case(ledger_path, _case("b"))
+    signed = sign_ledger(ledger_path, key, signer="op", case_ids={"b"})
+    assert signed == ["b"]
+    pub = load_public_key_from_hex(tmp_path, pubhex)
+    graded = {c.case_id for c in load_ledger(ledger_path).cases() if is_graded(c, pub)}
+    assert graded == {"b"}
+
+
+def test_cli_keygen_then_sign(tmp_path, capsys):
+    priv = tmp_path / "priv.pem"
+    rc = main(["keygen", "--private-out", str(priv)])
+    assert rc == 0
+    pubhex = capsys.readouterr().out.strip().splitlines()[-1]
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    append_case(ledger_path, _case("a"))
+    rc = main(["sign", "--private", str(priv), "--ledger", str(ledger_path), "--signer", "op"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "signed 1 case" in out
+    assert pubhex in out
+
+
+def test_cli_keygen_refuses_overwrite(tmp_path):
+    priv = tmp_path / "priv.pem"
+    priv.write_text("existing")
+    assert main(["keygen", "--private-out", str(priv)]) == 1
+
+
+def load_public_key_from_hex(tmp_path, pubhex):
+    p = tmp_path / "pub.ed25519"
+    p.write_text(pubhex + "\n")
+    return load_public_key(p)

--- a/tests/unit/eval/test_sign.py
+++ b/tests/unit/eval/test_sign.py
@@ -47,7 +47,7 @@ def test_sign_ledger_grades_candidates_and_keeps_chain_valid(tmp_path):
     append_case(ledger_path, _case("b"))
 
     # Before: both candidates.
-    pub = load_public_key_from_hex(tmp_path, pubhex)
+    pub = _pubkey_from_hex(tmp_path, pubhex)
     assert not any(is_graded(c, pub) for c in load_ledger(ledger_path).cases())
 
     signed = sign_ledger(ledger_path, key, signer="operator")
@@ -78,7 +78,7 @@ def test_sign_ledger_limits_to_case_ids(tmp_path):
     append_case(ledger_path, _case("b"))
     signed = sign_ledger(ledger_path, key, signer="op", case_ids={"b"})
     assert signed == ["b"]
-    pub = load_public_key_from_hex(tmp_path, pubhex)
+    pub = _pubkey_from_hex(tmp_path, pubhex)
     graded = {c.case_id for c in load_ledger(ledger_path).cases() if is_graded(c, pub)}
     assert graded == {"b"}
 
@@ -104,7 +104,7 @@ def test_cli_keygen_refuses_overwrite(tmp_path):
     assert main(["keygen", "--private-out", str(priv)]) == 1
 
 
-def load_public_key_from_hex(tmp_path, pubhex):
+def _pubkey_from_hex(tmp_path, pubhex):
     p = tmp_path / "pub.ed25519"
     p.write_text(pubhex + "\n")
     return load_public_key(p)


### PR DESCRIPTION
## What

Adds `operations_center.eval.sign` — the tool the **operator** runs **offline** to perform the one irreducibly-human step in the trust-hardening spec: anchoring the EVAL answer key so the gate can graduate from report-only to blocking.

This is the deliberate completion of the human-anchor seam left by #369. It is **not** automated and **not** called by any fleet/controller path — the private key it consumes must never touch a fleet host (a key reachable by a compromised agent could forge answer-key labels, which is the exact attack the design prevents).

## Subcommands

- **`keygen`** — generate an Ed25519 keypair. Writes the PEM private key (you keep it offline) and prints the public-key hex to paste into `eval/constitution/operator_pubkey.ed25519`.
- **`sign`** — convert unsigned candidate cases into signed graded cases with your offline private key (idempotent; `--case-id` to limit which). Re-chains the ledger via the new `corpus.write_ledger` (adding a signature changes an entry's hash, so the chain after it is recomputed) — `verify_chain` still validates the result.

## Why a CLI instead of just doing it

I declined to generate or hold the signing key in-session. A key generated on a fleet-reachable host, by the agent that builds the eval, would collapse the un-forgeable anchor the whole design rests on (self-dealing + a label-forging key sitting next to the attacker). The tooling keeps key generation and custody with the operator while making their manual step a single command.

## Verified end-to-end (throwaway ephemeral key, never committed)

```
report-only: 0/7 signed → gate report-only, all 7 candidates pass
keygen → sign 7 seeds
after: 7 graded → gate [blocking]: all graded cases pass and floor is cleared
tamper (flip a signed answer in place) → TAMPER: entry_hash mismatch, RESULT FAIL
```

41 eval unit tests (keygen roundtrip, candidate→graded conversion, idempotency, case-id limiting, CLI flows). ruff / ty / Custodian D12 clean.

## Operator runbook (to graduate the real gate, when ready)

1. **Offline:** `python -m operations_center.eval.sign keygen --private-out operator_priv.pem` → keep `operator_priv.pem` off all fleet hosts.
2. Paste the printed public hex as the sole first line of `eval/constitution/operator_pubkey.ed25519`.
3. Review the candidate cases, then `python -m operations_center.eval.sign sign --private operator_priv.pem` (after adding cases to reach `min_graded_cases`).
4. Commit the pubkey + signed ledger. CI flips the gate to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)