### PR TITLE
docs(eval): operator signing runbook + key-loss recovery

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,22 @@
+## 2026-06-21 — Phase 4: operator signing runbook + key-loss recovery docs
+
+Operator asked the right questions (key loss? what am I signing? recurring?).
+Added the missing docs:
+- `eval/SIGNING.md` — plain-English operator runbook: what a signature attests
+  (with example), one-time anchoring (keygen→anchor pubkey→sign→verify via the
+  sign CLI), the **lost-key rotation** procedure (new key, repaste pubkey,
+  re-sign — old sigs revert to candidate, fleet stays report-only mid-rotation,
+  then blocking), adding a case later, and why crypto vs a plain rule.
+- Fixed the FOOTGUN in `operator_pubkey.ed25519`: its old keygen snippet used
+  `private_bytes_raw()` (raw bytes) which `load_private_key` can't read; now
+  points at `sign keygen` (PEM) + SIGNING.md.
+- `.gitignore`: guard `operator_priv.pem` / `*operator_priv*.pem` /
+  `eval/**/operator_priv*` so a private key can never be committed by accident.
+
+Verified the whole runbook live with throwaway keys incl. rotation: keygen→sign
+15→blocking PASS; rotate→old sigs become candidates (report-only, no halt)→
+re-sign→blocking PASS. Loss is recoverable, proven. Docs-only.
+
 ## 2026-06-21 — Phase 4: wire the two production data seams
 
 Built the live adapters behind the flagger + drift monitor:

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ improve-output.json
 # Flaky test detection metrics and artifacts (local + CI storage)
 .flaky-tests/
 improve-output.json
+
+# EVAL operator signing key — must NEVER be committed (private answer-key root)
+operator_priv.pem
+*operator_priv*.pem
+eval/**/operator_priv*

--- a/eval/SIGNING.md
+++ b/eval/SIGNING.md
@@ -1,0 +1,128 @@
+# EVAL answer-key signing — operator runbook
+
+This is the **one human step** in the whole trust-hardening spec. Everything else
+self-heals; this is the part only you can do. It is a **one-time anchoring**, then
+occasional appends — not a recurring chore. Read this once; it covers the normal
+flow *and* what to do if you lose the key.
+
+---
+
+## What a signature actually is (read this first)
+
+You are **not** signing code, a PR, or a merge. You are signing a small,
+human-readable **answer-key entry** — one exam question and its correct answer:
+
+```json
+{"case_id": "legit-code-quality-fail",
+ "kind": "verdict",
+ "input":  {"checks": [{"check_id": "code_quality", "status": "fail", "...": "..."}]},
+ "ground_truth": {"result": "CONCERNS", "failing": ["code_quality"]}}
+```
+
+Your signature attests one sentence: **"for this reviewer input, the correct
+verdict is X."** That's it.
+
+Two things that make this low-stakes:
+
+- **The key encrypts nothing.** The corpus (inputs + correct answers) is plaintext
+  in `eval/corpus/ledger.jsonl`, readable forever. The signature is just a **wax
+  stamp** proving you vouched for an answer. Lose the stamp and the answers are
+  still right there — you just make a new stamp (see *Lost key* below).
+- **You sign once.** A signed case is permanent; the gate re-checks it on every CI
+  run with no human. No expiry, no renewal, no re-signing old cases. You only sign
+  again when a genuinely *new* kind of reviewer mistake appears that's worth adding
+  — and the system flags those for you.
+
+---
+
+## One-time anchoring (turns the gate from report-only to blocking)
+
+Run these on a machine you trust. The private key must **never** be committed and
+**never** placed on a fleet host — only the *public* key is committed.
+
+### 1. Generate your keypair
+
+```bash
+python -m operations_center.eval.sign keygen --private-out operator_priv.pem
+```
+
+This writes the **private** key to `operator_priv.pem` and **prints the public key
+hex**. Save `operator_priv.pem` somewhere safe and offline — a password-manager
+entry is ideal. You do not need it day-to-day; only to sign future cases.
+
+### 2. Anchor the public key
+
+Open `eval/constitution/operator_pubkey.ed25519`, delete the placeholder, and paste
+the printed public-key hex as the **sole first line**. Commit it (you own this file
+via CODEOWNERS).
+
+### 3. Sign the corpus
+
+```bash
+python -m operations_center.eval.sign sign \
+  --private operator_priv.pem \
+  --ledger eval/corpus/ledger.jsonl \
+  --signer your-handle
+```
+
+This converts the unsigned candidate cases into signed graded cases and re-chains
+the ledger. Re-running is safe (already-signed cases are skipped).
+
+### 4. Verify and commit
+
+```bash
+python -m operations_center.eval.verify
+```
+
+You want to see `gate [blocking]: all graded cases pass and floor is cleared`.
+Commit the updated `eval/corpus/ledger.jsonl` + `operator_pubkey.ed25519`. CI's
+required `EVAL corpus integrity` check now enforces the answer key on every PR.
+
+---
+
+## Lost the private key? (rotation — it's fine)
+
+Losing the key is **recoverable**, not a disaster. The key only *stamps* the
+plaintext corpus; it doesn't lock it. To rotate:
+
+1. `python -m operations_center.eval.sign keygen --private-out operator_priv.pem --force`
+   (makes a fresh keypair).
+2. Paste the **new** public hex into `eval/constitution/operator_pubkey.ed25519`.
+3. Re-run the **sign** command from step 3 above. The old signatures no longer
+   verify against the new key, so they count as unsigned and get re-stamped
+   automatically.
+4. `verify`, commit.
+
+Because the public-key file is CODEOWNERS-pinned, only you can rotate it — an
+attacker who lost-and-found nothing can't swap in their own key.
+
+> **Note:** losing the key means you can't make *new* signatures with the *old*
+> key — but you never need to. You just mint a new key and re-stamp. The answers
+> were never at risk.
+
+---
+
+## Adding a case later (the only recurring action — and it's rare)
+
+When the outcome flagger or drift monitor surfaces a *new* class of reviewer
+mistake worth memorializing:
+
+1. Append it as an **unsigned candidate** (the fleet can do this; it's replayed and
+   reported but doesn't gate).
+2. When you're ready, read it, then `sign` it (optionally `--case-id <id>` to sign
+   just that one).
+
+If the existing cases already cover the space, you sign nothing. There is no clock.
+
+---
+
+## Why a signature instead of just "don't change this"
+
+`CODEOWNERS` already pins the corpus to you, and the hash chain already makes any
+out-of-band edit visible. The signature is the third layer: it makes "don't change
+unless I say so" an **un-forgeable cryptographic fact** rather than a rule the
+autonomous (possibly injected) fleet could edit. If you ever decide the crypto
+isn't worth the custody for your setup, a no-key CODEOWNERS-trust mode is a
+reasonable alternative — ask and it can be added.
+
+See `docs/design/HARNESS_TRUST_HARDENING.md` §4.2 for the full design.

