### PR TITLE
feat(eval): wire production OutcomeSource + drift-monitor extractor seams

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,24 @@
+## 2026-06-21 — Phase 4: wire the two production data seams
+
+Built the live adapters behind the flagger + drift monitor:
+
+- **`eval/outcome_sources.py:GitHubOutcomeSource`** — turns
+  `detect_post_merge_regressions` signals into ReviewOutcome records. Key insight:
+  a merged PR necessarily passed the required `reviewer-verdict` (=LGTM), so a
+  post-merge regression IS an LGTM-then-regression reviewer miss — no separate
+  decision log needed. Detector injectable for tests. Wired as the flagger's
+  default source, opt-in via `OC_EVAL_OUTCOME_SOURCE=github` (+ token), fail-safe
+  to skipped (no env → None → no network, no false flags).
+- **`eval/check_extractors.py:BackendCheckExtractor`** — drift-monitor model
+  adapter: builds the verdict-schema review prompt from a case's diff/context,
+  invokes an injected (different-family) backend, parses `checks` (prose-wrapped
+  JSON tolerant; malformed → [] → CONCERNS = drift signal, never silent pass).
+  Real mechanism; awaits extraction-kind corpus cases + a configured backend to
+  run live.
+
+77 eval/maintenance tests; ruff/ty/audit clean (B2 env-only). Spec Phase-4 section
+updated: seams wired, only the operator signature remains.
+
 ## 2026-06-21 — Phase 4 §4.4 acceptance validation (executable + live)
 
 Encoded the four §4.4 acceptance criteria as a permanent re-runnable test

--- a/docs/design/HARNESS_TRUST_HARDENING.md
+++ b/docs/design/HARNESS_TRUST_HARDENING.md
@@ -547,12 +547,19 @@ exit gate that must pass before the next begins.
     over-flag classes); all pass replay; gate correctly report-only (0/15 signed).
   Verified end-to-end with a throwaway ephemeral key: report-only → sign → gate
   graduates to **blocking**, and an in-place edit of a signed answer is caught.
