### PR TITLE
fix(net): assemble full ClientHello before SNI decision (#379 deploy-blocker)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,17 @@
+## 2026-06-21 — NET: fix #379 partial-ClientHello fail-closed regression (deploy-blocker)
+
+Failure investigation found #379 (SNI fail-closed) was a deploy-blocker: it dropped
+on extract_sni()==None, but None ALSO occurs benignly when the proxy's single
+read(4096) returns a PARTIAL ClientHello (TCP segmentation) — confirmed: truncated
+hello -> sni None. Once deployed it would convert intermittent github clone-EOFs
+into deterministic drops. Fix: `_read_client_hello` parses the 5-byte TLS record
+header and accumulates until the full record (capped 16389B) before deciding SNI;
+only a COMPLETE no-SNI hello (real ECH) fail-closes. Validated: segmented-hello test
+tunnels; LIVE shallow clone through the new proxy rc=0. Note: the pre-existing
+clone-EOFs (Jun 20-21, ~4/9 failures) are transient network/TLS to github, NOT from
+#379 (running proxy is still old code); they self-recover via requeue. 25 proxy/probe
+tests pass; ruff/ty/audit clean.
+
 ## 2026-06-21 — INJ: fence fix-loop diff + complete output sanitization (audit G-3/G-1)
 
 Operator confirmed board tasks are operator-authored ONLY → G-2 (unfenced task

--- a/src/operations_center/entrypoints/egress_proxy/main.py
+++ b/src/operations_center/entrypoints/egress_proxy/main.py
@@ -43,8 +43,39 @@ logger = logging.getLogger("oc_egress_proxy")
 
 _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8889
-_PEEK_BYTES = 4096
 _BUF = 65536
+# Max TLS record payload (2^14) + 5-byte record header — the cap for assembling a
+# ClientHello before deciding SNI.
+_CLIENT_HELLO_MAX = 16384 + 5
+_TLS_HANDSHAKE = b"\x16"
+
+
+async def _read_client_hello(reader: asyncio.StreamReader, *, timeout: float) -> bytes:
+    """Read a COMPLETE TLS ClientHello record, tolerating TCP segmentation.
+
+    A single ``read()`` can return a PARTIAL handshake when the ClientHello spans
+    multiple TCP segments; running ``extract_sni`` on a partial record yields a
+    false 'no SNI' and (under fail-closed) wrongly drops a legitimate connection.
+    Parse the 5-byte TLS record header (type, version, length), then accumulate
+    until the full ``5 + length`` record (capped) is buffered. Returns whatever was
+    read — the caller forwards it upstream regardless, and decides SNI on the
+    assembled bytes. A non-handshake first byte (not 0x16) returns immediately so
+    the caller fail-closes a non-TLS tunnel attempt."""
+
+    async def _read_at_least(buf: bytes, n: int) -> bytes:
+        while len(buf) < n:
+            chunk = await reader.read(_BUF)
+            if not chunk:
+                break  # peer closed before the record completed
+            buf += chunk
+        return buf
+
+    buf = await asyncio.wait_for(_read_at_least(b"", 5), timeout=timeout)
+    if len(buf) < 5 or buf[:1] != _TLS_HANDSHAKE:
+        return buf
+    record_len = int.from_bytes(buf[3:5], "big")
+    want = min(5 + record_len, _CLIENT_HELLO_MAX)
+    return await asyncio.wait_for(_read_at_least(buf, want), timeout=timeout)
 
 
 def _parse_connect(line: bytes) -> tuple[str, int] | None:
@@ -107,9 +138,11 @@ async def _handle(
     cwriter.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
     await cwriter.drain()
 
-    # Peek the ClientHello and verify the in-TLS SNI is also allowlisted.
+    # Read the FULL ClientHello (not a single possibly-partial read) before deciding
+    # SNI — a partial read yields a false 'no SNI' that fail-closed would wrongly
+    # drop, breaking legitimate clones whose hello spans TCP segments.
     try:
-        hello = await asyncio.wait_for(creader.read(_PEEK_BYTES), timeout=10)
+        hello = await _read_client_hello(creader, timeout=10)
     except Exception:  # noqa: BLE001 — drop the connection on any read/parse error
         cwriter.close()
         return

--- a/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
+++ b/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
@@ -197,6 +197,50 @@ def test_missing_sni_fails_closed():
     asyncio.run(scenario())
 
 
+def test_segmented_client_hello_still_tunnels():
+    """Regression: a ClientHello split across TCP segments must NOT read as 'no SNI'
+    and get dropped — the proxy assembles the full record before deciding."""
+    from operations_center.entrypoints.egress_proxy.main import _handle
+
+    async def scenario():
+        async def echo(r, w):
+            while (data := await r.read(1024)):
+                w.write(data)
+                await w.drain()
+            w.close()
+        echo_srv = await asyncio.start_server(echo, "127.0.0.1", 0)
+        eport = echo_srv.sockets[0].getsockname()[1]
+        proxy = await asyncio.start_server(
+            lambda r, w: _handle(r, w, DEFAULT_ALLOWLIST), "127.0.0.1", 0
+        )
+        pport = proxy.sockets[0].getsockname()[1]
+        async with echo_srv, proxy:
+            r, w = await asyncio.open_connection("127.0.0.1", pport)
+            w.write(f"CONNECT 127.0.0.1:{eport} HTTP/1.1\r\n\r\n".encode())
+            await w.drain()
+            assert b"200" in await asyncio.wait_for(r.read(64), timeout=5)
+            hello = _client_hello("github.com")  # allowlisted SNI
+            # Send the hello SPLIT across two segments with a gap — the proxy's first
+            # read() sees only a fragment; it must wait for the rest, not fail-close.
+            w.write(hello[:12])
+            await w.drain()
+            await asyncio.sleep(0.05)
+            w.write(hello[12:])
+            await w.drain()
+            w.write(b"ping-through-proxy")
+            await w.drain()
+            buf = b""
+            while b"ping-through-proxy" not in buf:
+                chunk = await asyncio.wait_for(r.read(4096), timeout=5)
+                if not chunk:
+                    break
+                buf += chunk
+            assert b"ping-through-proxy" in buf  # tunnelled despite segmentation
+            w.close()
+
+    asyncio.run(scenario())
+
+
 def test_strict_sni_pin_denies_allowlisted_mismatch(monkeypatch):
     """OC_EGRESS_SNI_STRICT=1 pins SNI == CONNECT host: an allowlisted-but-different
     SNI (in-allowlist domain-fronting) is refused."""


### PR DESCRIPTION
## What

Fixes a **deploy-blocker regression in #379**, surfaced by investigating recent fleet failures.

#379 made the egress proxy **fail-closed** when `extract_sni()` returns `None`. But `None` *also* occurs **benignly** when the proxy's single `read(4096)` returns a **partial ClientHello** (TCP segmentation). Confirmed empirically:

```
full ClientHello       → sni: github.com
partial read (40 bytes) → sni: None   ← would be hard-dropped under fail-closed
```

So once the hardened proxy is deployed, any connection whose ClientHello spans multiple TCP segments would be dropped — converting today's **intermittent** GitHub clone-EOFs into **deterministic** failures. (The running proxy is still old code, so this hasn't bitten production yet — but it would on the next deploy.)

## Fix

`_read_client_hello` parses the 5-byte TLS record header (type/version/length) and **accumulates reads until the full `5 + length` record** (capped at 16389 B) is buffered, *then* decides SNI on the complete hello:
- a genuinely absent SNI (real **ECH / no-SNI** on a *complete* record) still **fail-closes** — the security property of #379 is preserved;
- a non-TLS first byte still fail-closes;
- the assembled bytes are forwarded upstream exactly as before.

## Validation

- New **segmented-ClientHello** regression test: a hello split across two TCP segments now tunnels through (would have dropped before).
- Existing missing-SNI / strict-pin / deny / tunnel tests still pass.
- **LIVE**: a shallow `git clone` of this repo through the new proxy returns `rc=0` (`egress ALLOW github.com sni=github.com`).
- 25 proxy + probe tests pass; ruff / ty / Custodian clean.

## Note on the other failures

The pre-existing clone-EOFs (Jun 20–21, ~4 of 9 recent fleet failures) are **transient** network/TLS to GitHub and are **not** caused by #379 — they self-recover via requeue. This PR is purely the #379 regression-on-deploy; it should also be merged **before** the hardened proxy is redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)