--- a/eval/constitution/operator_pubkey.ed25519
+++ b/eval/constitution/operator_pubkey.ed25519
@@ -1,19 +1,19 @@
 OPERATOR_PUBKEY_PLACEHOLDER
-# Replace this entire file with the operator's Ed25519 PUBLIC key — either a
-# 64-character raw hex string (32 bytes) on the first line, or a PEM block
-# (-----BEGIN PUBLIC KEY-----). The matching PRIVATE key is generated OFFLINE by
-# the operator and never committed, never placed on any fleet host, and used only
-# to sign corpus cases (convert a candidate into a graded answer-key entry).
+# Replace this entire file with the operator's Ed25519 PUBLIC key — a 64-character
+# raw hex string (32 bytes) on the first line, as printed by the keygen command
+# below. The matching PRIVATE key is generated OFFLINE by the operator and never
+# committed, never placed on any fleet host, and used only to sign corpus cases
+# (convert a candidate into a graded answer-key entry).
 #
 # While this placeholder is present, signing.load_public_key() returns None: no
 # case can be graded, so the EVAL gate stays in report-only mode (it can never
 # block the fleet before the answer key is anchored — §0.1 degrade-never-halt).
 #
-# To anchor:
-#   1. (offline)  python -c "from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey; \
-#                 k=Ed25519PrivateKey.generate(); \
-#                 open('operator_priv.pem','wb').write(k.private_bytes_raw()); \
-#                 print(k.public_key().public_bytes_raw().hex())"
+# To anchor (full walkthrough incl. key-loss recovery: eval/SIGNING.md):
+#   1. (offline)  python -m operations_center.eval.sign keygen --private-out operator_priv.pem
+#                 # writes operator_priv.pem (KEEP OFFLINE) and prints the public hex
 #   2. paste the printed hex as the sole first line of this file, commit it
 #      (operator-authored, CODEOWNERS-pinned).
-#   3. keep operator_priv.pem offline; use it only to sign seed cases.
+#   3. python -m operations_center.eval.sign sign --private operator_priv.pem \
+#          --ledger eval/corpus/ledger.jsonl --signer your-handle
+#   4. python -m operations_center.eval.verify   # expect: gate [blocking]


### PR DESCRIPTION
## What

Closes a real documentation gap surfaced by operator questions: **key loss/rotation** and **"what am I actually signing"** were not written down anywhere.

## Changes

- **`eval/SIGNING.md`** — a plain-English operator runbook:
  - what a signature attests (with a concrete example) — you're stamping "for this input, the correct verdict is X", nothing more
  - that it's a **one-time anchoring**, not a recurring chore (no expiry, no re-signing old cases)
  - the anchoring flow via the `sign` CLI: keygen → anchor pubkey → sign → verify
  - the **lost-key rotation** procedure — mint a new key, repaste the pubkey, re-sign. Old signatures revert to *candidate*, so the fleet stays **report-only mid-rotation (never halts)**, then returns to blocking
  - adding a case later, and why a signature is used instead of a plain "don't change this" rule
- **`operator_pubkey.ed25519`** — fixed a footgun: the old keygen snippet wrote `private_bytes_raw()` (raw bytes), which `load_private_key` can't read. Now points at `sign keygen` (PEM) + the runbook.
- **`.gitignore`** — guards `operator_priv.pem` so a private signing key can never be committed by accident.

## Verified live (throwaway keys, including rotation)

```
keygen → sign 15 → gate [blocking]: all graded cases pass → PASS
LOST KEY → rotate: new key, repaste pubkey
  → old sigs no longer verify → 0 graded → gate [report-only] (no halt)
  → re-sign → 15 graded → gate [blocking] → PASS
```

Loss is recoverable — demonstrated, not just asserted. Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)