+- **PRODUCTION SEAMS WIRED (2026-06-21, #372 + #374):** the Component 2 flagger
+  (D-EVAL-1, D-EVAL-4 attribution) is registered and runs on a real source —
+  `eval/outcome_sources.py:GitHubOutcomeSource` turns post-merge regressions on
+  merged PRs into LGTM-miss tickets (a merged PR necessarily passed
+  `reviewer-verdict`=LGTM), opt-in via `OC_EVAL_OUTCOME_SOURCE=github`, fail-safe
+  to skipped. The drift-monitor model adapter is built —
+  `eval/check_extractors.py:BackendCheckExtractor` (prompts a different-family
+  backend with the verdict schema, parses `checks`); it awaits an *extraction-kind*
+  corpus layer (diff→checks cases) + a configured non-implementer backend to run
+  live.
 - **REMAINING (deferred, gated on the operator):** the one encode-once human step
   — generate the Ed25519 key offline, commit the pubkey, sign ≥`min_graded_cases`
-  seed cases — which flips the gate from report-only to blocking. Component 2
-  outcome-correlation flagger (→ ledger tickets, no metric, D-EVAL-1) and the
-  D-EVAL-4 over-flag attribution are not yet wired; the live drift-monitor model
-  adapter (a different-family backend behind `critic.CheckExtractor`) is a seam.
+  seed cases — which flips the gate from report-only to blocking.
 - Self-healing body (once seeded): drift detection, `[check:]` reconfirmation,
   corpus growth via *unsigned candidate* append, regression auto-fix on
   worker/reviewer behavior only. *(D-OP-3)*

--- a/src/operations_center/entrypoints/maintenance/outcome_flagger_task.py
+++ b/src/operations_center/entrypoints/maintenance/outcome_flagger_task.py
@@ -14,6 +14,7 @@ wired the task returns ``skipped`` — no data means no tickets, never a false f
 
 from __future__ import annotations
 
+import os
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -25,6 +26,7 @@ from operations_center.eval.outcome_flagger import (
 from operations_center.maintenance.contracts import MaintenanceResult
 
 if TYPE_CHECKING:
+    from operations_center.adapters.github_pr import GitHubPRClient
     from operations_center.adapters.plane.client import PlaneClient
     from operations_center.maintenance.contracts import MaintenanceContext
 
@@ -32,6 +34,9 @@ DEFAULT_INTERVAL_SECONDS = 3600
 _TICKET_PREFIX = "[eval-flag]"
 _TICKET_LABELS = ("kind:improve", "repo:OperationsCenter", "source:eval-flagger")
 _TERMINAL_STATES = {"done", "cancelled", "canceled"}
+# Opt-in: only build the live GitHub outcome source when explicitly enabled, so the
+# task stays skipped (and network-free) by default until an operator turns it on.
+_SOURCE_ENV = "OC_EVAL_OUTCOME_SOURCE"
 
 
 class OutcomeFlaggerTask:
@@ -67,14 +72,39 @@ class OutcomeFlaggerTask:
             project_id=p.project_id,
         )
 
+    def _make_gh_client(self) -> GitHubPRClient | None:
+        from operations_center.adapters.github_pr import GitHubPRClient
+
+        token_env = (
+            getattr(getattr(self._settings, "git", None), "token_env", None) or "GITHUB_TOKEN"
+        )
+        token = os.environ.get(token_env)
+        return GitHubPRClient(token=token) if token else None
+
+    def _resolve_outcome_source(self) -> OutcomeSource | None:
+        """Injected source wins; otherwise build the live GitHub source only when
+        explicitly opted in (``OC_EVAL_OUTCOME_SOURCE=github``) and a token exists.
+        Default: ``None`` → skipped (no data, no false flags, no network)."""
+        if self._outcome_source is not None:
+            return self._outcome_source
+        if os.environ.get(_SOURCE_ENV) != "github":
+            return None
+        gh = self._make_gh_client()
+        if gh is None:
+            return None
+        from operations_center.eval.outcome_sources import make_github_outcome_source
+
+        return make_github_outcome_source(self._settings, gh)
+
     def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
         started = time.monotonic()
-        if self._outcome_source is None:
+        source = self._resolve_outcome_source()
+        if source is None:
             return self._result(
                 "skipped", started, {"reason": "no outcome source wired"}
             )
         try:
-            outcomes = self._outcome_source()
+            outcomes = source()
         except Exception as exc:  # noqa: BLE001 — a flaky source must not halt the loop
             return self._result(
                 "failed", started, {}, error=f"outcome_source_failed: {exc}"

--- a/src/operations_center/eval/check_extractors.py
+++ b/src/operations_center/eval/check_extractors.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Production check-extractor for the drift monitor (§4.2, D-EVAL-5).
+
+The non-blocking drift monitor (:mod:`operations_center.eval.critic`) needs a model
+to re-derive the typed ``checks`` for a case from its diff/context, so it can detect
+when the reviewer model's *extraction* behavior drifts from the signed answer.
+
+``BackendCheckExtractor`` is that model adapter. It builds the same review prompt the
+reviewer uses (``verdict_schema_prompt``), asks an injected model invoker, and parses
+the ``checks`` array out of the response — the same shape the reviewer writes to
+``verdict.json``. The invoker is injected so the extractor is testable without a live
+backend; production wires it to a **different model family than the implementer**
+(N copies of one family is N=1 — a same-weights clone shares blindspots), per
+D-EVAL-5.
+
+Note: this needs *extraction-kind* corpus cases (input carries a ``diff``/``context``
+for the model to review) to be exercised live. The current seed corpus is
+verdict-kind (pre-filled ``checks``), so this adapter is wired and tested but waits
+on an extraction corpus layer + a configured non-implementer backend."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable
+
+from operations_center.entrypoints.pr_review_watcher.verdict import verdict_schema_prompt
+from operations_center.eval.corpus import Case
+
+# invoke(prompt, vote) -> raw model text. ``vote`` lets the caller vary sampling per
+# N-of-M vote (seed/temperature) so repeated calls are genuinely independent.
+ModelInvoker = Callable[[str, int], str]
+
+
+def build_extraction_prompt(case: Case) -> str:
+    """The review prompt for a case: its change context + the typed-verdict schema."""
+    inp = case.input
+    context = inp.get("diff") or inp.get("context")
+    if not isinstance(context, str) or not context:
+        context = json.dumps(inp, sort_keys=True, ensure_ascii=False)
+    return (
+        "Review the following change and report a status for each enumerated "
+        f"check.\n\n--- change ---\n{context}\n--- end change ---\n\n"
+        + verdict_schema_prompt()
+    )
+
+
+def parse_checks(raw: str) -> list:
+    """Extract the ``checks`` list from a model response (JSON, possibly prose-wrapped).
+
+    Fail-safe: an unparseable/absent ``checks`` returns ``[]`` — which
+    ``compute_verdict`` turns into CONCERNS, so a model that stops emitting valid
+    output reads as drift (a signal), never as a silent pass."""
+    if not isinstance(raw, str):
+        return []
+    text = raw.strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        return []
+    try:
+        obj = json.loads(text[start : end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return []
+    checks = obj.get("checks") if isinstance(obj, dict) else None
+    return checks if isinstance(checks, list) else []
+
+
+class BackendCheckExtractor:
+    """A :class:`operations_center.eval.critic.CheckExtractor` backed by a model."""
+
+    def __init__(self, invoke: ModelInvoker) -> None:
+        self._invoke = invoke
+
+    def __call__(self, case: Case, *, vote: int) -> object:
+        prompt = build_extraction_prompt(case)
+        try:
+            raw = self._invoke(prompt, vote)
+        except Exception:  # noqa: BLE001 — a backend hiccup reads as drift, never a pass
+            return []
+        return parse_checks(raw)
+
+
+__all__ = [
+    "BackendCheckExtractor",
+    "ModelInvoker",
+    "build_extraction_prompt",
+    "parse_checks",
+]

--- a/src/operations_center/eval/outcome_sources.py
+++ b/src/operations_center/eval/outcome_sources.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Production outcome sources for the Component-2 flagger (§4.2, D-EVAL-1).
+
+The flagger correlates reviewer decisions with downstream outcomes. The cleanest
+*real* correlation needs no separate decision log: **a merged PR necessarily passed
+the required ``reviewer-verdict`` check**, i.e. the reviewer said LGTM. So a
+post-merge regression on a merged PR *is* an LGTM-then-regression — a candidate
+reviewer miss — recoverable straight from GitHub via
+:func:`detect_post_merge_regressions`.
+
+``GitHubOutcomeSource`` turns those regression signals into :class:`ReviewOutcome`
+records. The ``requeue_to_death`` signal (worker non-convergence, D-EVAL-4) lives in
+board state, not GitHub, and is sourced separately; this adapter only owns the
+merge→regression half. The detector is injectable so the join is unit-testable
+without a live GitHub client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from operations_center.eval.outcome_flagger import LGTM, ReviewOutcome
+from operations_center.post_merge_regression import (
+    RegressionSignal,
+    detect_post_merge_regressions,
+)
+
+if TYPE_CHECKING:
+    from operations_center.adapters.github_pr import GitHubPRClient
+
+# (owner, repo) targets to scan. Defaults to OC's own repo (the one the reviewer
+# self-reviews and where the eval lives); extend as the flagger is pointed wider.
+DEFAULT_TARGETS: tuple[tuple[str, str], ...] = (("ProtocolWarden", "OperationsCenter"),)
+
+# A detector with the signature of detect_post_merge_regressions, injectable for tests.
+Detector = Callable[..., list[RegressionSignal]]
+
+
+class GitHubOutcomeSource:
+    """Yield review outcomes from post-merge regressions (merged ⟹ LGTM, regressed)."""
+
+    def __init__(
+        self,
+        gh_client: GitHubPRClient,
+        *,
+        targets: tuple[tuple[str, str], ...] = DEFAULT_TARGETS,
+        base_branch: str = "main",
+        lookback_hours: int = 24,
+        detector: Detector | None = None,
+    ) -> None:
+        self._gh = gh_client
+        self._targets = targets
+        self._base_branch = base_branch
+        self._lookback_hours = lookback_hours
+        self._detector = detector or detect_post_merge_regressions
+
+    def __call__(self) -> list[ReviewOutcome]:
+        outcomes: list[ReviewOutcome] = []
+        for owner, repo in self._targets:
+            try:
+                signals = self._detector(
+                    self._gh,
+                    owner,
+                    repo,
+                    base_branch=self._base_branch,
+                    lookback_hours=self._lookback_hours,
+                )
+            except Exception:  # noqa: BLE001 — a flaky GitHub call must not break the join
+                continue
+            for sig in signals:
+                if sig.pr_number is None:
+                    # Can't attribute to a PR → can't make it a reviewer ticket.
+                    continue
+                outcomes.append(
+                    ReviewOutcome(
+                        pr_number=sig.pr_number,
+                        decision=LGTM,  # merge required reviewer-verdict=success
+                        merged=True,
+                        main_regressed=True,
+                        repo=repo,
+                    )
+                )
+        return outcomes
+
+
+def make_github_outcome_source(settings: Any, gh_client: GitHubPRClient) -> GitHubOutcomeSource:
+    """Build the source from settings (targets/lookback overridable later)."""
+    return GitHubOutcomeSource(gh_client)
+
+
+__all__ = ["DEFAULT_TARGETS", "GitHubOutcomeSource", "make_github_outcome_source"]

--- a/tests/unit/entrypoints/maintenance/test_outcome_flagger_task.py
+++ b/tests/unit/entrypoints/maintenance/test_outcome_flagger_task.py
@@ -46,11 +46,28 @@ def test_satisfies_protocol_and_defaults():
     assert task.enabled is True
 
 
-def test_skipped_when_no_source_wired():
+def test_skipped_when_no_source_wired(monkeypatch):
+    monkeypatch.delenv("OC_EVAL_OUTCOME_SOURCE", raising=False)
     task = OutcomeFlaggerTask(settings=None)
     result = task.run_once(_ctx())
     assert result.status == "skipped"
     assert "no outcome source" in result.details["reason"]
+
+
+def test_github_source_opt_in_builds_a_source(monkeypatch):
+    monkeypatch.setenv("OC_EVAL_OUTCOME_SOURCE", "github")
+    monkeypatch.setenv("GITHUB_TOKEN", "x-token")
+    from operations_center.eval.outcome_sources import GitHubOutcomeSource
+
+    task = OutcomeFlaggerTask(settings=None)
+    assert isinstance(task._resolve_outcome_source(), GitHubOutcomeSource)
+
+
+def test_github_source_not_built_without_opt_in(monkeypatch):
+    monkeypatch.delenv("OC_EVAL_OUTCOME_SOURCE", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "x-token")  # token present but not opted in
+    task = OutcomeFlaggerTask(settings=None)
+    assert task._resolve_outcome_source() is None
 
 
 def test_skipped_when_source_empty():

--- a/tests/unit/eval/test_check_extractors.py
+++ b/tests/unit/eval/test_check_extractors.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""BackendCheckExtractor: prompt build, parse, and drift-monitor integration."""
+
+from __future__ import annotations
+
+from operations_center.eval.check_extractors import (
+    BackendCheckExtractor,
+    build_extraction_prompt,
+    parse_checks,
+)
+from operations_center.eval.corpus import Case
+from operations_center.eval.critic import run_drift_monitor
+
+
+def _case(cid="c") -> Case:
+    return Case(
+        case_id=cid,
+        kind="verdict",
+        input={"diff": "def f():\n-  return 1\n+  return None"},
+        ground_truth={"result": "CONCERNS", "failing": ["code_quality"]},
+    )
+
+
+def test_build_prompt_includes_change_and_schema():
+    prompt = build_extraction_prompt(_case())
+    assert "return None" in prompt
+    assert "verdict.json" in prompt  # the typed-verdict schema fragment
+
+
+def test_parse_checks_plain_json():
+    raw = '{"checks": [{"check_id": "code_quality", "status": "fail"}]}'
+    assert parse_checks(raw) == [{"check_id": "code_quality", "status": "fail"}]
+
+
+def test_parse_checks_prose_wrapped_json():
+    raw = "Sure! Here is my review:\n{\"checks\": [{\"check_id\": \"x\"}]}\nHope that helps."
+    assert parse_checks(raw) == [{"check_id": "x"}]
+
+
+def test_parse_checks_malformed_returns_empty():
+    assert parse_checks("not json at all") == []
+    assert parse_checks('{"checks": "not a list"}') == []
+    assert parse_checks("") == []
+
+
+def test_extractor_returns_parsed_checks():
+    ext = BackendCheckExtractor(
+        invoke=lambda prompt, vote: '{"checks": [{"check_id": "code_quality", "status": "fail"},'
+        '{"check_id": "no_tooling_artifacts", "status": "pass"}]}'
+    )
+    checks = ext(_case(), vote=0)
+    assert {c["check_id"] for c in checks} == {"code_quality", "no_tooling_artifacts"}
+
+
+def test_extractor_backend_error_reads_as_drift_not_pass():
+    def _boom(prompt, vote):
+        raise RuntimeError("backend down")
+
+    ext = BackendCheckExtractor(invoke=_boom)
+    assert ext(_case(), vote=0) == []  # empty → compute_verdict → CONCERNS (drift), never a pass
+
+
+def test_drift_monitor_with_backend_extractor_agrees():
+    # Model reproduces the answer (code_quality fail) → no drift.
+    ext = BackendCheckExtractor(
+        invoke=lambda p, v: '{"checks": [{"check_id": "code_quality", "status": "fail"},'
+        '{"check_id": "no_tooling_artifacts", "status": "pass"}]}'
+    )
+    results = run_drift_monitor([_case()], ext, votes=3)
+    assert results[0].drifted is False
+
+
+def test_drift_monitor_with_backend_extractor_flags_drift():
+    # Model now says everything passes → computes LGTM, answer is CONCERNS → drift.
+    ext = BackendCheckExtractor(
+        invoke=lambda p, v: '{"checks": [{"check_id": "code_quality", "status": "pass"},'
+        '{"check_id": "no_tooling_artifacts", "status": "pass"}]}'
+    )
+    results = run_drift_monitor([_case()], ext, votes=3)
+    assert results[0].drifted is True

--- a/tests/unit/eval/test_outcome_sources.py
+++ b/tests/unit/eval/test_outcome_sources.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""GitHubOutcomeSource: merged-then-regressed PRs become LGTM-miss outcomes."""
+
+from __future__ import annotations
+
+from operations_center.eval.outcome_sources import GitHubOutcomeSource
+from operations_center.post_merge_regression import RegressionSignal
+
+
+def _sig(pr_number):
+    return RegressionSignal(
+        pr_number=pr_number,
+        merge_commit_sha="abc",
+        head_sha="def",
+        failed_checks=("Test (pytest)",),
+        merged_at="2026-06-21T00:00:00+00:00",
+        base_branch="main",
+    )
+
+
+def _detector(signals):
+    def _fn(gh, owner, repo, *, base_branch="main", lookback_hours=24):
+        return list(signals)
+    return _fn
+
+
+def test_regressed_merged_pr_becomes_lgtm_miss():
+    src = GitHubOutcomeSource(gh_client=object(), detector=_detector([_sig(42)]))
+    outcomes = src()
+    assert len(outcomes) == 1
+    o = outcomes[0]
+    assert o.pr_number == 42
+    assert o.decision == "LGTM"  # merge required reviewer-verdict=success
+    assert o.merged and o.main_regressed
+    assert o.repo == "OperationsCenter"
+
+
+def test_signal_without_pr_number_is_skipped():
+    src = GitHubOutcomeSource(gh_client=object(), detector=_detector([_sig(None)]))
+    assert src() == []
+
+
+def test_no_regressions_yields_no_outcomes():
+    src = GitHubOutcomeSource(gh_client=object(), detector=_detector([]))
+    assert src() == []
+
+
+def test_detector_exception_does_not_break_the_join():
+    def _boom(*a, **k):
+        raise RuntimeError("github down")
+
+    src = GitHubOutcomeSource(gh_client=object(), detector=_boom)
+    assert src() == []  # best-effort; a flaky source must not raise
+
+
+def test_multiple_targets_are_scanned():
+    src = GitHubOutcomeSource(
+        gh_client=object(),
+        targets=(("o", "r1"), ("o", "r2")),
+        detector=_detector([_sig(7)]),
+    )
+    outcomes = src()
+    assert {o.repo for o in outcomes} == {"r1", "r2"}
+    assert all(o.pr_number == 7 for o in outcomes)


### PR DESCRIPTION
## What

Builds the two live data adapters the Phase 4 scaffolding left as injected seams, so the Component 2 flagger and the drift monitor run on **real** signals.

## 1. `GitHubOutcomeSource` (the flagger's real feed)

`eval/outcome_sources.py` turns `detect_post_merge_regressions` signals into `ReviewOutcome` records. The key insight that makes this real with no new plumbing: **a merged PR necessarily passed the required `reviewer-verdict` check (=LGTM)**, so a post-merge regression on a merged PR *is* an LGTM-then-regression — a candidate reviewer miss — straight from GitHub.

- Detector is injectable → unit-testable without a live GitHub client.
- Wired as `OutcomeFlaggerTask`'s default source, **opt-in** via `OC_EVAL_OUTCOME_SOURCE=github` (+ token). Default off → `skipped` (no network, no false flags — §0.1 fail-safe).

## 2. `BackendCheckExtractor` (the drift monitor's model adapter)

`eval/check_extractors.py` is the `critic.CheckExtractor` implementation: it builds the verdict-schema review prompt from a case's diff/context, asks an **injected (different-family) backend**, and parses the `checks` array (tolerates prose-wrapped JSON; malformed/absent → `[]` → `compute_verdict` CONCERNS, so a broken model reads as *drift*, never a silent pass).

A real, tested mechanism. It awaits an *extraction-kind* corpus layer (diff→checks cases) + a configured non-implementer backend to run live — both noted in the spec.

## Tests / docs

77 eval + maintenance unit tests (outcome-source join, opt-in gating, extractor parse/prompt/drift integration). ruff / ty clean; Custodian B2 env-only. Spec Phase-4 section updated: seams wired, only the operator signature remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)