### PR TITLE
feat: finish lineage/determinism open items (A3, A4, A5, B3, C2)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8263,3 +8263,23 @@ CI audit (D12 incomplete-integration gate) flagged two unwired symbols:
 display_edges() (now used by cli.render_chain to show the trust split) and
 owner_of() (removed — speculative API with no consumer; ownership is enforced
 internally in append()). D12 gate now clean. PR #388.
+
+## 2026-06-23 — Lineage/determinism follow-ups (A3, A4, A5, B3, C2)
+
+Finished the open spec items on branch feat/lineage-followups:
+- **A5 durable tier** `lineage/durable.py`: append-only JSONL ledger over the D1
+  hash chain; entries loaded VERBATIM (preserve stored hashes) so verify() catches
+  tampering; a tampered ledger vouches for nothing. Projection consults
+  durable_lineage_ids → an aged-source edge stays completeness=durable.
+- **A4 conformance gate** test_conformance.py: rebuild==rebuild determinism;
+  aged source = EXPIRED (not dropped); durable tier keeps aged lineage durable.
+- **A3 RepoGraph binding** `lineage/repograph_binding.py`: maps a chain to
+  RUN/AUDIT/EVIDENCE RepoIdentity + GraphEdge, Source.WORK_SCOPE, derived=true,
+  trust carried into metadata; lazy import; does NOT call RepoGraph.build.
+- **B3 per-root cap** propagating `lineage-root` label + max_descendants_per_root;
+  refuses follow-ups once a root's open descendants hit the cap.
+- **C2 capability owner** `capability_ownership.py`: synchronous resolve_owner +
+  opt-in verify_owner_or_degrade guard wired in BoardUnblockTask. DORMANT — OC's
+  pinned repograph wheel has no capabilities plane, so the registry is None and
+  the guard degrades; load-bearing only once the plane is an OC runtime dep.
+Full suite 8090 green (one observer perf test flakes under -n auto; passes solo).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8283,3 +8283,11 @@ Finished the open spec items on branch feat/lineage-followups:
   pinned repograph wheel has no capabilities plane, so the registry is None and
   the guard degrades; load-bearing only once the plane is an OC runtime dep.
 Full suite 8090 green (one observer perf test flakes under -n auto; passes solo).
+
+## 2026-06-23 — A3 X2 boundary fix
+
+Custodian X2: repograph_binding.py imported repograph directly, crossing the
+undeclared OC->RepoGraph edge (OC depends on platform_manifest, which does not
+re-export the RUN/AUDIT/EVIDENCE EntityKind vocab). Rewrote A3 to emit
+RepoGraph-SHAPED dicts (kind names as strings), no repograph import — a derived
+export the manifest side hydrates. Custodian clean.

--- a/docs/design/EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md
+++ b/docs/design/EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md
@@ -1,10 +1,34 @@
 ---
-status: partially-implemented
+status: implemented
 ---
 
 # Execution Lineage & the Determinism Boundary
 
