### PR TITLE
fix(sbx): sandbox the CI-loop / spec-author / intake executor spawns (audit HIGH-3)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,14 @@
+## 2026-06-21 — SBX: sandbox the 3 un-wrapped executor spawn sites (audit HIGH-3)
+
+Architectural audit found the reviewer-sandbox story incomplete: the CI fix-loop
+(outcomes.py), spec-author (spec_author.py), and intake (intake/main.py) spawned
+execute.main via RAW subprocess.run — un-sandboxed even with OC_BWRAP_SANDBOX=1.
+Routed all three through run_executor (bwrap + rlimits). board_worker sites already
+get the minimized build_allowlist_env from dispatch; intake built a full-os.environ
+env, so gave it a focused build_allowlist_env (git token only) to avoid bwrap
+--clearenv re-injecting every secret. Updated 3 outcomes tests (patch run_executor,
+not subprocess). 536 board_worker/spec_author tests pass; ruff/ty/audit clean.
+
 ## 2026-06-21 — Phase 4: operator signing runbook + key-loss recovery docs
 
 Operator asked the right questions (key loss? what am I signing? recurring?).

--- a/src/operations_center/entrypoints/board_worker/outcomes.py
+++ b/src/operations_center/entrypoints/board_worker/outcomes.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import json
 import logging
-import subprocess
 from pathlib import Path
 
+from ._subprocess import run_executor
 from .labels import (
     LIFECYCLE_EXPANDED,
     STATE_BLOCKED,
@@ -713,7 +713,13 @@ def run_ci_loop(
             attempt_number,
             task_id,
         )
-        subprocess.run(exec_cmd, cwd=oc_root, env=env, capture_output=True, text=True)
+        # SBX: route the CI fix-loop executor through the same bwrap/rlimits wrap as
+        # dispatch (was a raw subprocess.run — un-sandboxed even with the flag on).
+        # The fix-loop runs model-driven code on least-trusted failing branches; env
+        # is already the minimized build_allowlist_env from dispatch.
+        run_executor(
+            exec_cmd, oc_root=oc_root, rw_root=tmp, workspace=attempt_workspace, env=env
+        )
 
         run_id: str = f"ci-{task_id[:8]}-attempt-{attempt_number}"
         changed_files: list[str] = []

--- a/src/operations_center/entrypoints/board_worker/spec_author.py
+++ b/src/operations_center/entrypoints/board_worker/spec_author.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from ._subprocess import run_executor
 from ._text import summarize_prompt_diff_block
 from .labels import STATE_DONE, add_label
 from .outcomes import fail_task, handle_failure
@@ -152,7 +153,10 @@ def process_spec_author(
             "--source",
             source_tag,
         ]
-        subprocess.run(exec_cmd, cwd=oc_root, env=env, capture_output=True, text=True)
+        # SBX: route the spec-author executor through the bwrap/rlimits wrap (was a
+        # raw subprocess.run). env is already the minimized build_allowlist_env from
+        # _dispatch_spec_author.
+        run_executor(exec_cmd, oc_root=oc_root, rw_root=tmp, workspace=workspace, env=env)
 
         if not result_file.exists():
             logger.error(

--- a/src/operations_center/entrypoints/intake/main.py
+++ b/src/operations_center/entrypoints/intake/main.py
@@ -41,6 +41,11 @@ import time
 import uuid
 from pathlib import Path
 
+from operations_center.entrypoints.board_worker._subprocess import (
+    build_allowlist_env,
+    run_executor,
+)
+
 logger = logging.getLogger(__name__)
 
 QUEUE_DIR = Path.home() / ".console" / "queue"
@@ -199,7 +204,14 @@ def _process_item(item: dict, config_path: Path, venv_python: str) -> bool:
             "intake",
         ]
 
-        exec_proc = subprocess.run(exec_cmd, cwd=oc_root, env=env, capture_output=True, text=True)
+        # SBX: route the intake executor through the bwrap/rlimits wrap with a
+        # MINIMIZED env (intake's _build_env is full os.environ → bwrap --clearenv
+        # would otherwise re-inject every secret). Forward only the git token so
+        # push still works; sibling-repo tokens / Plane token / host secrets drop.
+        exec_env = build_allowlist_env(oc_root, passthrough=("GITHUB_TOKEN", "GIT_TOKEN"))
+        exec_proc = run_executor(
+            exec_cmd, oc_root=oc_root, rw_root=tmp, workspace=workspace, env=exec_env
+        )
 
         if not result_file.exists():
             logger.error(

--- a/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
@@ -932,7 +932,7 @@ def test_run_ci_loop_execute_closure(ci_modules, tmp_path, monkeypatch):
         )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(outcomes.subprocess, "run", fake_run)
+    monkeypatch.setattr(outcomes, "run_executor", fake_run)
     outcomes.run_ci_loop(**kw)
     run_id, changed, success = state["execute_return"]
     assert run_id == "real-run"
@@ -947,8 +947,8 @@ def test_run_ci_loop_execute_no_result_file(ci_modules, tmp_path, monkeypatch):
     kw = _ci_kwargs(tmp_path)
 
     monkeypatch.setattr(
-        outcomes.subprocess,
-        "run",
+        outcomes,
+        "run_executor",
         lambda cmd, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
     outcomes.run_ci_loop(**kw)
@@ -970,7 +970,7 @@ def test_run_ci_loop_execute_malformed_result(ci_modules, tmp_path, monkeypatch)
         result_path.write_text("not-json{", encoding="utf-8")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(outcomes.subprocess, "run", fake_run)
+    monkeypatch.setattr(outcomes, "run_executor", fake_run)
     outcomes.run_ci_loop(**kw)
     run_id, changed, success = state["execute_return"]
     assert run_id == "ci-task-123-attempt-1"


### PR DESCRIPTION
## What

Closes audit finding **SBX HIGH-3**: the "reviewer executor is sandboxed" story was incomplete. Three executor spawn sites ran `execute.main` via **raw `subprocess.run`**, bypassing `maybe_sandbox` entirely — so they were **un-sandboxed even with `OC_BWRAP_SANDBOX=1`**:

- `board_worker/outcomes.py` — the **CI fix-loop**, which runs model-driven code on the least-trusted failing branches
- `board_worker/spec_author.py`
- `intake/main.py`

## Fix

All three now route through `run_executor` (bwrap PID/fs isolation + the Layer-3 rlimits wrap), identical to `dispatch.py`'s spawn sites.

- The two `board_worker` sites already receive the minimized `build_allowlist_env` from dispatch — pure routing change.
- `intake` built a **full `os.environ`** env, which `bwrap --clearenv`+`--setenv` would re-inject wholesale (the exact pre-#357 reviewer leak). It now builds a focused `build_allowlist_env` forwarding only the git token, so sibling-repo tokens, the Plane token, and host secrets drop.

## Tests

Updated 3 `outcomes` coverage tests to patch `run_executor` instead of `subprocess.run`. **536** board_worker/spec_author tests pass; ruff / ty / Custodian clean.

Note: this is containment only. The companion gaps (INJ fencing of board ingestion, and the deeper "agent holds the push token so it can push directly" issue) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)