### PR TITLE
fix(net): egress proxy fail-closed on missing/mismatched SNI (audit Finding 3, partial)

### DIFF
--- a/src/operations_center/entrypoints/egress_proxy/main.py
+++ b/src/operations_center/entrypoints/egress_proxy/main.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 
 from operations_center.entrypoints.egress_proxy.allowlist import (
     DEFAULT_ALLOWLIST,
@@ -113,7 +114,16 @@ async def _handle(
         cwriter.close()
         return
     sni = extract_sni(hello)
-    if sni is not None and not host_allowed(sni, allowlist):
+    # Fail-CLOSED on the in-TLS SNI. Previously a MISSING sni (ECH / no-SNI
+    # ClientHello) passed — letting an attacker tunnel anywhere through an
+    # allowlisted CONNECT host. Now an absent or non-allowlisted SNI is refused.
+    # OC_EGRESS_SNI_STRICT additionally pins sni == CONNECT host (blocks
+    # in-allowlist domain-fronting, e.g. CONNECT github.com / SNI gist.github…);
+    # opt-in so connection-coalescing clients aren't broken by default.
+    sni_ok = sni is not None and host_allowed(sni, allowlist)
+    if sni_ok and os.environ.get("OC_EGRESS_SNI_STRICT") == "1":
+        sni_ok = sni.lower() == host.lower()
+    if not sni_ok:
         logger.warning("egress DENY sni=%s (connect host=%s) peer=%s", sni, host, peer)
         cwriter.close()
         return

--- a/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
+++ b/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
@@ -112,16 +112,25 @@ def test_proxy_denies_then_tunnels():
             resp = await asyncio.wait_for(r.read(64), timeout=5)
             assert b"403" in resp
             w.close()
-            # 2) ALLOW 127.0.0.1 -> tunnel bytes through to echo
+            # 2) ALLOW 127.0.0.1 + a valid allowlisted ClientHello -> tunnel through
+            #    echo. (A real HTTPS client sends the ClientHello first; the proxy
+            #    now fail-closes on a missing SNI, so plaintext-first no longer works.)
             r2, w2 = await asyncio.open_connection("127.0.0.1", pport)
             w2.write(f"CONNECT 127.0.0.1:{eport} HTTP/1.1\r\n\r\n".encode())
             await w2.drain()
             est = await asyncio.wait_for(r2.read(64), timeout=5)
             assert b"200" in est
+            w2.write(_client_hello("github.com"))  # allowlisted SNI -> passes fail-closed
+            await w2.drain()
             w2.write(b"ping-through-proxy")
             await w2.drain()
-            back = await asyncio.wait_for(r2.read(64), timeout=5)
-            assert back == b"ping-through-proxy"
+            buf = b""
+            while b"ping-through-proxy" not in buf:
+                chunk = await asyncio.wait_for(r2.read(4096), timeout=5)
+                if not chunk:
+                    break
+                buf += chunk
+            assert b"ping-through-proxy" in buf  # bytes tunnelled through to echo
             w2.close()
 
     asyncio.run(scenario())
@@ -161,5 +170,52 @@ def test_proxy_405_on_non_connect_and_sni_deny_and_upstream_fail():
             await w3.drain()
             assert await asyncio.wait_for(r3.read(64), timeout=5) == b""  # upstream fail -> drop
             w3.close()
+
+    asyncio.run(scenario())
+
+
+def test_missing_sni_fails_closed():
+    """A ClientHello with no extractable SNI (ECH / no-SNI) is now REFUSED — it used
+    to pass, letting an attacker tunnel anywhere through an allowlisted CONNECT host."""
+    from operations_center.entrypoints.egress_proxy.main import _handle
+
+    async def scenario():
+        proxy = await asyncio.start_server(
+            lambda r, w: _handle(r, w, DEFAULT_ALLOWLIST), "127.0.0.1", 0
+        )
+        pport = proxy.sockets[0].getsockname()[1]
+        async with proxy:
+            r, w = await asyncio.open_connection("127.0.0.1", pport)
+            w.write(b"CONNECT 127.0.0.1:443 HTTP/1.1\r\n\r\n")  # allowed CONNECT host
+            await w.drain()
+            assert b"200" in await asyncio.wait_for(r.read(64), timeout=5)
+            w.write(b"GET / HTTP/1.1\r\n\r\n")  # not a TLS ClientHello -> SNI None
+            await w.drain()
+            assert await asyncio.wait_for(r.read(64), timeout=5) == b""  # fail-closed: dropped
+            w.close()
+
+    asyncio.run(scenario())
+
+
+def test_strict_sni_pin_denies_allowlisted_mismatch(monkeypatch):
+    """OC_EGRESS_SNI_STRICT=1 pins SNI == CONNECT host: an allowlisted-but-different
+    SNI (in-allowlist domain-fronting) is refused."""
+    monkeypatch.setenv("OC_EGRESS_SNI_STRICT", "1")
+    from operations_center.entrypoints.egress_proxy.main import _handle
+
+    async def scenario():
+        proxy = await asyncio.start_server(
+            lambda r, w: _handle(r, w, DEFAULT_ALLOWLIST), "127.0.0.1", 0
+        )
+        pport = proxy.sockets[0].getsockname()[1]
+        async with proxy:
+            r, w = await asyncio.open_connection("127.0.0.1", pport)
+            w.write(b"CONNECT 127.0.0.1:443 HTTP/1.1\r\n\r\n")  # allowed CONNECT host
+            await w.drain()
+            assert b"200" in await asyncio.wait_for(r.read(64), timeout=5)
+            w.write(_client_hello("github.com"))  # allowlisted, but != CONNECT host
+            await w.drain()
+            assert await asyncio.wait_for(r.read(64), timeout=5) == b""  # strict: dropped
+            w.close()
 
     asyncio.run(scenario())


### PR DESCRIPTION
## What

Hardens the egress proxy's in-TLS SNI verification (audit **Finding 3**) — and reports honestly on why the deeper hole can't be closed in this deployment.

### The fix (clean win for proxy-honoring clients)

- A **missing SNI** (ECH / no-SNI ClientHello) previously **passed** the check (`if sni is not None and not host_allowed(...)`), letting an attacker tunnel to **anywhere** through an allowlisted CONNECT host. Now an absent or non-allowlisted SNI is **refused** (fail-closed).
- `OC_EGRESS_SNI_STRICT=1` additionally pins `sni == CONNECT host`, blocking in-allowlist domain-fronting (CONNECT `github.com` / SNI `gist.githubusercontent.com`). Opt-in so connection-coalescing clients aren't broken by default.

### Honest scope — what this does NOT fix

This only hardens the path for clients that **honor the proxy**. It does not close the core Phase-3 hole: the netns is **shared**, so a sandboxed agent can `unset HTTPS_PROXY` or open a **raw socket** and egress directly (Finding 1), and egress is **fail-open** when the proxy is down (Finding 2).

**I empirically tested the audit's suggested kernel fix and it's dead here:**
```
$ systemd-run --user --scope -p IPAddressDeny=any -p 'IPAddressAllow=127.0.0.0/8 ::1/128' \
    python3 -c 'socket.connect(("1.1.1.1",443))'
EXTERNAL 1.1.1.1:443: CONNECTED   # filter NOT enforced
```
BPF egress filtering needs the **system** manager / cgroup delegation that a rootless `systemd --user` instance lacks. The real structural fix requires **privilege** (root nftables / a system-level unit) or **`--unshare-net` + netns forwarding** — a design effort and an ops/privilege decision, not something to fake in a PR.

## Tests

Updated the tunnel test to send a real ClientHello before data (HTTPS does this; plaintext-first no longer works under fail-closed). 13 proxy + 11 probe tests pass; ruff / ty / Custodian clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)