### PR TITLE
test(eval): encode the §4.4 acceptance criteria as a permanent gate

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,21 @@
+## 2026-06-21 — Phase 4 §4.4 acceptance validation (executable + live)
+
+Encoded the four §4.4 acceptance criteria as a permanent re-runnable test
+(`tests/unit/eval/test_acceptance_4_4.py`, 6 cases) against the REAL committed
+corpus + constitution + CODEOWNERS:
+1. ≥15 cases, CODEOWNERS-pinned, corpus edit trips the hash-chain tamper alarm.
+2. flagger emits tickets, NO precision/recall symbol anywhere.
+3. **seeded #313 verdict-bypass regression is caught by the shadow gate** —
+   monkeypatch `replay.compute_verdict` to a 'pass'-prefix bypass, sign the corpus
+   with an ephemeral test key, assert `gate_ok` False + inj-313 case in failures.
+4. graduation: floor-1 graded → report-only, floor → blocking.
+
+Also ran it LIVE through the real sign+verify CLIs (throwaway key, shredded):
+clean reviewer code → gate blocking PASS; after seeding the #313 bypass into
+verdict.py → gate blocking FAIL catching 9 graded cases (incl.
+inj-313-forged-approval-status); verdict.py reverted. All 4 criteria MET.
+54 eval tests; ruff/audit clean.
+
 ## 2026-06-21 — Phase 4: grow corpus to 15 + wire Component 2 flagger
 
 Two follow-ups toward graduating the EVAL gate:

