### PR TITLE
fix(sbx): PatchApplier blocks dangerous basenames at any depth + whole .github (HIGH-2)

### DIFF
--- a/src/operations_center/adapters/workspace/patch_applier.py
+++ b/src/operations_center/adapters/workspace/patch_applier.py
@@ -34,46 +34,64 @@ class PatchApplyResult:
 
 # Paths and patterns that must NEVER be modified in a patch (load-bearing rules).
 # These block RCE vectors, credential exposure, and infrastructure changes.
+# Dangerous BASENAMES — blocked at ANY directory depth. The previous patterns were
+# root-anchored (`^conftest\.py$`), so `src/conftest.py`, `tools/Makefile`,
+# `pkg/setup.py` etc. slipped through — yet pytest auto-imports ANY conftest.py in
+# the collection tree (RCE the moment CI/the reviewer runs pytest), and build tools
+# read these wherever they sit. Checked by basename, position-independent.
+_BLOCKED_BASENAMES = frozenset(
+    {
+        # python build / test-autoload hooks (RCE on the host that runs them)
+        "conftest.py",
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "tox.ini",
+        "noxfile.py",
+        ".pre-commit-config.yaml",
+        ".pre-commit-config.yml",
+        # rust / go manifests with build hooks
+        "Cargo.toml",
+        "Cargo.lock",
+        "go.mod",
+        "go.sum",
+        # git + shell configs (sourced / executed)
+        ".gitmodules",
+        ".bashrc",
+        ".zshrc",
+        ".profile",
+    }
+)
+
+# Dangerous basename PATTERNS (the `.*`/optional-suffix cases), also any-depth.
+_BLOCKED_BASENAME_RE = re.compile(
+    r"^(?:Makefile(?:\..*)?|Dockerfile.*|\.env(?:\..*)?|.*\.pem|.*\.key|.*\.pub)$"
+)
+
+# Paths and patterns that must NEVER be modified in a patch (load-bearing rules).
+# These block RCE vectors, credential exposure, and infrastructure changes.
+# (Filename-based hooks live in _BLOCKED_BASENAMES above; this list is for
+# path-position patterns.)
 _BLOCKED_PATH_PATTERNS = [
-    # CI/CD configs (sandbox → CI → secrets)
-    r"\.github/workflows/.*",
+    # CI/CD + governance: block the WHOLE .github tree, not just workflows — the old
+    # rule missed .github/actions/*/action.yml (composite-action RCE),
+    # .github/CODEOWNERS (self-approval rewrite), and .github/dependabot.yml.
+    r"\.github/.*",
     r"\.gitlab-ci\.yml",
     r"\.circleci/.*",
     r"bitbucket-pipelines\.yml",
     r"\.circle/.*",
-    # Build/install hooks (RCE on host)
-    r"^setup\.py$",
-    r"^setup\.cfg$",
-    r"^pyproject\.toml$",
-    r"^Makefile(?:\..*)?$",
-    r"^conftest\.py$",
-    # Package manifests with build hooks
-    r"^Cargo\.toml$",
-    r"^Cargo\.lock$",
-    r"^go\.mod$",
-    r"^go\.sum$",
-    # package.json (only if it contains "scripts" field — caught by content check)
     # Git metadata
     r"\.git/.*",
-    r"\.gitmodules",
-    # Hooks (all forms)
+    # Hooks (all forms, any depth)
     r"\.husky/.*",
     r"\.githooks/.*",
     r".*\/hooks/.*",
-    # Environment and shell configs (often sourced)
-    r"\.env(?:\..*)?",
-    r"\.bashrc",
-    r"\.zshrc",
-    r"\.profile",
-    # Credentials and keys
+    # Credentials and keys (directories)
     r"\.ssh/.*",
     r"\.gnupg/.*",
-    r".*\.pem",
-    r".*\.key",
-    r".*\.pub",
     # Deployment/infrastructure configs
     r"docker-compose(?:\..*)?\.yml",
-    r"Dockerfile.*",
     r"kubernetes/.*",
     r"terraform/.*",
     r"ansible/.*",
@@ -148,6 +166,11 @@ class PatchApplier:
         normalized = file_path
         if normalized.startswith("./"):
             normalized = normalized[2:]
+
+        # Position-independent basename block (any directory depth).
+        basename = normalized.rsplit("/", 1)[-1]
+        if basename in _BLOCKED_BASENAMES or _BLOCKED_BASENAME_RE.match(basename):
+            return True
 
         for pattern in self._compiled_patterns:
             if pattern.match(normalized):

--- a/tests/unit/adapters/workspace/test_patch_applier.py
+++ b/tests/unit/adapters/workspace/test_patch_applier.py
@@ -747,8 +747,54 @@ class TestPatchApplierCustomPatterns:
         assert applier._is_blocked(".custom/file.txt")
         assert applier._is_blocked("forbidden.py")
 
-        # Should not block standard patterns (not in custom list)
-        assert not applier._is_blocked("setup.py")
+        # Custom patterns REPLACE the standard path-pattern list, so a standard
+        # path pattern not in the custom list is not blocked.
+        assert not applier._is_blocked(".github/workflows/ci.yml")
+
+        # …but dangerous RCE-vector BASENAMES (conftest.py/setup.py/…) are always
+        # blocked at any depth, regardless of custom patterns — a custom caller must
+        # not be able to silently un-block a build/test-hook RCE vector.
+        assert applier._is_blocked("setup.py")
+        assert applier._is_blocked("src/conftest.py")
+
+    def test_dangerous_basenames_blocked_at_any_depth(self):
+        """Regression: root-anchored patterns let subdir RCE files slip through."""
+        applier = PatchApplier()
+        for p in [
+            "src/conftest.py",
+            "tools/conftest.py",
+            "pkg/setup.py",
+            "a/b/pyproject.toml",
+            "deep/dir/Makefile",
+            "x/Cargo.toml",
+            "y/tox.ini",
+            "z/noxfile.py",
+            "nested/.pre-commit-config.yaml",
+            "any/where/id.pem",
+        ]:
+            assert applier._is_blocked(p), f"should block {p}"
+
+    def test_whole_github_tree_blocked(self):
+        """Composite actions, CODEOWNERS, dependabot — not just workflows."""
+        applier = PatchApplier()
+        for p in [
+            ".github/workflows/ci.yml",
+            ".github/actions/build/action.yml",
+            ".github/CODEOWNERS",
+            ".github/dependabot.yml",
+        ]:
+            assert applier._is_blocked(p), f"should block {p}"
+
+    def test_legit_paths_not_overblocked(self):
+        applier = PatchApplier()
+        for p in [
+            "src/operations_center/foo.py",
+            "tests/test_x.py",
+            "README.md",
+            "package.json",
+            "docs/guide.md",
+        ]:
+            assert not applier._is_blocked(p), f"should allow {p}"
 
     def test_custom_patterns_in_apply(self):
         """Test that custom patterns are enforced in apply()."""


### PR DESCRIPTION
## What

Closes audit finding **SBX HIGH-2**: the non-executing pre-push path-allowlist applier was leaky.

- Patterns were **root-anchored** (`^conftest\.py$`), so subdirectory variants slipped through. The dangerous one: **`src/conftest.py` / `tools/conftest.py`** — pytest auto-imports *any* `conftest.py` in the collection tree, so a sandboxed agent could drop one and get **RCE the moment CI or the reviewer runs pytest**. Same for `subdir/Makefile`, `pkg/setup.py`, `a/b/pyproject.toml`, nested `Cargo.toml`, etc.
- `.github` only blocked `workflows/` — missing **`.github/actions/*/action.yml`** (composite-action RCE), **`.github/CODEOWNERS`** (self-approval rewrite), and **`.github/dependabot.yml`**.

## Fix

- A position-independent `_BLOCKED_BASENAMES` set + `_BLOCKED_BASENAME_RE` (`Makefile*`/`Dockerfile*`/`.env*`/`*.pem`/`*.key`/`*.pub`), matched on the basename at **any depth**.
- Broadened the path pattern to the **whole `.github/.*` tree**.
- Added `tox.ini`, `noxfile.py`, `.pre-commit-config.{yaml,yml}`.
- The basename block is **always-on** even when a caller passes custom path patterns — a custom caller must not be able to silently un-block a build/test-hook RCE vector.

## Tests

76 applier tests pass. Added regressions for any-depth blocking, the whole-`.github` tree, and a no-overblock check (legit `src/...`, `tests/...`, `package.json`, `README.md` still allowed). Updated the custom-patterns test to the hardened contract. ruff / Custodian clean.

> Scope note: this hardens the path policy on the write path the applier *does* gate. The deeper finding — that a sandboxed agent holds the git push token and can `git push` directly, bypassing the applier entirely — is a separate, larger fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)