### PR TITLE
fix(custodian): rename .console detectors R1/R2 → OC1/OC2 (id collision)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-06-22 — FU1: fix Custodian detector-id collision (.console R1/R2 → OC1/OC2)
+
+The repo's custom .console detectors registered as "R1"/"R2", colliding with
+Custodian's BUILTIN README R1/R2 (Custodian #48 masking bug). The collision made a
+.console violation (e.g. task.md missing '## Objective') surface under the wrong
+title — "README first H1 does not match repo name" — which misdirected the reviewer
+(it escalated as ci_misconfigured_check) and stalled goal/c99f3159 + the whole goal
+lane for hours. Renamed the custom ids to OC1/OC2 (matching the OC-prefix convention
+of OC3/OC8/OC10…). Now .console findings show their own correct label; the builtin
+README R1/R2 also run independently (and pass — H1 normalizes to match the repo
+name). 14 detector tests pass incl. a regression asserting no R1/R2 collision; audit
+clean.
+
 ## 2026-06-22 — NET: B1 structural egress confinement IMPLEMENTED (opt-in, pasta+netns)
 
 Completed follow-up B. `board_worker/netns.py:maybe_netns` (OC_EGRESS_NETNS=1, fail-open)

--- a/.custodian/detectors.py
+++ b/.custodian/detectors.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 from custodian.audit_kit.detector import LOW, MEDIUM, AuditContext, Detector, DetectorResult
 
-# ── R1: .console/ directory presence ─────────────────────────────────────────
+# ── OC1: .console/ directory presence ─────────────────────────────────────────
 
 _CONSOLE_REQUIRED_FILES = ["task.md", "guidelines.md", "backlog.md", "log.md", "workers.yaml"]
 
@@ -65,7 +65,7 @@ def _detect_r1_console_presence(ctx: AuditContext) -> DetectorResult:
     return DetectorResult(count=len(samples), samples=samples)
 
 
-# ── R2: .console/ file budget and structure ───────────────────────────────────
+# ── OC2: .console/ file budget and structure ───────────────────────────────────
 
 _TASK_SIZE_LIMIT = 100 * 1024  # 100 KB (task.md should remain concise)
 _CONSOLE_SIZE_LIMIT = 500 * 1024  # 500 KB (log.md grows through legitimate operational history)
@@ -138,7 +138,7 @@ def _py_files(root: Path) -> list[Path]:
     return [p for p in root.rglob("*.py") if "__pycache__" not in p.parts]
 
 
-# ── R1: .console/ directory presence validator ───────────────────────────────
+# ── OC1: .console/ directory presence validator ───────────────────────────────
 
 
 def _detect_r1_console_presence(ctx: AuditContext) -> DetectorResult:
@@ -180,7 +180,7 @@ def _detect_r1_console_presence(ctx: AuditContext) -> DetectorResult:
     return DetectorResult(count=0, samples=[])
 
 
-# ── R2: .console/ budget and structure validator ─────────────────────────────
+# ── OC2: .console/ budget and structure validator ─────────────────────────────
 
 
 def _detect_r2_console_budget(ctx: AuditContext) -> DetectorResult:
@@ -852,9 +852,9 @@ def _detect_oc13_test_reimplements_metric(ctx: AuditContext) -> DetectorResult:
 
 def build_oc_detectors() -> list[Detector]:
     return [
-        Detector("R1", ".console/ presence validator", "open", _detect_r1_console_presence, MEDIUM),
+        Detector("OC1", ".console/ presence validator", "open", _detect_r1_console_presence, MEDIUM),
         Detector(
-            "R2",
+            "OC2",
             ".console/ budget and structure validator",
             "open",
             _detect_r2_console_budget,

--- a/tests/unit/detectors/test_r2_console_budget_validator.py
+++ b/tests/unit/detectors/test_r2_console_budget_validator.py
@@ -485,3 +485,21 @@ def test_r2_multiple_violations_reported(tmp_path: Path) -> None:
     # Should report multiple violations
     assert result.count >= 2, f"Should report multiple violations, got {result.count}"
     assert len(result.samples) >= 2, "Should have multiple error samples"
+
+
+def test_console_detector_ids_do_not_collide_with_builtin_readme_r1_r2():
+    """Regression: the custom .console detectors must NOT register as 'R1'/'R2' —
+    those collide with Custodian's builtin README R1/R2, masking each other so a
+    .console violation gets mislabeled as a 'README first H1' finding (the bug that
+    stalled goal/c99f3159). They must use the OC-prefixed ids OC1/OC2."""
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "oc_detectors", str(Path(__file__).resolve().parents[3] / ".custodian" / "detectors.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    ids = {d.id for d in mod.build_oc_detectors()}
+    assert "R1" not in ids and "R2" not in ids, f"custom detectors still collide: {ids & {'R1','R2'}}"
+    assert "OC1" in ids and "OC2" in ids, f"expected OC1/OC2, got {sorted(ids)}"


### PR DESCRIPTION
## What

Fixes the **Custodian detector-id collision** (Custodian #48) that wasted hours diagnosing #374.

The repo's custom `.console` detectors in `.custodian/detectors.py` registered as **`R1`/`R2`** — colliding with Custodian's **builtin README R1/R2**. When two detectors share an id they overwrite/mask each other, so a `.console` violation surfaced under the *wrong* detector's title:

> `task.md` missing `## Objective`  →  reported as **"[R2] README first H1 does not match repo name"**

That mislabeling **actively misdirected diagnosis**: the reviewer saw a nonsensical "README H1" failure on a CLI PR, classified it `ci_misconfigured_check`, escalated to human, and **#374 (plus the entire goal lane via OPEN_PR_GATE) stalled for hours.**

## Fix

Rename the custom ids to **`OC1`/`OC2`** — the OC-prefix convention already used by `OC3`/`OC8`/`OC10`/`OC11`/`OC12`. Now:
- `.console` findings show their own correct label (`.console budget and structure validator` → e.g. `task.md missing ## Objective`);
- the builtin README R1/R2 run **independently** and pass (the H1 normalizes to match the repo name — no new findings).

## Verified

- Broke `task.md` → finding now reads `[MED] [OC2] .console/ budget and structure validator` (was `[R2] README first H1…`).
- Intact tree → clean (0 findings, no regressions).
- 14 detector tests pass, including a **regression test** asserting the custom detectors never re-collide with `R1`/`R2`.

> Note: this fixes the collision for *this* repo. The complementary durable fix is upstream in Custodian (#48) — detect/namespace duplicate detector ids so the masking can't happen for any repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)