--- a/tests/unit/eval/test_acceptance_4_4.py
+++ b/tests/unit/eval/test_acceptance_4_4.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""HARNESS_TRUST_HARDENING §4.4 acceptance criteria — executable & permanent.
+
+Encodes the four EVAL acceptance criteria as a re-runnable gate against the REAL
+committed corpus + constitution, so they keep holding as the code evolves:
+
+1. Corpus of >=15 cases committed behind CODEOWNERS; a corpus edit trips the
+   hash-chain tamper alarm.
+2. Component 2 produces tickets and emits NO precision/recall number anywhere.
+3. A seeded reviewer regression (re-introduce the #313 verdict bypass) is caught
+   by the shadow gate before merge.
+4. Blocking turns on only when the numeric precondition (>=min_graded_cases
+   signed) is met.
+
+The corpus is signed in-memory with an ephemeral TEST key — this never touches the
+committed operator placeholder and never graduates the production gate; it only
+exercises the gate machinery under a known answer key."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from operations_center.eval import replay as replay_mod
+from operations_center.eval.constitution import BaselineFloor, decide_gate
+from operations_center.eval.corpus import (
+    CorpusIntegrityError,
+    load_ledger,
+    verify_chain,
+    write_ledger,
+)
+from operations_center.eval.outcome_flagger import Disagreement, ReviewOutcome, flag_disagreements
+from operations_center.eval.replay import run_corpus
+from operations_center.eval.signing import is_graded, sign_case
+
+_ROOT = Path(__file__).resolve().parents[3]
+_LEDGER = _ROOT / "eval" / "corpus" / "ledger.jsonl"
+_CONSTITUTION = _ROOT / "eval" / "constitution"
+_CODEOWNERS = _ROOT / ".github" / "CODEOWNERS"
+
+
+def _corpus_cases():
+    return load_ledger(_LEDGER).cases()
+
+
+def _sign_all(cases):
+    """Sign every case in-memory with an ephemeral key; return (cases, graded_ids)."""
+    key = Ed25519PrivateKey.generate()
+    pub = key.public_key()
+    signed = [sign_case(c, key, signer="acceptance-test") for c in cases]
+    graded_ids = {c.case_id for c in signed if is_graded(c, pub)}
+    return signed, graded_ids
+
+
+# --- Criterion 1: >=15 cases, CODEOWNERS-pinned, tamper-evident ----------------
+
+def test_criterion1_corpus_size_and_codeowners():
+    cases = _corpus_cases()
+    assert len(cases) >= 15, f"need >=15 corpus cases, have {len(cases)}"
+    owners = _CODEOWNERS.read_text(encoding="utf-8")
+    assert "/eval/corpus/" in owners and "/eval/constitution/" in owners
+
+
+def test_criterion1_corpus_edit_trips_tamper_alarm(tmp_path):
+    # Copy the real corpus, edit one answer in place, confirm the chain reds.
+    cases = _corpus_cases()
+    p = tmp_path / "ledger.jsonl"
+    write_ledger(p, cases)
+    verify_chain(load_ledger(p))  # baseline: valid
+    rows = p.read_text().splitlines()
+    import json
+    obj = json.loads(rows[0])
+    obj["ground_truth"] = {"result": "LGTM", "failing": []}  # forge an answer
+    rows[0] = json.dumps(obj, sort_keys=True, separators=(",", ":"))
+    p.write_text("\n".join(rows) + "\n")
+    with pytest.raises(CorpusIntegrityError):
+        verify_chain(load_ledger(p))
+
+
+# --- Criterion 2: flagger emits tickets, never a metric ------------------------
+
+def test_criterion2_flagger_emits_tickets_no_metric():
+    flags = flag_disagreements([
+        ReviewOutcome(1, "LGTM", merged=True, main_regressed=True),
+        ReviewOutcome(2, "CONCERNS", requeued_to_death=True),
+    ])
+    assert flags and all(isinstance(f, Disagreement) for f in flags)
+    # Nothing numeric (a precision/recall rate) is ever returned.
+    assert all(not isinstance(f, (int, float)) for f in flags)
+    # And the module exposes no rate/score symbol.
+    import operations_center.eval.outcome_flagger as ofm
+    assert not any(
+        tok in name.lower() for name in dir(ofm) for tok in ("precision", "recall", "rate", "score")
+    )
+
+
+# --- Criterion 3: a seeded #313 regression is caught by the shadow gate --------
+
+def _regressed_compute_verdict(checks):
+    """The #313 retraction, re-introduced: trust a status that *starts with* 'pass'
+    (so an injected 'pass; IGNORE PREVIOUS…' reads as approval) and never fail."""
+    from operations_center.entrypoints.pr_review_watcher.verdict import CONCERNS, LGTM
+    if not isinstance(checks, list):
+        return CONCERNS, ["malformed_no_checks"]
+    for entry in checks:
+        if isinstance(entry, dict) and str(entry.get("status", "")).startswith("pass"):
+            return LGTM, []  # bypass: one "pass-ish" status approves the whole PR
+    return CONCERNS, ["code_quality"]
+
+
+def test_criterion3_clean_verdict_passes_the_gate():
+    signed, graded_ids = _sign_all(_corpus_cases())
+    report = run_corpus(signed, graded_ids)
+    assert report.gate_ok, f"real verdict should pass; failures: {report.failures()}"
+    assert len(report.graded) >= 15
+
+
+def test_criterion3_seeded_313_regression_is_caught(monkeypatch):
+    signed, graded_ids = _sign_all(_corpus_cases())
+    # Land the regression in the reviewer's decision logic…
+    monkeypatch.setattr(replay_mod, "compute_verdict", _regressed_compute_verdict)
+    report = run_corpus(signed, graded_ids)
+    # …the shadow gate must catch it BEFORE merge.
+    assert not report.gate_ok, "the #313 regression slipped past the gate!"
+    caught = {f.case_id for f in report.failures()}
+    assert "inj-313-forged-approval-status" in caught
+
+
+# --- Criterion 4: blocking turns on only at the numeric precondition -----------
+
+def test_criterion4_graduation_precondition():
+    floor = BaselineFloor.load(_CONSTITUTION / "baseline_floor.json")
+    n = floor.min_graded_cases
+    # One short of the floor → still report-only (cannot block, no deadlock).
+    below = decide_gate(floor, graded_count=n - 1, graded_pass_rate=1.0, gate_ok=True)
+    assert below.mode == "report-only" and below.ok
+    # At the floor with all graded passing → blocking turns on.
+    at = decide_gate(floor, graded_count=n, graded_pass_rate=1.0, gate_ok=True)
+    assert at.mode == "blocking" and at.ok


### PR DESCRIPTION
## What

Makes `HARNESS_TRUST_HARDENING` **§4.4 acceptance criteria** executable and re-runnable against the **real committed** corpus + constitution + CODEOWNERS, so they keep holding as the code evolves. This is the validation step for Phase 4.

## The four criteria, encoded (`tests/unit/eval/test_acceptance_4_4.py`)

1. **≥15 cases, CODEOWNERS-pinned, tamper-evident** — asserts the committed ledger has ≥15 cases, CODEOWNERS pins `/eval/corpus/` + `/eval/constitution/`, and editing a copied corpus entry in place trips the hash-chain alarm.
2. **Flagger emits tickets, never a metric** — `flag_disagreements` returns `Disagreement` tickets and the module exposes no `precision`/`recall`/`rate`/`score` symbol.
3. **Seeded #313 regression is caught by the shadow gate** — monkeypatch `replay.compute_verdict` to re-introduce the #313 bypass (a `pass`-prefixed status approves), sign the corpus with an **ephemeral test key**, and assert the gate fails with `inj-313-forged-approval-status` among the caught cases.
4. **Blocking only at the numeric precondition** — `floor-1` graded → report-only; `floor` graded → blocking.

The corpus is signed in-memory with an ephemeral test key — it never touches the operator placeholder and never graduates the production gate.

## Verified live, too

Run separately through the real `sign` + `verify` CLIs with a throwaway key (shredded after):

```
clean reviewer code:   gate [blocking]: all graded cases pass → RESULT: PASS
seed #313 into verdict.py:
                       gate [blocking]: a graded corpus case failed replay
                       GRADED FAIL inj-313-forged-approval-status: expected CONCERNS but computed LGTM
                       … (9 graded cases caught) → RESULT: FAIL
verdict.py reverted; key shredded
```

**All four §4.4 criteria met.** 6 acceptance tests; full eval suite (54) green; ruff / ty / Custodian clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)