-**Status:** Draft spec (adversarially reviewed)
+**Status:** Implemented (adversarially reviewed)
+
+## Implementation status (2026-06-23)
+
+All build items shipped (PRs #388, #389):
+
+- **A1–A3, A4, A5** ✅ — `operations_center.lineage` (projection, 4-dim trust,
+  steering split, CLI, integrity, **durable tier**, **RepoGraph binding**) +
+  the **rebuild-conformance gate** (`tests/unit/lineage/test_conformance.py`).
+- **B1, B2, B3, B4** ✅ — admission allowlist, global work ceiling, **per-root
+  descendant cap**, fail-closed containment.
+- **C1** ✅ — self-contained self-merge gate.
+- **C2** ⚠️ **mechanism shipped, dormant-by-environment** —
+  `capability_ownership.py` provides synchronous owner resolution + a wired
+  opt-in guard in `BoardUnblockTask`, but OC's pinned `repograph` wheel ships no
+  capabilities plane, so the registry is unavailable and the guard degrades. It
+  becomes load-bearing only when the capability plane is an OC runtime
+  dependency (a PlatformManifest/dep-pinning concern). Do not claim surface 1
+  closed until the registry loads in production.
+- **D1, D2** ✅ — lineage hash chain + authorship binding; external controller
+  liveness.
+
+Every flag defaults OFF; the steerable set remains empty until an edge is
+`code-computed ∧ chained ∧ durable ∧ causal` (ordering is still host-relative,
+so steering stays impossible by construction — as intended).
 **Date:** 2026-06-22
 **Related:** [[HARNESS_TRUST_HARDENING.md]], [[SELF_HEAL_LADDER.md]], `oc-harness-guide-gap-audit` (memory)
 

--- a/src/operations_center/capability_ownership.py
+++ b/src/operations_center/capability_ownership.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""capability_ownership.py — synchronous capability-owner resolution (C2).
+
+The audit (determinism surface 1) found that exactly-one-owns is enforced only by
+an async Custodian registry-lint that no-ops in OC's own environment — "code acts
+first; the sweep flags drift later." This module provides the *synchronous* check
+the thesis requires: resolve a capability's owner from the registry at the moment
+of invocation and fail-CLOSED if ownership is ambiguous (≠1 owner).
+
+HONEST SCOPE — dormant-by-environment. OC's pinned ``repograph`` wheel does not
+ship the ``capabilities`` plane (it lives in the RepoGraph source / PlatformManifest
+registry, not OC's runtime deps). So ``load_capability_registry`` returns None here
+today and the guard DEGRADES (proceeds) rather than blocking — the mechanism is
+wired and tested, but it does not become load-bearing until the capability plane is
+an OC runtime dependency. That binding is a dependency-pinning concern OC cannot
+self-resolve; this is the EVAL "blocking-deferred" pattern, not a live enforcement.
+Do not claim it closes surface 1 until the registry actually loads in production.
+
+Default posture is opt-in + fail-open (§0.1): the guard is a no-op unless
+``require_capability_owner`` is set, and an unavailable registry degrades rather
+than halting critical self-healing (board_unblock).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class AmbiguousOwnerError(ValueError):
+    """A capability does not have exactly one owner — a real integrity violation."""
+
+
+def _edge_is_owns(edge: object) -> bool:
+    kind = getattr(edge, "kind", None)
+    # string-robust: works against the real CapabilityEdgeKind enum (.value ==
+    # "owns") and any duck-typed test double.
+    return str(getattr(kind, "value", kind)).lower() == "owns"
+
+
+def resolve_owner(registry: object, action_id: str) -> str:
+    """Return the single owner repo_id of ``action_id`` or raise.
+
+    Mirrors RepoGraph's build-time owner-count invariant
+    (capabilities/validation.py) but applied synchronously at call time. Raises
+    ``AmbiguousOwnerError`` on zero or multiple OWNS edges.
+    """
+
+    owners = [
+        getattr(e, "target_id", None)
+        for e in getattr(registry, "edges", ())
+        if getattr(e, "source_id", None) == action_id and _edge_is_owns(e)
+    ]
+    owners = [o for o in owners if o]
+    if len(owners) != 1:
+        raise AmbiguousOwnerError(
+            f"capability {action_id!r} must have exactly one owner, found {len(owners)}"
+        )
+    return owners[0]
+
+
+def load_capability_registry():
+    """Best-effort load of the capability registry, or None if unavailable.
+
+    Returns None in OC's current environment (the pinned ``repograph`` wheel has
+    no capabilities plane) — callers must treat None as "cannot verify" and
+    degrade, never halt.
+    """
+
+    import importlib
+
+    try:
+        mod = importlib.import_module("repograph")
+    except Exception:  # noqa: BLE001 — repograph absent entirely
+        return None
+    loader = getattr(mod, "load_capability_registry", None)
+    if loader is None:
+        # the pinned wheel has no capabilities plane — the expected case today
+        return None
+    try:
+        return loader()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("capability_ownership: registry load failed — %s", exc)
+        return None
+
+
+def verify_owner_or_degrade(
+    action_id: str,
+    *,
+    required: bool,
+    expected_owner: str | None = None,
+    registry: object | None = None,
+) -> bool:
+    """Gate for a capability invocation. Returns True = proceed, False = refuse.
+
+    * ``required`` False → no-op, always proceeds (the default).
+    * registry unavailable → DEGRADE (proceed) with an observable warning; never
+      halt critical self-healing on a missing registry (§0.1).
+    * registry available + exactly one owner (matching ``expected_owner`` if
+      given) → proceed.
+    * registry available + ambiguous owner, or owner ≠ expected → REFUSE
+      (fail-closed): this is the real integrity violation worth blocking on.
+    """
+
+    if not required:
+        return True
+    reg = registry if registry is not None else load_capability_registry()
+    if reg is None:
+        logger.warning(
+            "capability_ownership: registry unavailable, cannot verify %r — degrading "
+            '(proceeding) {"event": "capability_owner_unverifiable", "action": "%s"}',
+            action_id,
+            action_id,
+        )
+        return True
+    try:
+        owner = resolve_owner(reg, action_id)
+    except AmbiguousOwnerError as exc:
+        logger.error(
+            "capability_ownership: REFUSING %r — %s "
+            '{"event": "capability_owner_ambiguous", "action": "%s"}',
+            action_id,
+            exc,
+            action_id,
+        )
+        return False
+    if expected_owner is not None and owner != expected_owner:
+        logger.error(
+            "capability_ownership: REFUSING %r — owner %r != expected %r",
+            action_id,
+            owner,
+            expected_owner,
+        )
+        return False
+    return True
+
+
+__all__ = [
+    "AmbiguousOwnerError",
+    "load_capability_registry",
+    "resolve_owner",
+    "verify_owner_or_degrade",
+]

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -535,6 +535,18 @@ class Settings(BaseModel):
     # (follow-ups, scope-splits, maintenance fix-tasks) refuse to create more
     # once reached, so a systemic fault cannot flood the board. 0 = disabled.
     max_open_fleet_tasks: int = 0
+    # Per-root descendant cap (B3, determinism surface 7). Bounds the AGGREGATE
+    # number of open follow-up/scope-split descendants sharing one lineage root,
+    # so a single runaway root cannot consume the whole global budget even when
+    # each generation is individually under the per-lineage retry cap. 0 = off.
+    max_descendants_per_root: int = 0
+    # Synchronous capability-owner check (C2, determinism surface 1). When set,
+    # owner-bearing capabilities (board_unblock) verify exactly-one-owner from the
+    # registry at invocation and refuse on ambiguity, instead of trusting the
+    # async Custodian lint. DORMANT-by-environment: OC's pinned repograph wheel has
+    # no capabilities plane, so the registry is unavailable and the guard degrades
+    # (proceeds) until that becomes a runtime dependency. False = off (default).
+    require_capability_owner: bool = False
 
     def plane_token(self) -> str:
         return os.environ[self.plane.api_token_env]

--- a/src/operations_center/entrypoints/board_worker/outcomes.py
+++ b/src/operations_center/entrypoints/board_worker/outcomes.py
@@ -24,7 +24,7 @@ from .labels import (
     label_value,
     retry_count_from_labels,
 )
-from .work_ceiling import ceiling_reached
+from .work_ceiling import ceiling_reached, root_descendant_cap_reached
 
 logger = logging.getLogger(__name__)
 
@@ -588,6 +588,20 @@ def create_follow_up(
         )
         return ""
 
+    # Per-root descendant cap (surface 7): a lineage root propagates down the
+    # tree; even fresh-lineage scope-split children inherit it, so one runaway
+    # root cannot keep spawning under the per-generation retry cap.
+    lineage_root = label_value(parent_labels, "lineage-root") or parent_id
+    if root_descendant_cap_reached(client, _settings, lineage_root):
+        logger.warning(
+            "board_worker: refusing follow-up — per-root descendant cap reached "
+            "(root=%s parent task_id=%s kind=%s)",
+            lineage_root,
+            parent_id,
+            follow_kind,
+        )
+        return ""
+
     description = (
         f"## Goal\n{parent_title} — {reason.replace('_', ' ')}\n\n"
         f"## Execution\n"
@@ -611,6 +625,7 @@ def create_follow_up(
         "source: board_worker",
         *inherited_sources,
         f"original-task-id: {parent_id}",
+        f"lineage-root: {lineage_root}",
         f"handoff-reason: {reason}",
         f"retry-count: {retry_count + 1}",
     ]

--- a/src/operations_center/entrypoints/board_worker/work_ceiling.py
+++ b/src/operations_center/entrypoints/board_worker/work_ceiling.py
@@ -58,6 +58,51 @@ def fleet_open_work_count(issues: list[dict]) -> int:
     return sum(1 for issue in issues if _is_open(issue) and _is_fleet_created(issue))
 
 
+def open_descendants_of_root(issues: list[dict], root: str) -> int:
+    """Count open tasks carrying ``lineage-root: <root>`` — the aggregate size of
+    one lineage tree, regardless of per-generation retry depth."""
+
+    target = f"lineage-root: {root}".lower()
+    out = 0
+    for issue in issues:
+        if not _is_open(issue):
+            continue
+        if any(n.lower() == target for n in _label_names(issue)):
+            out += 1
+    return out
+
+
+def root_descendant_cap_reached(client, settings, root: str) -> bool:
+    """True if the lineage tree rooted at ``root`` has reached its per-root cap.
+
+    Fail-open like ``ceiling_reached``: disabled (0) or an unreadable board never
+    throttles. ``root`` falsy → no cap (can't scope a count).
+    """
+
+    cap = int(getattr(settings, "max_descendants_per_root", 0) or 0)
+    if cap <= 0 or not root:
+        return False
+    try:
+        issues = client.list_issues()
+    except Exception:
+        logger.warning("work_ceiling: failed to list issues for root cap — not throttling")
+        return False
+    count = open_descendants_of_root(issues, root)
+    if count >= cap:
+        logger.warning(
+            "work_ceiling: per-root cap REACHED — root=%s has %d/%d open descendants "
+            '{"event": "root_descendant_cap_reached", "root": "%s", "open": %d, "cap": %d}',
+            root,
+            count,
+            cap,
+            root,
+            count,
+            cap,
+        )
+        return True
+    return False
+
+
 def ceiling_reached(client, settings) -> bool:
     """True if the fleet has reached its global open-work ceiling.
 
@@ -87,4 +132,9 @@ def ceiling_reached(client, settings) -> bool:
     return False
 
 
-__all__ = ["ceiling_reached", "fleet_open_work_count"]
+__all__ = [
+    "ceiling_reached",
+    "fleet_open_work_count",
+    "open_descendants_of_root",
+    "root_descendant_cap_reached",
+]

--- a/src/operations_center/entrypoints/maintenance/board_unblock_task.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock_task.py
@@ -31,6 +31,7 @@ from datetime import UTC, datetime
 
 from operations_center.adapters.github_pr import GitHubPRClient
 from operations_center.adapters.plane import PlaneClient
+from operations_center.capability_ownership import verify_owner_or_degrade
 from operations_center.config.settings import Settings
 from operations_center.in_flight_reconcile import state_name as _state_name
 from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceResult
@@ -251,6 +252,21 @@ class BoardUnblockTask:
                 status="skipped",
                 duration_seconds=time.monotonic() - started,
                 details={"reason": f"mem_available {mem_gb:.2f}GB < {_MEM_SKIP_THRESHOLD_GB}GB"},
+            )
+
+        # Synchronous capability-owner check (surface 1). No-op unless
+        # require_capability_owner is set; degrades (proceeds) when the capability
+        # registry is unavailable, so this never halts self-healing on its own.
+        if not verify_owner_or_degrade(
+            self.name,
+            required=getattr(self._settings, "require_capability_owner", False),
+            expected_owner=getattr(self._settings, "self_repo_key", None),
+        ):
+            return MaintenanceResult(
+                name=self.name,
+                status="skipped",
+                duration_seconds=time.monotonic() - started,
+                details={"reason": "capability_owner_ambiguous"},
             )
 
         client = ctx.resources.get("plane_client") or self._make_plane_client()

--- a/src/operations_center/lineage/__init__.py
+++ b/src/operations_center/lineage/__init__.py
@@ -10,6 +10,7 @@ own untrustworthiness, and exposes a single sanctioned steering path.
 
 from __future__ import annotations
 
+from .durable import DurableLineageStore, lineage_id_for_task
 from .integrity import (
     AuthorshipError,
     LedgerEntry,
@@ -28,11 +29,13 @@ from .models import (
     TrustFlags,
 )
 from .projection import build_all, build_chain
+from .repograph_binding import to_repograph
 from .steering import SteerableFact, steerable_facts
 
 __all__ = [
     "AuthorshipError",
     "Completeness",
+    "DurableLineageStore",
     "Integrity",
     "LedgerEntry",
     "LineageChain",
@@ -47,5 +50,7 @@ __all__ = [
     "build_chain",
     "chained_trust",
     "entry_hash",
+    "lineage_id_for_task",
     "steerable_facts",
+    "to_repograph",
 ]

--- a/src/operations_center/lineage/durable.py
+++ b/src/operations_center/lineage/durable.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""lineage/durable.py — the durable lineage tier (Phase A5).
+
+The projection reads signals that the fleet GCs at ~44 days, so a rebuild past
+that horizon yields a smaller graph than the live one — "derived ⇒ can't drift"
+is false once source lifetime < projection lifetime (spec §1.3). This tier closes
+that: lineage entries are appended to a git-trackable JSON ledger whose retention
+is independent of the source, so an edge backed by the durable tier stays
+``completeness=durable`` even after its source record is GC'd.
+
+It wraps the D1 ``LineageLedger`` (hash chain + authorship binding), so a durable
+entry is also tamper-evident and authorship-bound — the two properties an edge
+needs before it may ever be steerable.
+
+Writes are atomic (tmp + ``os.replace``). The store never deletes; trimming is an
+operator decision, not the fleet's.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+from .integrity import LedgerEntry, LineageLedger
+
+_DEFAULT_PATH = Path("state") / "lineage" / "ledger.jsonl"
+
+
+class DurableLineageStore:
+    """Append-only, on-disk lineage ledger backing the durable tier."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or _DEFAULT_PATH
+        self._ledger = self._load()
+
+    # ── load / persist ────────────────────────────────────────────────────────
+    def _load(self) -> LineageLedger:
+        ledger = LineageLedger()
+        if not self.path.is_file():
+            return ledger
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                # Reconstruct each entry VERBATIM (preserving the stored prior/
+                # this hashes) rather than re-appending — re-appending would
+                # recompute the chain and silently re-bless a tampered payload,
+                # defeating tamper-evidence. verify() then recomputes from the
+                # payload and compares to the stored hash, so a mutated line is
+                # caught. A malformed line is skipped, not fatal (§0.1).
+                entry = LedgerEntry(
+                    lineage_id=rec["lineage_id"],
+                    author=rec["author"],
+                    payload=rec["payload"],
+                    prior_hash=rec["prior_hash"],
+                    this_hash=rec["this_hash"],
+                )
+                ledger.entries.append(entry)
+                ledger._owner.setdefault(entry.lineage_id, entry.author)
+                ledger._tip[entry.lineage_id] = entry.this_hash
+            except Exception:  # noqa: BLE001 — a bad line must not break load
+                continue
+        return ledger
+
+    def _persist_entry(self, entry: LedgerEntry) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(entry), ensure_ascii=False, sort_keys=True)
+        # Append durably: read-existing + rewrite via atomic replace so a crash
+        # mid-write can't leave a torn last line that breaks the next load.
+        existing = self.path.read_text(encoding="utf-8") if self.path.is_file() else ""
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(existing + line + "\n", encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    # ── public API ────────────────────────────────────────────────────────────
+    def append(self, lineage_id: str, author: str, payload: dict) -> LedgerEntry:
+        """Append an entry (authorship-bound, hash-chained) and persist it.
+
+        Raises ``AuthorshipError`` if ``author`` does not own ``lineage_id`` — the
+        forged write is neither chained nor persisted.
+        """
+
+        entry = self._ledger.append(lineage_id, author, payload)
+        self._persist_entry(entry)
+        return entry
+
+    def verify(self) -> bool:
+        return self._ledger.verify()
+
+    def durable_lineage_ids(self) -> set[str]:
+        """The set of lineage_ids the durable tier vouches for — but only if the
+        whole chain verifies. A tampered ledger vouches for NOTHING (returns an
+        empty set), so a corrupted durable tier degrades to source-age semantics
+        rather than falsely marking edges durable."""
+
+        if not self._ledger.verify():
+            return set()
+        return {e.lineage_id for e in self._ledger.entries}
+
+    @property
+    def entries(self) -> list[LedgerEntry]:
+        return list(self._ledger.entries)
+
+
+def lineage_id_for_task(task_id: str) -> str:
+    """The lineage_id the fleet derives for a task (mirrors outcomes.py)."""
+
+    return f"lin-{task_id[:12]}"
+
+
+__all__ = ["DurableLineageStore", "lineage_id_for_task"]

--- a/src/operations_center/lineage/projection.py
+++ b/src/operations_center/lineage/projection.py
@@ -55,10 +55,20 @@ def _parse_ts(value: Any) -> datetime | None:
     return ts
 
 
-def _completeness(ts: datetime | None, *, now: datetime, retention_days: int) -> Completeness:
+def _completeness(
+    ts: datetime | None,
+    *,
+    now: datetime,
+    retention_days: int,
+    durable: bool = False,
+) -> Completeness:
     """An edge older than the source retention window is not reproducible on a
-    rebuild from source, so it is EXPIRED even if the file is still present."""
+    rebuild from source, so it is EXPIRED even if the file is still present —
+    UNLESS the durable tier (Phase A5) vouches for its lineage, in which case it
+    stays DURABLE because that tier outlives the source GC."""
 
+    if durable:
+        return Completeness.DURABLE
     if ts is None:
         return Completeness.EXPIRED
     if now - ts > timedelta(days=retention_days):
@@ -114,10 +124,17 @@ def build_chain(
     state_dir: Path,
     now: datetime | None = None,
     retention_days: int = _DEFAULT_RETENTION_DAYS,
+    durable_lineage_ids: set[str] | None = None,
 ) -> LineageChain:
-    """Assemble the lineage chain for one task_id from on-disk signals."""
+    """Assemble the lineage chain for one task_id from on-disk signals.
+
+    ``durable_lineage_ids`` (Phase A5) is the set of lineage_ids the durable tier
+    vouches for; an edge whose lineage is durable stays ``completeness=durable``
+    even when its source record is past the GC horizon.
+    """
 
     now = now or datetime.now(timezone.utc)
+    durable = (durable_lineage_ids is not None) and (f"lin-{task_id[:12]}" in durable_lineage_ids)
     runs = [r for r in _iter_runs(runs_root) if r.task_id == task_id]
     pr_states = _load_pr_reviews(state_dir)
 
@@ -141,7 +158,7 @@ def build_chain(
             kind="task",
             trust=default_trust(
                 provenance=Provenance.TEXT_DERIVED,
-                completeness=_completeness(task_ts, now=now, retention_days=retention_days),
+                completeness=_completeness(task_ts, now=now, retention_days=retention_days, durable=durable),
             ),
             attributes={"task_id": task_id, "repo_key": repo, "goal_text": goal},
         )
@@ -151,7 +168,7 @@ def build_chain(
     for r in runs:
         run_node_id = f"run:{r.run_id}"
         run_ts = _parse_ts(r.meta.get("written_at"))
-        run_complete = _completeness(run_ts, now=now, retention_days=retention_days)
+        run_complete = _completeness(run_ts, now=now, retention_days=retention_days, durable=durable)
         # Run/proposal facts are machine-generated → code-computed.
         nodes.append(
             LineageNode(
@@ -203,7 +220,7 @@ def build_chain(
             continue
         pr_node_id = f"pr:{pr_num}"
         pr_ts = _parse_ts(state.get("updated_at")) or _parse_ts(state.get("created_at"))
-        pr_complete = _completeness(pr_ts, now=now, retention_days=retention_days)
+        pr_complete = _completeness(pr_ts, now=now, retention_days=retention_days, durable=durable)
         nodes.append(
             LineageNode(
                 node_id=pr_node_id,
@@ -270,6 +287,7 @@ def build_all(
     state_dir: Path,
     now: datetime | None = None,
     retention_days: int = _DEFAULT_RETENTION_DAYS,
+    durable_lineage_ids: set[str] | None = None,
 ) -> dict[str, LineageChain]:
     """Build chains for every task_id discoverable in the run artifacts."""
 
@@ -287,6 +305,7 @@ def build_all(
             state_dir=state_dir,
             now=now,
             retention_days=retention_days,
+            durable_lineage_ids=durable_lineage_ids,
         )
         for tid in sorted(task_ids)
     }

--- a/src/operations_center/lineage/repograph_binding.py
+++ b/src/operations_center/lineage/repograph_binding.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""lineage/repograph_binding.py — express a lineage chain in RepoGraph terms (A3).
+
+Maps a ``LineageChain`` into RepoGraph's existing RUN / AUDIT / EVIDENCE node
+vocabulary and ontology edges, so the lineage read-model can live in the
+projection plane rather than as a bespoke side structure (spec §1.2, A3).
+
+Two deliberate properties:
+
+* **Derived, never authored.** Every node/edge is stamped ``Source.WORK_SCOPE``
+  and carries ``metadata[("derived", "true")]`` so it can never be mistaken for a
+  hand-authored platform fact. The binding does NOT call ``RepoGraph.build`` —
+  lineage nodes are not repositories and must not be subjected to (or pollute)
+  topology validation; it returns the RepoGraph-native building blocks for a
+  consumer to merge into a projection.
+* **Trust is preserved.** Each node/edge's four trust dimensions are carried into
+  ``metadata`` verbatim, so a downstream RepoGraph consumer sees the same honest
+  steerable/display-only split the native chain exposes.
+
+Imports of ``repograph`` are lazy (inside the function) so the core lineage
+package stays importable in environments without the manifest library.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .models import LineageChain
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    pass
+
+# lineage node.kind → RepoGraph EntityKind name. RepoGraph has no "task"/"pr"
+# kind; map to the closest execution-lineage primitive it does have.
+_KIND_TO_ENTITY = {
+    "task": "RUN",
+    "run": "RUN",
+    "pr": "EVIDENCE",
+    "verdict": "AUDIT",
+    "merge": "EVIDENCE",
+}
+
+# lineage edge.kind → RepoGraph EdgeKind name.
+_EDGE_TO_KIND = {
+    "executed_as": "ORCHESTRATES",
+    "produced_pr": "PRODUCES_ARTIFACT",
+    "reviewed_as": "VALIDATES_OUTPUT",
+    "merged_as": "INDEXES_OUTPUT",
+}
+
+
+def _trust_metadata(trust) -> list[tuple[str, str]]:
+    d = trust.as_dict()
+    return [(f"trust.{k}", v) for k, v in d.items()] + [
+        ("steerable", "true" if trust.is_steerable() else "false")
+    ]
+
+
+def to_repograph(chain: LineageChain) -> tuple[list[Any], list[Any]]:
+    """Return ``(nodes, relationships)`` as RepoGraph ``RepoIdentity`` +
+    ``GraphEdge`` objects representing the lineage chain. Derived/read-only."""
+
+    from repograph.ontology.enums import EntityKind, Source
+    from repograph.ontology.models import RepoIdentity
+    from repograph.topology.edges import EdgeKind
+    from repograph.topology.models import GraphEdge
+
+    nodes: list[Any] = []
+    for n in chain.nodes:
+        entity = EntityKind[_KIND_TO_ENTITY.get(n.kind, "RUN")]
+        meta = [("derived", "true"), ("lineage_kind", n.kind), *_trust_metadata(n.trust)]
+        nodes.append(
+            RepoIdentity(
+                repo_id=n.node_id,
+                canonical_name=n.node_id,
+                kind=entity,
+                source=Source.WORK_SCOPE,
+                metadata=tuple(meta),
+            )
+        )
+
+    relationships: list[Any] = []
+    for e in chain.edges:
+        edge_kind = EdgeKind[_EDGE_TO_KIND.get(e.kind, "REPORTS_TO")]
+        meta = [("derived", "true"), ("lineage_edge", e.kind), *_trust_metadata(e.trust)]
+        relationships.append(
+            GraphEdge(
+                relationship_id=f"{e.src}->{e.dst}:{e.kind}",
+                source_id=e.src,
+                target_id=e.dst,
+                kind=edge_kind,
+                source=Source.WORK_SCOPE,
+                metadata=tuple(meta),
+            )
+        )
+    return nodes, relationships
+
+
+__all__ = ["to_repograph"]

--- a/src/operations_center/lineage/repograph_binding.py
+++ b/src/operations_center/lineage/repograph_binding.py
@@ -3,96 +3,83 @@
 """lineage/repograph_binding.py — express a lineage chain in RepoGraph terms (A3).
 
 Maps a ``LineageChain`` into RepoGraph's existing RUN / AUDIT / EVIDENCE node
-vocabulary and ontology edges, so the lineage read-model can live in the
-projection plane rather than as a bespoke side structure (spec §1.2, A3).
+vocabulary and ontology edges, so the lineage read-model can be merged into the
+projection plane rather than living as a bespoke side structure (spec §1.2, A3).
 
-Two deliberate properties:
+**Boundary-respecting export.** OperationsCenter's sanctioned dependency is
+``platform_manifest`` (it consumes the *EffectiveRepoGraph*), not the lower-level
+``repograph`` package — and ``platform_manifest`` does not re-export the
+RUN/AUDIT/EVIDENCE ``EntityKind`` vocabulary. So rather than import ``repograph``
+directly (which would cross an undeclared cross-repo edge — Custodian X2), this
+emits **RepoGraph-shaped dicts** using the kind *names* as strings. The manifest
+side, which does have ``repograph``, can hydrate these into ``RepoIdentity`` /
+``GraphEdge`` objects. This keeps OC decoupled from repograph internals.
 
-* **Derived, never authored.** Every node/edge is stamped ``Source.WORK_SCOPE``
-  and carries ``metadata[("derived", "true")]`` so it can never be mistaken for a
-  hand-authored platform fact. The binding does NOT call ``RepoGraph.build`` —
-  lineage nodes are not repositories and must not be subjected to (or pollute)
-  topology validation; it returns the RepoGraph-native building blocks for a
-  consumer to merge into a projection.
-* **Trust is preserved.** Each node/edge's four trust dimensions are carried into
-  ``metadata`` verbatim, so a downstream RepoGraph consumer sees the same honest
-  steerable/display-only split the native chain exposes.
-
-Imports of ``repograph`` are lazy (inside the function) so the core lineage
-package stays importable in environments without the manifest library.
+Two deliberate properties carry over: every node/edge is stamped
+``source="work_scope"`` + ``metadata["derived"]="true"`` (never mistakable for a
+hand-authored platform fact), and each one's four trust dimensions are carried in
+``metadata`` verbatim so a downstream consumer sees the same honest
+steerable/display-only split.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
 from .models import LineageChain
 
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    pass
-
-# lineage node.kind → RepoGraph EntityKind name. RepoGraph has no "task"/"pr"
+# lineage node.kind → RepoGraph EntityKind value. RepoGraph has no "task"/"pr"
 # kind; map to the closest execution-lineage primitive it does have.
 _KIND_TO_ENTITY = {
-    "task": "RUN",
-    "run": "RUN",
-    "pr": "EVIDENCE",
-    "verdict": "AUDIT",
-    "merge": "EVIDENCE",
+    "task": "Run",
+    "run": "Run",
+    "pr": "Evidence",
+    "verdict": "Audit",
+    "merge": "Evidence",
 }
 
-# lineage edge.kind → RepoGraph EdgeKind name.
+# lineage edge.kind → RepoGraph EdgeKind value.
 _EDGE_TO_KIND = {
-    "executed_as": "ORCHESTRATES",
-    "produced_pr": "PRODUCES_ARTIFACT",
-    "reviewed_as": "VALIDATES_OUTPUT",
-    "merged_as": "INDEXES_OUTPUT",
+    "executed_as": "orchestrates",
+    "produced_pr": "produces_artifact",
+    "reviewed_as": "validates_output",
+    "merged_as": "indexes_output",
 }
 
 
-def _trust_metadata(trust) -> list[tuple[str, str]]:
-    d = trust.as_dict()
-    return [(f"trust.{k}", v) for k, v in d.items()] + [
-        ("steerable", "true" if trust.is_steerable() else "false")
-    ]
+def _trust_metadata(trust) -> dict[str, str]:
+    md = {f"trust.{k}": v for k, v in trust.as_dict().items()}
+    md["steerable"] = "true" if trust.is_steerable() else "false"
+    return md
 
 
-def to_repograph(chain: LineageChain) -> tuple[list[Any], list[Any]]:
-    """Return ``(nodes, relationships)`` as RepoGraph ``RepoIdentity`` +
-    ``GraphEdge`` objects representing the lineage chain. Derived/read-only."""
+def to_repograph(chain: LineageChain) -> tuple[list[dict], list[dict]]:
+    """Return ``(nodes, relationships)`` as RepoGraph-shaped dicts representing
+    the lineage chain. Derived/read-only; no ``repograph`` import."""
 
-    from repograph.ontology.enums import EntityKind, Source
-    from repograph.ontology.models import RepoIdentity
-    from repograph.topology.edges import EdgeKind
-    from repograph.topology.models import GraphEdge
-
-    nodes: list[Any] = []
+    nodes: list[dict] = []
     for n in chain.nodes:
-        entity = EntityKind[_KIND_TO_ENTITY.get(n.kind, "RUN")]
-        meta = [("derived", "true"), ("lineage_kind", n.kind), *_trust_metadata(n.trust)]
+        metadata = {"derived": "true", "lineage_kind": n.kind, **_trust_metadata(n.trust)}
         nodes.append(
-            RepoIdentity(
-                repo_id=n.node_id,
-                canonical_name=n.node_id,
-                kind=entity,
-                source=Source.WORK_SCOPE,
-                metadata=tuple(meta),
-            )
+            {
+                "repo_id": n.node_id,
+                "canonical_name": n.node_id,
+                "kind": _KIND_TO_ENTITY.get(n.kind, "Run"),
+                "source": "work_scope",
+                "metadata": metadata,
+            }
         )
 
-    relationships: list[Any] = []
+    relationships: list[dict] = []
     for e in chain.edges:
-        edge_kind = EdgeKind[_EDGE_TO_KIND.get(e.kind, "REPORTS_TO")]
-        meta = [("derived", "true"), ("lineage_edge", e.kind), *_trust_metadata(e.trust)]
+        metadata = {"derived": "true", "lineage_edge": e.kind, **_trust_metadata(e.trust)}
         relationships.append(
-            GraphEdge(
-                relationship_id=f"{e.src}->{e.dst}:{e.kind}",
-                source_id=e.src,
-                target_id=e.dst,
-                kind=edge_kind,
-                source=Source.WORK_SCOPE,
-                metadata=tuple(meta),
-            )
+            {
+                "relationship_id": f"{e.src}->{e.dst}:{e.kind}",
+                "source_id": e.src,
+                "target_id": e.dst,
+                "kind": _EDGE_TO_KIND.get(e.kind, "reports_to"),
+                "source": "work_scope",
+                "metadata": metadata,
+            }
         )
     return nodes, relationships
 

--- a/tests/unit/entrypoints/board_worker/test_work_ceiling.py
+++ b/tests/unit/entrypoints/board_worker/test_work_ceiling.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock
 from operations_center.entrypoints.board_worker.work_ceiling import (
     ceiling_reached,
     fleet_open_work_count,
+    open_descendants_of_root,
+    root_descendant_cap_reached,
 )
 
 
@@ -65,3 +67,57 @@ def test_ceiling_fail_open_on_list_error():
     settings = SimpleNamespace(max_open_fleet_tasks=1)
     # a broken count must not deadlock self-healing
     assert ceiling_reached(client, settings) is False
+
+
+# ── Per-root descendant cap (B3, determinism surface 7) ────────────────────────
+
+
+def _rooted(root, *, state="Ready for AI"):
+    return _issue(state=state, labels=[f"lineage-root: {root}", "source: board_worker"])
+
+
+def test_open_descendants_counts_only_matching_root():
+    issues = [
+        _rooted("R1"),
+        _rooted("R1"),
+        _rooted("R1", state="Done"),  # terminal → excluded
+        _rooted("R2"),
+        _issue(labels=["task-kind: goal"]),  # no root → excluded
+    ]
+    assert open_descendants_of_root(issues, "R1") == 2
+    assert open_descendants_of_root(issues, "R2") == 1
+
+
+def test_root_cap_disabled_by_default():
+    client = MagicMock()
+    assert root_descendant_cap_reached(client, SimpleNamespace(), "R1") is False
+    client.list_issues.assert_not_called()
+
+
+def test_root_cap_empty_root_never_throttles():
+    client = MagicMock()
+    settings = SimpleNamespace(max_descendants_per_root=1)
+    assert root_descendant_cap_reached(client, settings, "") is False
+    client.list_issues.assert_not_called()
+
+
+def test_root_cap_reached():
+    client = MagicMock()
+    client.list_issues.return_value = [_rooted("R1") for _ in range(4)]
+    settings = SimpleNamespace(max_descendants_per_root=4)
+    assert root_descendant_cap_reached(client, settings, "R1") is True
+
+
+def test_root_cap_not_reached_for_other_root():
+    client = MagicMock()
+    client.list_issues.return_value = [_rooted("R1") for _ in range(9)]
+    settings = SimpleNamespace(max_descendants_per_root=3)
+    # a different root with no descendants is unaffected by R1's overflow
+    assert root_descendant_cap_reached(client, settings, "R2") is False
+
+
+def test_root_cap_fail_open_on_error():
+    client = MagicMock()
+    client.list_issues.side_effect = RuntimeError("plane down")
+    settings = SimpleNamespace(max_descendants_per_root=1)
+    assert root_descendant_cap_reached(client, settings, "R1") is False

--- a/tests/unit/lineage/test_conformance.py
+++ b/tests/unit/lineage/test_conformance.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Rebuild-conformance gate (Phase A4, determinism surface 4 / spec §1.3, A4).
+
+Pins the property the spec demands: a rebuild from source is deterministic, and
+an edge whose source has aged past the GC horizon is marked EXPIRED (not silently
+dropped) UNLESS the durable tier (A5) vouches for it. This is the gate that "fails
+today, passes after A5" — here it passes precisely because A5 is wired.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from operations_center.lineage import Completeness, build_all, build_chain
+from operations_center.lineage.durable import DurableLineageStore, lineage_id_for_task
+
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+_OLD_TASK = "old00000-1111-2222"
+_FRESH_TASK = "new00000-3333-4444"
+
+
+def _write_run(runs: Path, *, run_id: str, task_id: str, written_at: datetime) -> None:
+    d = runs / run_id
+    d.mkdir(parents=True)
+    (d / "proposal.json").write_text(
+        json.dumps({"proposal_id": "p", "task_id": task_id, "goal_text": "g", "target": {}})
+    )
+    (d / "run_metadata.json").write_text(
+        json.dumps({"run_id": run_id, "status": "succeeded", "success": True,
+                    "written_at": written_at.isoformat()})
+    )
+    (d / "result.json").write_text(json.dumps({"run_id": run_id, "pull_request_url": None}))
+
+
+def _corpus(tmp_path: Path) -> tuple[Path, Path]:
+    runs = tmp_path / "runs"
+    state = tmp_path / "state"
+    _write_run(runs, run_id="r-old", task_id=_OLD_TASK, written_at=_NOW - timedelta(days=90))
+    _write_run(runs, run_id="r-new", task_id=_FRESH_TASK, written_at=_NOW - timedelta(days=2))
+    return runs, state
+
+
+def _run_completeness(chain) -> Completeness:
+    return next(n for n in chain.nodes if n.kind == "run").trust.completeness
+
+
+def test_rebuild_is_deterministic(tmp_path: Path):
+    runs, state = _corpus(tmp_path)
+    a = build_all(runs_root=runs, state_dir=state, now=_NOW)
+    b = build_all(runs_root=runs, state_dir=state, now=_NOW)
+    assert {k: v.as_dict() for k, v in a.items()} == {k: v.as_dict() for k, v in b.items()}
+
+
+def test_aged_source_is_expired_not_dropped(tmp_path: Path):
+    runs, state = _corpus(tmp_path)
+    chains = build_all(runs_root=runs, state_dir=state, now=_NOW, retention_days=44)
+    # the old task still APPEARS (not silently dropped) but is marked expired
+    assert _OLD_TASK in chains
+    assert _run_completeness(chains[_OLD_TASK]) is Completeness.EXPIRED
+    # the fresh one is durable
+    assert _run_completeness(chains[_FRESH_TASK]) is Completeness.DURABLE
+
+
+def test_durable_tier_keeps_aged_lineage_durable(tmp_path: Path):
+    runs, state = _corpus(tmp_path)
+    # A5: record the OLD task's lineage in the durable tier
+    store = DurableLineageStore(tmp_path / "ledger.jsonl")
+    store.append(lineage_id_for_task(_OLD_TASK), "goal-lane", {"step": "merged"})
+
+    chain = build_chain(
+        _OLD_TASK,
+        runs_root=runs,
+        state_dir=state,
+        now=_NOW,
+        retention_days=44,
+        durable_lineage_ids=store.durable_lineage_ids(),
+    )
+    # now the aged source is DURABLE because the durable tier outlives source GC
+    assert _run_completeness(chain) is Completeness.DURABLE
+
+
+def test_durable_tier_does_not_rescue_untracked_lineage(tmp_path: Path):
+    runs, state = _corpus(tmp_path)
+    store = DurableLineageStore(tmp_path / "ledger.jsonl")
+    store.append(lineage_id_for_task(_FRESH_TASK), "goal-lane", {})  # only the fresh one
+    chain = build_chain(
+        _OLD_TASK, runs_root=runs, state_dir=state, now=_NOW, retention_days=44,
+        durable_lineage_ids=store.durable_lineage_ids(),
+    )
+    assert _run_completeness(chain) is Completeness.EXPIRED

--- a/tests/unit/lineage/test_durable.py
+++ b/tests/unit/lineage/test_durable.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the durable lineage tier (Phase A5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from operations_center.lineage.durable import DurableLineageStore, lineage_id_for_task
+from operations_center.lineage.integrity import AuthorshipError
+
+
+def test_append_persists_and_reloads(tmp_path: Path):
+    p = tmp_path / "ledger.jsonl"
+    store = DurableLineageStore(p)
+    store.append("lin-a", "goal-lane", {"step": "proposed"})
+    store.append("lin-a", "goal-lane", {"step": "merged"})
+
+    # a fresh store over the same file sees the persisted entries
+    reloaded = DurableLineageStore(p)
+    assert reloaded.verify()
+    assert len(reloaded.entries) == 2
+    assert reloaded.durable_lineage_ids() == {"lin-a"}
+
+
+def test_authorship_binding_persists_across_reload(tmp_path: Path):
+    p = tmp_path / "ledger.jsonl"
+    store = DurableLineageStore(p)
+    store.append("lin-a", "goal-lane", {"x": 1})
+    with pytest.raises(AuthorshipError):
+        store.append("lin-a", "attacker", {"x": "forged"})
+    # the forged entry was neither chained nor persisted
+    reloaded = DurableLineageStore(p)
+    assert [e.author for e in reloaded.entries] == ["goal-lane"]
+
+
+def test_tampered_file_vouches_for_nothing(tmp_path: Path):
+    p = tmp_path / "ledger.jsonl"
+    store = DurableLineageStore(p)
+    store.append("lin-a", "goal-lane", {"step": "one"})
+    store.append("lin-a", "goal-lane", {"step": "two"})
+    # tamper with a persisted line
+    lines = p.read_text().splitlines()
+    p.write_text(lines[0].replace("one", "ONE-TAMPERED") + "\n" + lines[1] + "\n")
+
+    reloaded = DurableLineageStore(p)
+    # a broken chain must vouch for NOTHING (degrade to source-age semantics)
+    assert reloaded.durable_lineage_ids() == set()
+
+
+def test_missing_file_is_empty(tmp_path: Path):
+    store = DurableLineageStore(tmp_path / "nope.jsonl")
+    assert store.entries == []
+    assert store.durable_lineage_ids() == set()
+
+
+def test_lineage_id_for_task_matches_fleet_format():
+    # mirrors outcomes.py: f"lin-{task_id[:12]}" (first 12 chars, hyphens incl.)
+    assert lineage_id_for_task("11111111-2222-3333") == "lin-11111111-222"

--- a/tests/unit/lineage/test_repograph_binding.py
+++ b/tests/unit/lineage/test_repograph_binding.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the RepoGraph binding (Phase A3).
+
+The lineage read-model maps into RepoGraph's RUN/AUDIT/EVIDENCE vocabulary,
+stamped as derived (WORK_SCOPE) with trust preserved in metadata.
+"""
+
+from __future__ import annotations
+
+from operations_center.lineage.models import (
+    Completeness,
+    Integrity,
+    LineageChain,
+    LineageEdge,
+    LineageNode,
+    Order,
+    Provenance,
+    TrustFlags,
+    default_trust,
+)
+from operations_center.lineage.repograph_binding import to_repograph
+
+
+def _green() -> TrustFlags:
+    return TrustFlags(
+        provenance=Provenance.CODE_COMPUTED,
+        integrity=Integrity.CHAINED,
+        completeness=Completeness.DURABLE,
+        order=Order.CAUSAL,
+    )
+
+
+def _chain() -> LineageChain:
+    nodes = (
+        LineageNode("task:t", "task", default_trust(provenance=Provenance.TEXT_DERIVED)),
+        LineageNode("run:r", "run", default_trust(provenance=Provenance.CODE_COMPUTED)),
+        LineageNode("pr:1", "pr", default_trust(provenance=Provenance.CODE_COMPUTED)),
+        LineageNode("verdict:1", "verdict", _green()),
+    )
+    edges = (
+        LineageEdge("task:t", "run:r", "executed_as", default_trust(provenance=Provenance.CODE_COMPUTED)),
+        LineageEdge("run:r", "pr:1", "produced_pr", default_trust(provenance=Provenance.CODE_COMPUTED)),
+        LineageEdge("pr:1", "verdict:1", "reviewed_as", _green()),
+    )
+    return LineageChain(task_id="t", nodes=nodes, edges=edges)
+
+
+def test_nodes_map_to_run_audit_evidence_kinds():
+    nodes, _ = to_repograph(_chain())
+    by_id = {n.repo_id: n.kind.value for n in nodes}
+    assert by_id["run:r"] == "Run"
+    assert by_id["verdict:1"] == "Audit"
+    assert by_id["pr:1"] == "Evidence"
+    assert by_id["task:t"] == "Run"
+
+
+def test_all_nodes_marked_derived_work_scope():
+    nodes, _ = to_repograph(_chain())
+    for n in nodes:
+        assert n.source.value == "work_scope"
+        assert ("derived", "true") in n.metadata
+
+
+def test_edges_map_and_preserve_trust():
+    _, rels = to_repograph(_chain())
+    by_pair = {(r.source_id, r.target_id): r for r in rels}
+    reviewed = by_pair[("pr:1", "verdict:1")]
+    assert reviewed.kind.value == "validates_output"
+    # the green edge is marked steerable in metadata
+    assert ("steerable", "true") in reviewed.metadata
+    executed = by_pair[("task:t", "run:r")]
+    assert executed.kind.value == "orchestrates"
+    # default-trust edge is NOT steerable
+    assert ("steerable", "false") in executed.metadata
+
+
+def test_trust_dimensions_carried_into_metadata():
+    nodes, _ = to_repograph(_chain())
+    verdict = next(n for n in nodes if n.repo_id == "verdict:1")
+    md = dict(verdict.metadata)
+    assert md["trust.provenance"] == "code-computed"
+    assert md["trust.integrity"] == "chained"
+
+
+def test_empty_chain_yields_empty():
+    nodes, rels = to_repograph(LineageChain(task_id="t", nodes=(), edges=()))
+    assert nodes == [] and rels == []

--- a/tests/unit/lineage/test_repograph_binding.py
+++ b/tests/unit/lineage/test_repograph_binding.py
@@ -2,8 +2,9 @@
 # Copyright (C) 2026 ProtocolWarden
 """Tests for the RepoGraph binding (Phase A3).
 
-The lineage read-model maps into RepoGraph's RUN/AUDIT/EVIDENCE vocabulary,
-stamped as derived (WORK_SCOPE) with trust preserved in metadata.
+The lineage read-model maps into RepoGraph's RUN/AUDIT/EVIDENCE vocabulary as
+boundary-respecting dicts (no repograph import), stamped derived (work_scope)
+with trust preserved in metadata.
 """
 
 from __future__ import annotations
@@ -48,7 +49,7 @@ def _chain() -> LineageChain:
 
 def test_nodes_map_to_run_audit_evidence_kinds():
     nodes, _ = to_repograph(_chain())
-    by_id = {n.repo_id: n.kind.value for n in nodes}
+    by_id = {n["repo_id"]: n["kind"] for n in nodes}
     assert by_id["run:r"] == "Run"
     assert by_id["verdict:1"] == "Audit"
     assert by_id["pr:1"] == "Evidence"
@@ -58,27 +59,44 @@ def test_nodes_map_to_run_audit_evidence_kinds():
 def test_all_nodes_marked_derived_work_scope():
     nodes, _ = to_repograph(_chain())
     for n in nodes:
-        assert n.source.value == "work_scope"
-        assert ("derived", "true") in n.metadata
+        assert n["source"] == "work_scope"
+        assert n["metadata"]["derived"] == "true"
+
+
+def test_no_repograph_import():
+    # A3 must not cross the OC->repograph boundary (Custodian X2). Parse the
+    # actual import statements (not source text, which mentions repograph in
+    # prose) and assert none reference repograph.
+    import ast
+    import inspect
+
+    import operations_center.lineage.repograph_binding as mod
+
+    tree = ast.parse(inspect.getsource(mod))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+    assert not any(name.split(".")[0] == "repograph" for name in imported)
 
 
 def test_edges_map_and_preserve_trust():
     _, rels = to_repograph(_chain())
-    by_pair = {(r.source_id, r.target_id): r for r in rels}
+    by_pair = {(r["source_id"], r["target_id"]): r for r in rels}
     reviewed = by_pair[("pr:1", "verdict:1")]
-    assert reviewed.kind.value == "validates_output"
-    # the green edge is marked steerable in metadata
-    assert ("steerable", "true") in reviewed.metadata
+    assert reviewed["kind"] == "validates_output"
+    assert reviewed["metadata"]["steerable"] == "true"
     executed = by_pair[("task:t", "run:r")]
-    assert executed.kind.value == "orchestrates"
-    # default-trust edge is NOT steerable
-    assert ("steerable", "false") in executed.metadata
+    assert executed["kind"] == "orchestrates"
+    assert executed["metadata"]["steerable"] == "false"
 
 
 def test_trust_dimensions_carried_into_metadata():
     nodes, _ = to_repograph(_chain())
-    verdict = next(n for n in nodes if n.repo_id == "verdict:1")
-    md = dict(verdict.metadata)
+    verdict = next(n for n in nodes if n["repo_id"] == "verdict:1")
+    md = verdict["metadata"]
     assert md["trust.provenance"] == "code-computed"
     assert md["trust.integrity"] == "chained"
 

--- a/tests/unit/test_capability_ownership.py
+++ b/tests/unit/test_capability_ownership.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the synchronous capability-owner check (Phase C2, surface 1).
+
+The registry is dormant-by-environment in OC today, so these exercise the
+mechanism against a fake registry plus the degrade/no-op paths that govern its
+real behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from operations_center.capability_ownership import (
+    AmbiguousOwnerError,
+    resolve_owner,
+    verify_owner_or_degrade,
+)
+
+
+@dataclass
+class _Edge:
+    source_id: str
+    target_id: str
+    kind: str  # "owns" | "targets" | ...
+
+
+class _Registry:
+    def __init__(self, edges):
+        self.edges = edges
+
+
+def _registry(*edges):
+    return _Registry([_Edge(*e) for e in edges])
+
+
+def test_resolve_single_owner():
+    reg = _registry(("board_unblock", "OperationsCenter", "owns"))
+    assert resolve_owner(reg, "board_unblock") == "OperationsCenter"
+
+
+def test_resolve_ignores_non_owns_edges():
+    reg = _registry(
+        ("board_unblock", "OperationsCenter", "owns"),
+        ("board_unblock", "RepoGraph", "targets"),
+    )
+    assert resolve_owner(reg, "board_unblock") == "OperationsCenter"
+
+
+def test_zero_owners_raises():
+    reg = _registry(("board_unblock", "X", "targets"))
+    with pytest.raises(AmbiguousOwnerError):
+        resolve_owner(reg, "board_unblock")
+
+
+def test_multiple_owners_raises():
+    reg = _registry(
+        ("board_unblock", "OperationsCenter", "owns"),
+        ("board_unblock", "Rogue", "owns"),
+    )
+    with pytest.raises(AmbiguousOwnerError):
+        resolve_owner(reg, "board_unblock")
+
+
+# ── the guard ──────────────────────────────────────────────────────────────────
+
+
+def test_disabled_is_noop():
+    # required=False → proceed without even consulting a registry
+    assert verify_owner_or_degrade("board_unblock", required=False, registry=None) is True
+
+
+def test_unavailable_registry_degrades(monkeypatch):
+    # required + no registry available → DEGRADE (proceed), never halt
+    monkeypatch.setattr(
+        "operations_center.capability_ownership.load_capability_registry", lambda: None
+    )
+    assert verify_owner_or_degrade("board_unblock", required=True) is True
+
+
+def test_available_single_owner_proceeds():
+    reg = _registry(("board_unblock", "OperationsCenter", "owns"))
+    assert verify_owner_or_degrade("board_unblock", required=True, registry=reg) is True
+
+
+def test_available_ambiguous_owner_refuses():
+    reg = _registry(
+        ("board_unblock", "OperationsCenter", "owns"),
+        ("board_unblock", "Rogue", "owns"),
+    )
+    assert verify_owner_or_degrade("board_unblock", required=True, registry=reg) is False
+
+
+def test_owner_mismatch_refuses():
+    reg = _registry(("board_unblock", "SomeoneElse", "owns"))
+    assert (
+        verify_owner_or_degrade(
+            "board_unblock", required=True, expected_owner="OperationsCenter", registry=reg
+        )
+        is False
+    )
+
+
+def test_owner_match_proceeds():
+    reg = _registry(("board_unblock", "OperationsCenter", "owns"))
+    assert (
+        verify_owner_or_degrade(
+            "board_unblock", required=True, expected_owner="OperationsCenter", registry=reg
+        )
+        is True
+    )
+
+
+def test_load_returns_none_in_this_environment():
+    # OC's pinned repograph wheel has no capabilities plane → None (dormant).
+    from operations_center.capability_ownership import load_capability_registry
+
+    assert load_capability_registry() is None


### PR DESCRIPTION
## Summary

Completes the open follow-ups from #388's spec
`docs/design/EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md`. Every change is
fail-safe / opt-in; defaults are unchanged. Full unit suite green, custodian +
D12 + X2 clean.

## Items

- **A5 — durable lineage tier** (`lineage/durable.py`): append-only JSONL ledger
  over the D1 hash chain. Entries are loaded **verbatim** (preserving stored
  hashes) so `verify()` catches tampering — a tampered ledger vouches for
  nothing. The projection consults `durable_lineage_ids()` so an aged-source edge
  stays `completeness=durable` past the GC horizon.
- **A4 — rebuild-conformance gate** (`tests/unit/lineage/test_conformance.py`):
  rebuild determinism; aged source = **EXPIRED, not silently dropped**; durable
  tier keeps aged lineage durable. The gate the spec said "fails today, passes
  after A5" — passes because A5 is wired.
- **A3 — RepoGraph binding** (`lineage/repograph_binding.py`): maps a chain to
  RUN/AUDIT/EVIDENCE **RepoGraph-shaped dicts** (kind names as strings),
  `work_scope`/`derived`, trust carried in metadata. Emits dicts rather than
  importing `repograph` directly — OC's sanctioned dependency is
  `platform_manifest`, and importing the lower-level package would cross an
  undeclared edge (Custodian X2). The manifest side hydrates the dicts.
- **B3 — per-root descendant cap**: a propagating `lineage-root` label +
  `max_descendants_per_root`, so one runaway lineage tree can't consume the whole
  global budget even under the per-generation retry cap.
- **C2 — capability-owner check** (`capability_ownership.py`): synchronous
  `resolve_owner` + an opt-in `verify_owner_or_degrade` guard wired into
  `BoardUnblockTask`. **Dormant-by-environment**: OC's pinned `repograph` wheel
  ships no capabilities plane, so the registry is unavailable and the guard
  degrades (proceeds). The mechanism is wired + tested but is **not load-bearing**
  until the capability plane is an OC runtime dependency — honestly documented,
  not claimed as closing surface 1.

## Tests
New: `test_durable`, `test_conformance`, `test_repograph_binding` (rewritten),
additions to `test_work_ceiling` (B3), `tests/unit/test_capability_ownership.py`.
All green; the steerable set stays empty by construction (ordering still
host-relative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)