### PR TITLE
fix: remediate lineage/determinism audit findings (R1-R5, F1/F2/F4, A1/A2/A3)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8317,3 +8317,14 @@ dirs ONCE and shares records (was O(tasks*runs)). F1: dispatch_issue success now
 appends to the durable tier (typed fields only, best-effort) — the read-model has
 a real producer. F4: create_split_followups honors the ceiling + per-root cap and
 stamps lineage-root (was bypassing both).
+
+## 2026-06-23 — Remediation F2 + A2/A3
+
+F2: controller_liveness gained an --enforce mode (SIGTERMs a stalled supervisor
+so the watchdog PID-revive restarts it) and is now CALLED from the watchdog loop
+(scripts/operations-center.sh) for pid:heartbeat pairs incl. spec:spec_hygiene —
+closing surface 10 (the in-loop detector that died with its host). A2: added
+LineageChain.display_view() as the sanctioned human path + a regression test that
+free text reaches display_view but never steerable_facts; cli emits display_view.
+A3: documented the read/write split in lineage/__init__ — projection reads, the
+durable/integrity tier is the isolated attestation authority (the only writer).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8303,3 +8303,17 @@ RequiredError → fail_task (clean block) instead of stranding the task in Runni
 R2b: reviewer exec now routes through maybe_netns (egress confinement was a no-op
 for the least-trusted executor); worklist loop catches containment errors per-PR
 (skip one) instead of aborting the whole cycle.
+
+## 2026-06-23 — Remediation R3/R4/A1/R5/F1/F4: durable tier + model functional
+
+R3: DurableLineageStore.append now uses flock + O_APPEND single-line write +
+reload-under-lock — no lost writes, no fixed-tmp clobber, no read-modify-rewrite.
+R4: payload canonicalized (json round-trip) before hashing so non-JSON-native
+payloads survive reload-verify. A1: durable-backed edges are now `attested`
+(integrity CHAINED + completeness DURABLE + order CAUSAL via attested_trust); a
+code-computed durable edge is finally steerable — the 4-dim model is no longer
+inert-by-construction (Order was never CAUSAL anywhere). R5: build_all scans run
+dirs ONCE and shares records (was O(tasks*runs)). F1: dispatch_issue success now
+appends to the durable tier (typed fields only, best-effort) — the read-model has
+a real producer. F4: create_split_followups honors the ceiling + per-root cap and
+stamps lineage-root (was bypassing both).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8328,3 +8328,9 @@ LineageChain.display_view() as the sanctioned human path + a regression test tha
 free text reaches display_view but never steerable_facts; cli emits display_view.
 A3: documented the read/write split in lineage/__init__ — projection reads, the
 durable/integrity tier is the isolated attestation authority (the only writer).
+
+## 2026-06-23 — Remediation custodian fix
+
+Moved the F1 durable producer from dispatch.py into lineage/durable.py as
+record_task_completion (dispatch back under the 500-line C29 limit; producer now
+lives with the tier). Moved its tests to test_durable.py with asserts (T2).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8291,3 +8291,15 @@ undeclared OC->RepoGraph edge (OC depends on platform_manifest, which does not
 re-export the RUN/AUDIT/EVIDENCE EntityKind vocab). Rewrote A3 to emit
 RepoGraph-SHAPED dicts (kind names as strings), no repograph import — a derived
 export the manifest side hydrates. Custodian clean.
+
+## 2026-06-23 — Remediation R1+R2: heartbeat clobber + fail-closed containment
+
+R1: `_heartbeat_loop` now uses new `touch_liveness` (updates at/status, preserves
+last_success_at/consecutive_failures) instead of a success write; the poll loop
+records `success=dispatch_result` instead of unconditional True. A lane
+busy-failing real tasks now ages last_success_at → catchable by HeartbeatStallTask.
+R2a: board_worker poll loop catches ContainmentRequiredError/EgressContainment-
+RequiredError → fail_task (clean block) instead of stranding the task in Running.
+R2b: reviewer exec now routes through maybe_netns (egress confinement was a no-op
+for the least-trusted executor); worklist loop catches containment errors per-PR
+(skip one) instead of aborting the whole cycle.

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -586,6 +586,17 @@ start_watchdog() {
           '${ROOT_DIR}/scripts/operations-center.sh' watch --role \"\$_r\"
         fi
       done
+      # Liveness-SUCCESS enforcement (determinism surface 10): the PID revive
+      # above only catches DEAD watchers. controller_liveness catches a watcher
+      # that is LIVE but not succeeding (e.g. spec_hygiene crash-looping) — the
+      # blind spot HeartbeatStallTask can't cover for its own host — and SIGTERMs
+      # its supervisor so the revive restarts it. Pairs: pid-role:heartbeat-role.
+      for _pair in spec:spec_hygiene review:review goal:goal test:test improve:improve; do
+        _pidrole=\${_pair%%:*}; _hbrole=\${_pair##*:}
+        '${VENV_DIR}/bin/python' -m operations_center.entrypoints.controller_liveness \
+          --role \"\$_hbrole\" --status-dir '${WATCH_DIR}' \
+          --enforce --pid-file '${WATCH_DIR}'/\"\$_pidrole\".pid >/dev/null 2>&1 || true
+      done
     done
     echo '{\"event\":\"watchdog_exit\"}'
   " >>"${log_file}" 2>&1 < /dev/null &

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -318,10 +318,10 @@ def dispatch_issue(
                 pr_url=result.get("pull_request_url") or None,
             )
             # F1: populate the durable lineage tier on a real completion, so the
-            # read-model has an actual producer (without this the durable tier is
-            # never written and A5's attestation is inert). Typed, code-derived
-            # fields only — never the free-text goal. Best-effort.
-            _record_durable_lineage(oc_root, task_id, result)
+            # read-model has an actual producer (the writer lives with the tier).
+            from operations_center.lineage.durable import record_task_completion
+
+            record_task_completion(oc_root, task_id, result)
         else:
             log_reason = "scope_too_wide" if scope_too_wide else status
             logger.warning(
@@ -346,35 +346,6 @@ def dispatch_issue(
 
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
-
-
-def _record_durable_lineage(oc_root: Path, task_id: str, result: dict) -> None:
-    """Best-effort: append a completed task's lineage to the durable tier.
-
-    Records only typed, code-derived fields (status, run_id, pr_url) — never the
-    free-text goal — authored as ``board_worker`` (one trust domain for all board
-    lanes). Any failure (authorship conflict, I/O) is swallowed: lineage recording
-    must never break the success path.
-    """
-    try:
-        from operations_center.lineage.durable import (
-            DurableLineageStore,
-            lineage_id_for_task,
-        )
-
-        store = DurableLineageStore(oc_root / "state" / "lineage" / "ledger.jsonl")
-        store.append(
-            lineage_id_for_task(task_id),
-            "board_worker",
-            {
-                "task_id": task_id,
-                "run_id": result.get("run_id"),
-                "status": result.get("status"),
-                "pr_url": result.get("pull_request_url") or None,
-            },
-        )
-    except Exception as exc:  # noqa: BLE001 — never break dispatch on lineage I/O
-        logger.debug("board_worker: durable lineage record skipped for %s — %s", task_id, exc)
 
 
 def _repo_local_path(settings, repo_key: str) -> str:

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -317,6 +317,11 @@ def dispatch_issue(
                 improve_suggestions=improve_suggestions,
                 pr_url=result.get("pull_request_url") or None,
             )
+            # F1: populate the durable lineage tier on a real completion, so the
+            # read-model has an actual producer (without this the durable tier is
+            # never written and A5's attestation is inert). Typed, code-derived
+            # fields only — never the free-text goal. Best-effort.
+            _record_durable_lineage(oc_root, task_id, result)
         else:
             log_reason = "scope_too_wide" if scope_too_wide else status
             logger.warning(
@@ -341,6 +346,35 @@ def dispatch_issue(
 
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _record_durable_lineage(oc_root: Path, task_id: str, result: dict) -> None:
+    """Best-effort: append a completed task's lineage to the durable tier.
+
+    Records only typed, code-derived fields (status, run_id, pr_url) — never the
+    free-text goal — authored as ``board_worker`` (one trust domain for all board
+    lanes). Any failure (authorship conflict, I/O) is swallowed: lineage recording
+    must never break the success path.
+    """
+    try:
+        from operations_center.lineage.durable import (
+            DurableLineageStore,
+            lineage_id_for_task,
+        )
+
+        store = DurableLineageStore(oc_root / "state" / "lineage" / "ledger.jsonl")
+        store.append(
+            lineage_id_for_task(task_id),
+            "board_worker",
+            {
+                "task_id": task_id,
+                "run_id": result.get("run_id"),
+                "status": result.get("status"),
+                "pr_url": result.get("pull_request_url") or None,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — never break dispatch on lineage I/O
+        logger.debug("board_worker: durable lineage record skipped for %s — %s", task_id, exc)
 
 
 def _repo_local_path(settings, repo_key: str) -> str:

--- a/src/operations_center/entrypoints/board_worker/main.py
+++ b/src/operations_center/entrypoints/board_worker/main.py
@@ -34,11 +34,14 @@ import threading
 import time
 from pathlib import Path
 
-from operations_center.entrypoints.heartbeat import write_heartbeat
+from operations_center.entrypoints.heartbeat import touch_liveness, write_heartbeat
 
 from .claim import claim_next
 from .dispatch import dispatch_issue
 from .labels import ROLE_KINDS
+from .netns import EgressContainmentRequiredError
+from .outcomes import fail_task
+from .sandbox import ContainmentRequiredError
 
 logger = logging.getLogger(__name__)
 
@@ -82,9 +85,14 @@ def _write_heartbeat(
 
 
 def _heartbeat_loop(status_dir: Path, role: str, stop_event: threading.Event) -> None:
-    """Write 'executing' heartbeat every 60 s while a task runs."""
+    """Refresh liveness every 60 s while a task runs — WITHOUT stamping progress.
+
+    Uses ``touch_liveness`` (not a success write) so a task that ultimately fails
+    cannot leave behind a run of fresh ``last_success_at`` stamps that hide a
+    busy crash-loop from HeartbeatStallTask.
+    """
     while not stop_event.is_set():
-        _write_heartbeat(status_dir, role, status="executing")
+        touch_liveness(status_dir, role, status="executing")
         stop_event.wait(60)
 
 
@@ -154,6 +162,7 @@ def main() -> int:
             client = _plane_client(settings)
             try:
                 issue = claim_next(client, role, settings)
+                cycle_ok = True
                 if issue:
                     stop_event = threading.Event()
                     hb_thread = threading.Thread(
@@ -163,13 +172,33 @@ def main() -> int:
                     )
                     hb_thread.start()
                     try:
-                        dispatch_issue(issue, role, args.config, settings, client)
+                        cycle_ok = bool(
+                            dispatch_issue(issue, role, args.config, settings, client)
+                        )
+                    except (ContainmentRequiredError, EgressContainmentRequiredError) as exc:
+                        # Operator opted into fail-closed containment but it is
+                        # unavailable. Refuse to run un-contained AND block the task
+                        # cleanly — without this it would strand in Running forever.
+                        fail_task(
+                            client,
+                            str(issue["id"]),
+                            role,
+                            f"containment required but unavailable: {exc}",
+                        )
+                        cycle_ok = False
                     finally:
                         stop_event.set()
                         hb_thread.join(timeout=5)
                 else:
                     logger.debug("board_worker[%s]: nothing ready", role)
-                _write_heartbeat(status_dir, role)
+                # Record the cycle's ACTUAL outcome: a cleanly-failed dispatch
+                # (return False) must age last_success_at, not stamp success.
+                _write_heartbeat(
+                    status_dir,
+                    role,
+                    status="idle" if cycle_ok else "error",
+                    success=cycle_ok,
+                )
             finally:
                 client.close()
         except Exception as exc:

--- a/src/operations_center/entrypoints/board_worker/outcomes.py
+++ b/src/operations_center/entrypoints/board_worker/outcomes.py
@@ -312,6 +312,27 @@ def create_split_followups(
     if not chunks:
         return []
 
+    # Scope-split is the highest-fanout creation path (≤N children, each able to
+    # re-split). It must honor the SAME aggregate brakes as create_follow_up —
+    # the global ceiling (surface 6) and the per-root cap (surface 7) — or the
+    # cap that claims to bound "a runaway scope-split" is bypassed entirely.
+    lineage_root = label_value(parent_labels, "lineage-root") or parent_id
+    if ceiling_reached(client, _settings):
+        logger.warning(
+            "board_worker: refusing scope-split — fleet work ceiling reached "
+            "(parent task_id=%s)",
+            parent_id,
+        )
+        return []
+    if root_descendant_cap_reached(client, _settings, lineage_root):
+        logger.warning(
+            "board_worker: refusing scope-split — per-root descendant cap reached "
+            "(root=%s parent task_id=%s)",
+            lineage_root,
+            parent_id,
+        )
+        return []
+
     inherited_sources = [
         (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
         for lab in parent_labels
@@ -342,6 +363,7 @@ def create_split_followups(
             "source: scope-split",
             *inherited_sources,
             f"original-task-id: {parent_id}",
+            f"lineage-root: {lineage_root}",
             f"handoff-reason: {reason}",
             f"retry-count: {retry_count + 1}",
         ]

--- a/src/operations_center/entrypoints/controller_liveness.py
+++ b/src/operations_center/entrypoints/controller_liveness.py
@@ -82,11 +82,48 @@ def check_controller_liveness(
     return LivenessVerdict(role, "healthy", "live and succeeding")
 
 
+def signal_restart(pid_file: Path) -> bool:
+    """Best-effort SIGTERM the PID in ``pid_file`` so the watchdog's PID-revive
+    logic restarts the (live-but-stalled or hung) watcher. Returns True if a
+    signal was sent. Never raises — enforcement must not break the watchdog."""
+    import os
+    import signal
+
+    try:
+        pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+    except Exception:
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+        logger.error(
+            'controller_liveness: SIGTERM sent to stalled watcher pid=%d {"event": '
+            '"controller_restart_signaled", "pid": %d, "pid_file": "%s"}',
+            pid,
+            pid,
+            pid_file,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("controller_liveness: failed to signal pid from %s — %s", pid_file, exc)
+        return False
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="controller-liveness")
     parser.add_argument("--status-dir", type=Path, default=_DEFAULT_STATUS_DIR)
     parser.add_argument("--role", default=_DEFAULT_ROLE)
     parser.add_argument("--max-liveness-seconds", type=int, default=_DEFAULT_MAX_LIVENESS_SECONDS)
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="on dead/stalled, SIGTERM the watcher in --pid-file so it is restarted",
+    )
+    parser.add_argument(
+        "--pid-file",
+        type=Path,
+        default=None,
+        help="PID file of the supervisor to restart when --enforce and unhealthy",
+    )
     args = parser.parse_args(argv)
 
     verdict = check_controller_liveness(
@@ -102,6 +139,8 @@ def main(argv: list[str] | None = None) -> int:
             verdict.role,
             verdict.status,
         )
+        if args.enforce and args.pid_file is not None:
+            signal_restart(args.pid_file)
         return 1
     logger.info("controller_liveness: %s %s — %s", verdict.role, verdict.status, verdict.detail)
     return 0

--- a/src/operations_center/entrypoints/heartbeat.py
+++ b/src/operations_center/entrypoints/heartbeat.py
@@ -92,6 +92,47 @@ def write_heartbeat(
         pass
 
 
+def touch_liveness(
+    status_dir: Path,
+    role: str,
+    *,
+    status: str = "executing",
+    now: datetime | None = None,
+) -> None:
+    """Update ONLY liveness (``at`` + ``status``), preserving the progress fields.
+
+    Used by the in-task heartbeat thread: a long-running task must keep ``at``
+    fresh so the lane looks alive, but it must NOT stamp ``last_success_at`` or
+    reset ``consecutive_failures`` — otherwise a lane busy-failing real tasks
+    (claim → run → fail → reclaim → repeat) keeps a perpetually-fresh success
+    heartbeat and re-creates the exact "live but not succeeding" blind spot the
+    success/liveness split exists to close. Only a genuinely completed *successful*
+    cycle (``write_heartbeat(success=True)``) may advance progress.
+    """
+    from datetime import UTC
+
+    ts = (now or datetime.now(UTC)).isoformat()
+    prior = read_heartbeat(status_dir, role) or {}
+    payload = {
+        "role": role,
+        "at": ts,
+        "status": status,
+        # preserved verbatim — liveness must never touch progress
+        "last_success_at": prior.get("last_success_at"),
+        "consecutive_failures": int(prior.get("consecutive_failures", 0) or 0),
+        "last_error": prior.get("last_error"),
+    }
+    try:
+        sd = Path(status_dir)
+        sd.mkdir(parents=True, exist_ok=True)
+        dest = _path(sd, role)
+        tmp = dest.with_suffix(".json.liveness.tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, dest)
+    except Exception:
+        pass
+
+
 def _age_seconds(ts: str | None, now: datetime) -> float | None:
     """Seconds between ISO timestamp ``ts`` and ``now``; ``None`` if unparseable."""
     if not ts:

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -60,7 +60,16 @@ from operations_center.entrypoints.board_worker._subprocess import (
     build_allowlist_env,
     git_token_passthrough,
 )
-from operations_center.entrypoints.board_worker.sandbox import maybe_sandbox
+from operations_center.entrypoints.board_worker.netns import (
+    EgressContainmentRequiredError,
+    maybe_netns,
+    netns_enabled,
+)
+from operations_center.entrypoints.board_worker.sandbox import (
+    ContainmentRequiredError,
+    _resolve_egress_proxy,
+    maybe_sandbox,
+)
 from operations_center.entrypoints.heartbeat import write_heartbeat
 from operations_center.reviewer.instrumentation import (
     get_instrumenter,
@@ -729,6 +738,15 @@ def _run_pipeline(
                 env=exec_env,
                 enabled=True,
                 chdir=workspace,
+            )
+            # Structural egress confinement for the LEAST-trusted (reviewer)
+            # executor — the board_worker path applies this but the reviewer
+            # historically did not, so OC_EGRESS_NETNS was a no-op here. Opt-in +
+            # fail-open like the sandbox; honors OC_EGRESS_REQUIRED.
+            run_exec_cmd = maybe_netns(
+                run_exec_cmd,
+                proxy_url=_resolve_egress_proxy(exec_env),
+                enabled=netns_enabled(),
             )
         else:
             exec_env, run_exec_cmd = env, exec_cmd
@@ -3378,10 +3396,25 @@ def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
                 phase = "self_review"
                 state["phase"] = "self_review"
 
-            if phase == "ci_fix":
-                _phase0_ci_fix(state, sp, pr_data, gh_client, owner, repo, oc_root, settings)
-            elif phase == "self_review":
-                _phase1(state, sp, pr_data, gh_client, owner, repo, oc_root, config_path, settings)
+            try:
+                if phase == "ci_fix":
+                    _phase0_ci_fix(state, sp, pr_data, gh_client, owner, repo, oc_root, settings)
+                elif phase == "self_review":
+                    _phase1(
+                        state, sp, pr_data, gh_client, owner, repo, oc_root, config_path, settings
+                    )
+            except (ContainmentRequiredError, EgressContainmentRequiredError) as exc:
+                # Operator opted into fail-closed containment but it is unavailable
+                # on this host. Skip JUST this PR — without this, the error would
+                # abort the entire worklist and silently stall every other PR's
+                # review/merge for the cycle.
+                logger.error(
+                    "pr_review_watcher: skipping PR #%s — containment required but "
+                    "unavailable: %s",
+                    state.get("pr_number"),
+                    exc,
+                )
+                continue
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/src/operations_center/lineage/__init__.py
+++ b/src/operations_center/lineage/__init__.py
@@ -1,11 +1,26 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 ProtocolWarden
-"""Execution-lineage projection — a derived, trust-labeled read-model.
+"""Execution-lineage — a derived read-model plus an attestation authority.
 
-See ``docs/design/EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md``. The package
-reads signals the fleet already emits and joins them into per-task chains. It
-never authors; it labels each edge's trust so the projection is honest about its
-own untrustworthiness, and exposes a single sanctioned steering path.
+See ``docs/design/EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md``. This package
+has two halves with deliberately separated roles:
+
+* **Projection (read-model, derived):** ``projection.py`` reads signals the fleet
+  already emits and joins them into per-task chains. It NEVER writes; it only
+  *reads* the durable tier's ``durable_lineage_ids()`` to decide which edges are
+  attested. This half upholds the spec's "lineage = derived, never authored."
+* **Durable/integrity tier (attestation authority, authored):** ``durable.py`` +
+  ``integrity.py`` are an append-only, hash-chained, authorship-bound ledger —
+  genuinely a system of record (it establishes lineage ownership). It is the ONLY
+  writer, and the projection treats it as just another source signal (identical
+  to how it reads ``pr_reviews``). Keeping it here, with this one-directional
+  boundary (projection reads, durable writes), is intentional: the "authority" is
+  isolated to ``durable.py``/``integrity.py`` and never leaks into the projection.
+
+An edge becomes *steerable* only once the durable tier attests it (``attested_trust``)
+AND its provenance is code-computed; ``steering.steerable_facts`` is the single
+sanctioned path a lane may plan from (free text stripped). Humans read
+``LineageChain.display_view()``.
 """
 
 from __future__ import annotations

--- a/src/operations_center/lineage/cli.py
+++ b/src/operations_center/lineage/cli.py
@@ -71,7 +71,8 @@ def main(argv: list[str] | None = None) -> int:
             args.task_id, runs_root=args.runs_root, state_dir=args.state_dir, now=now
         )
         if args.json:
-            print(json.dumps(chain.as_dict(), indent=2, default=str, ensure_ascii=False))
+            # the sanctioned human/display representation (may include free text)
+            print(json.dumps(chain.display_view(), indent=2, default=str, ensure_ascii=False))
         else:
             print(render_chain(chain))
         return 0
@@ -80,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(
             json.dumps(
-                {k: v.as_dict() for k, v in chains.items()},
+                {k: v.display_view() for k, v in chains.items()},
                 indent=2,
                 default=str,
                 ensure_ascii=False,

--- a/src/operations_center/lineage/durable.py
+++ b/src/operations_center/lineage/durable.py
@@ -67,26 +67,40 @@ class DurableLineageStore:
                 continue
         return ledger
 
-    def _persist_entry(self, entry: LedgerEntry) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(asdict(entry), ensure_ascii=False, sort_keys=True)
-        # Append durably: read-existing + rewrite via atomic replace so a crash
-        # mid-write can't leave a torn last line that breaks the next load.
-        existing = self.path.read_text(encoding="utf-8") if self.path.is_file() else ""
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp.write_text(existing + line + "\n", encoding="utf-8")
-        os.replace(tmp, self.path)
-
     # ── public API ────────────────────────────────────────────────────────────
     def append(self, lineage_id: str, author: str, payload: dict) -> LedgerEntry:
         """Append an entry (authorship-bound, hash-chained) and persist it.
+
+        Concurrency-safe: an exclusive ``flock`` serializes appends across
+        processes/hosts, the ledger is RELOADED under the lock so this writer
+        chains off the true on-disk tip (no lost writes), and the entry is
+        ``O_APPEND``-written as a single line (no fixed-tmp clobber, no
+        read-modify-rewrite). The payload is canonicalized through a JSON
+        round-trip BEFORE hashing so the stored ``this_hash`` matches what a
+        later reload (which JSON-decodes the payload) recomputes — otherwise a
+        tuple/non-str-key payload would hash differently after reload and silently
+        break ``verify()``.
 
         Raises ``AuthorshipError`` if ``author`` does not own ``lineage_id`` — the
         forged write is neither chained nor persisted.
         """
 
-        entry = self._ledger.append(lineage_id, author, payload)
-        self._persist_entry(entry)
+        import fcntl
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.loads(json.dumps(payload, ensure_ascii=False, default=str))
+        with open(self.path, "a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                # Reload under the lock so we see (and chain off) any entries other
+                # writers appended since this store was constructed.
+                self._ledger = self._load()
+                entry = self._ledger.append(lineage_id, author, payload)
+                fh.write(json.dumps(asdict(entry), ensure_ascii=False, sort_keys=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
         return entry
 
     def verify(self) -> bool:

--- a/src/operations_center/lineage/durable.py
+++ b/src/operations_center/lineage/durable.py
@@ -127,4 +127,29 @@ def lineage_id_for_task(task_id: str) -> str:
     return f"lin-{task_id[:12]}"
 
 
-__all__ = ["DurableLineageStore", "lineage_id_for_task"]
+def record_task_completion(oc_root: Path, task_id: str, result: dict) -> None:
+    """Best-effort producer: append a completed task's lineage to the durable tier.
+
+    Records only typed, code-derived fields (status, run_id, pr_url) — NEVER the
+    free-text goal — authored as ``board_worker`` (one trust domain for all board
+    lanes). Any failure (authorship conflict, I/O) is swallowed: lineage recording
+    must never break the dispatch success path. This is the production writer that
+    makes the durable tier non-inert (Phase F1).
+    """
+    try:
+        store = DurableLineageStore(Path(oc_root) / "state" / "lineage" / "ledger.jsonl")
+        store.append(
+            lineage_id_for_task(task_id),
+            "board_worker",
+            {
+                "task_id": task_id,
+                "run_id": result.get("run_id"),
+                "status": result.get("status"),
+                "pr_url": result.get("pull_request_url") or None,
+            },
+        )
+    except Exception:  # noqa: BLE001 — never break dispatch on lineage I/O
+        pass
+
+
+__all__ = ["DurableLineageStore", "lineage_id_for_task", "record_task_completion"]

--- a/src/operations_center/lineage/models.py
+++ b/src/operations_center/lineage/models.py
@@ -177,6 +177,20 @@ class LineageChain:
 
         return tuple(e for e in self.edges if not e.trust.is_steerable())
 
+    def display_view(self) -> dict[str, object]:
+        """The sanctioned HUMAN/display representation (may contain free text).
+
+        Two readers, two methods, by design (the typed-steering / display-only
+        split, spec §2): a human/auditor calls ``display_view()`` and may see
+        free-text attributes; a LANE that plans from lineage MUST call
+        ``operations_center.lineage.steering.steerable_facts`` instead, which
+        emits only typed, allowlisted fields. Reading ``.nodes``/``.edges`` raw
+        for *planning* is a misuse — those carry display attributes (incl. the
+        attacker-controllable goal text) and are not a steering surface.
+        """
+
+        return self.as_dict()
+
     def as_dict(self) -> dict[str, object]:
         return {
             "task_id": self.task_id,

--- a/src/operations_center/lineage/models.py
+++ b/src/operations_center/lineage/models.py
@@ -88,13 +88,38 @@ def default_trust(
     provenance: Provenance,
     completeness: Completeness = Completeness.DURABLE,
 ) -> TrustFlags:
-    """Construct trust flags with the not-yet-built dimensions pinned red."""
+    """Construct trust flags with the not-yet-attested dimensions pinned red.
+
+    Used for edges NOT backed by the durable tier: integrity is unverified (no
+    chain) and order is host-relative (no per-lineage sequence), so such an edge
+    can never be steerable regardless of provenance — the safe default.
+    """
 
     return TrustFlags(
         provenance=provenance,
-        integrity=Integrity.UNVERIFIED,  # no chain yet → Phase D1
+        integrity=Integrity.UNVERIFIED,
         completeness=completeness,
-        order=Order.HOST_RELATIVE,  # no logical clock yet → Phase A ordering
+        order=Order.HOST_RELATIVE,
+    )
+
+
+def attested_trust(provenance: Provenance) -> TrustFlags:
+    """Trust flags for an edge BACKED BY THE DURABLE TIER (Phase A5/D1).
+
+    The durable ledger is hash-chained (→ ``integrity=CHAINED``), append-only and
+    retained past source GC (→ ``completeness=DURABLE``), and establishes a
+    monotonic per-lineage order via the chain itself (→ ``order=CAUSAL``). So an
+    attested edge is steerable iff its ``provenance`` is ``CODE_COMPUTED`` — the
+    one dimension the durable tier cannot vouch for. This is what makes the
+    four-dimension model functional: without it, ``order`` never goes CAUSAL and
+    ``is_steerable()`` is unreachable by construction.
+    """
+
+    return TrustFlags(
+        provenance=provenance,
+        integrity=Integrity.CHAINED,
+        completeness=Completeness.DURABLE,
+        order=Order.CAUSAL,
     )
 
 

--- a/src/operations_center/lineage/projection.py
+++ b/src/operations_center/lineage/projection.py
@@ -10,9 +10,11 @@ Joins three families of artifacts the fleet already writes, on stable keys:
                     → plane_task_id, pr_number, head_sha, phase, verdict
   * ci_lineage      <state_dir>/ci_lineage.json   (keyed lin-<task_id[:12]>)
 
-Nothing here writes; it only reads and joins. Every node/edge is trust-labeled
-(``models.default_trust``), so by construction the steerable set is empty until
-the integrity (Phase D1) and ordering work land — the safe default.
+Nothing here writes; it only reads and joins. Every node/edge is trust-labeled:
+edges whose lineage the durable tier vouches for are ``attested`` (steerable iff
+code-computed), all others get the not-yet-attested default (never steerable).
+So an edge becomes steerable ONLY once it is recorded in the durable/integrity
+tier — the safe default for everything else.
 """
 
 from __future__ import annotations
@@ -29,6 +31,8 @@ from .models import (
     LineageEdge,
     LineageNode,
     Provenance,
+    TrustFlags,
+    attested_trust,
     default_trust,
 )
 
@@ -125,18 +129,29 @@ def build_chain(
     now: datetime | None = None,
     retention_days: int = _DEFAULT_RETENTION_DAYS,
     durable_lineage_ids: set[str] | None = None,
+    _all_runs: list[_RunRecord] | None = None,
 ) -> LineageChain:
     """Assemble the lineage chain for one task_id from on-disk signals.
 
     ``durable_lineage_ids`` (Phase A5) is the set of lineage_ids the durable tier
-    vouches for; an edge whose lineage is durable stays ``completeness=durable``
-    even when its source record is past the GC horizon.
+    vouches for; an edge whose lineage is durable is ``attested`` — integrity
+    CHAINED, completeness DURABLE, order CAUSAL — so a code-computed durable edge
+    becomes steerable. ``_all_runs`` lets ``build_all`` scan the run dirs ONCE and
+    share the parsed records (R5), instead of re-scanning per task.
     """
 
     now = now or datetime.now(timezone.utc)
     durable = (durable_lineage_ids is not None) and (f"lin-{task_id[:12]}" in durable_lineage_ids)
-    runs = [r for r in _iter_runs(runs_root) if r.task_id == task_id]
+    all_runs = _all_runs if _all_runs is not None else _iter_runs(runs_root)
+    runs = [r for r in all_runs if r.task_id == task_id]
     pr_states = _load_pr_reviews(state_dir)
+
+    def _trust(provenance: Provenance, complete: Completeness) -> TrustFlags:
+        # A durable-backed edge is attested (3 dims green); otherwise the
+        # not-yet-attested default (integrity unverified, order host-relative).
+        if durable:
+            return attested_trust(provenance)
+        return default_trust(provenance=provenance, completeness=complete)
 
     nodes: list[LineageNode] = []
     edges: list[LineageEdge] = []
@@ -152,14 +167,12 @@ def build_chain(
         goal = goal or r.proposal.get("goal_text")
         target = r.proposal.get("target") or {}
         repo = repo or (target.get("repo_key") if isinstance(target, dict) else None)
+    task_complete = _completeness(task_ts, now=now, retention_days=retention_days, durable=durable)
     nodes.append(
         LineageNode(
             node_id=task_node_id,
             kind="task",
-            trust=default_trust(
-                provenance=Provenance.TEXT_DERIVED,
-                completeness=_completeness(task_ts, now=now, retention_days=retention_days, durable=durable),
-            ),
+            trust=_trust(Provenance.TEXT_DERIVED, task_complete),
             attributes={"task_id": task_id, "repo_key": repo, "goal_text": goal},
         )
     )
@@ -174,9 +187,7 @@ def build_chain(
             LineageNode(
                 node_id=run_node_id,
                 kind="run",
-                trust=default_trust(
-                    provenance=Provenance.CODE_COMPUTED, completeness=run_complete
-                ),
+                trust=_trust(Provenance.CODE_COMPUTED, run_complete),
                 attributes={
                     "run_id": r.run_id,
                     "proposal_id": r.proposal_id,
@@ -192,9 +203,7 @@ def build_chain(
                 src=task_node_id,
                 dst=run_node_id,
                 kind="executed_as",
-                trust=default_trust(
-                    provenance=Provenance.CODE_COMPUTED, completeness=run_complete
-                ),
+                trust=_trust(Provenance.CODE_COMPUTED, run_complete),
             )
         )
         pr_num = _pr_number_from_url(r.result.get("pull_request_url"))
@@ -205,9 +214,7 @@ def build_chain(
                     src=run_node_id,
                     dst=f"pr:{pr_num}",
                     kind="produced_pr",
-                    trust=default_trust(
-                        provenance=Provenance.CODE_COMPUTED, completeness=run_complete
-                    ),
+                    trust=_trust(Provenance.CODE_COMPUTED, run_complete),
                 )
             )
 
@@ -225,9 +232,7 @@ def build_chain(
             LineageNode(
                 node_id=pr_node_id,
                 kind="pr",
-                trust=default_trust(
-                    provenance=Provenance.CODE_COMPUTED, completeness=pr_complete
-                ),
+                trust=_trust(Provenance.CODE_COMPUTED, pr_complete),
                 attributes={
                     "pr_number": pr_num,
                     "repo_key": state.get("repo_key"),
@@ -244,9 +249,7 @@ def build_chain(
                     src=task_node_id,
                     dst=pr_node_id,
                     kind="produced_pr",
-                    trust=default_trust(
-                        provenance=Provenance.CODE_COMPUTED, completeness=pr_complete
-                    ),
+                    trust=_trust(Provenance.CODE_COMPUTED, pr_complete),
                 )
             )
         verdict = state.get("verdict")
@@ -258,9 +261,7 @@ def build_chain(
                 LineageNode(
                     node_id=verdict_node_id,
                     kind="verdict",
-                    trust=default_trust(
-                        provenance=Provenance.CODE_COMPUTED, completeness=pr_complete
-                    ),
+                    trust=_trust(Provenance.CODE_COMPUTED, pr_complete),
                     attributes={
                         "result": verdict.get("result"),
                         "failing_checks": verdict.get("failing_checks"),
@@ -272,9 +273,7 @@ def build_chain(
                     src=pr_node_id,
                     dst=verdict_node_id,
                     kind="reviewed_as",
-                    trust=default_trust(
-                        provenance=Provenance.CODE_COMPUTED, completeness=pr_complete
-                    ),
+                    trust=_trust(Provenance.CODE_COMPUTED, pr_complete),
                 )
             )
 
@@ -292,7 +291,10 @@ def build_all(
     """Build chains for every task_id discoverable in the run artifacts."""
 
     now = now or datetime.now(timezone.utc)
-    task_ids = {r.task_id for r in _iter_runs(runs_root) if r.task_id}
+    # R5: scan + parse the run dirs ONCE and share the records across every chain,
+    # instead of re-scanning runs_root per task (which was O(tasks × runs)).
+    all_runs = _iter_runs(runs_root)
+    task_ids = {r.task_id for r in all_runs if r.task_id}
     # Tasks that only show up in pr_reviews (via plane_task_id) also count.
     for state in _load_pr_reviews(state_dir):
         tid = state.get("plane_task_id")
@@ -306,6 +308,7 @@ def build_all(
             now=now,
             retention_days=retention_days,
             durable_lineage_ids=durable_lineage_ids,
+            _all_runs=all_runs,
         )
         for tid in sorted(task_ids)
     }

--- a/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
@@ -547,30 +547,3 @@ def test_dispatch_spec_author_no_repo_cfg_uses_file_url(monkeypatch):
     assert out is False
     assert proc.call_args.kwargs["clone_url"].startswith("file://")
     assert proc.call_args.kwargs["base_branch"] == "main"
-
-
-# ── F1: durable lineage producer ───────────────────────────────────────────────
-
-
-def test_record_durable_lineage_writes_typed_fields(tmp_path):
-    from operations_center.entrypoints.board_worker import dispatch
-    from operations_center.lineage.durable import DurableLineageStore, lineage_id_for_task
-
-    dispatch._record_durable_lineage(
-        tmp_path,
-        "task-abc-123456",
-        {"run_id": "r1", "status": "succeeded", "pull_request_url": "https://x/pull/9",
-         "goal_text": "SECRET"},
-    )
-    store = DurableLineageStore(tmp_path / "state" / "lineage" / "ledger.jsonl")
-    assert store.durable_lineage_ids() == {lineage_id_for_task("task-abc-123456")}
-    payload = store.entries[0].payload
-    assert payload["status"] == "succeeded" and payload["pr_url"] == "https://x/pull/9"
-    assert "goal_text" not in payload  # free text never recorded
-
-
-def test_record_durable_lineage_is_best_effort(tmp_path):
-    from operations_center.entrypoints.board_worker import dispatch
-
-    # an unwritable path must not raise
-    dispatch._record_durable_lineage(tmp_path / "nonexistent\x00bad", "t", {"status": "x"})

--- a/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
@@ -547,3 +547,30 @@ def test_dispatch_spec_author_no_repo_cfg_uses_file_url(monkeypatch):
     assert out is False
     assert proc.call_args.kwargs["clone_url"].startswith("file://")
     assert proc.call_args.kwargs["base_branch"] == "main"
+
+
+# ── F1: durable lineage producer ───────────────────────────────────────────────
+
+
+def test_record_durable_lineage_writes_typed_fields(tmp_path):
+    from operations_center.entrypoints.board_worker import dispatch
+    from operations_center.lineage.durable import DurableLineageStore, lineage_id_for_task
+
+    dispatch._record_durable_lineage(
+        tmp_path,
+        "task-abc-123456",
+        {"run_id": "r1", "status": "succeeded", "pull_request_url": "https://x/pull/9",
+         "goal_text": "SECRET"},
+    )
+    store = DurableLineageStore(tmp_path / "state" / "lineage" / "ledger.jsonl")
+    assert store.durable_lineage_ids() == {lineage_id_for_task("task-abc-123456")}
+    payload = store.entries[0].payload
+    assert payload["status"] == "succeeded" and payload["pr_url"] == "https://x/pull/9"
+    assert "goal_text" not in payload  # free text never recorded
+
+
+def test_record_durable_lineage_is_best_effort(tmp_path):
+    from operations_center.entrypoints.board_worker import dispatch
+
+    # an unwritable path must not raise
+    dispatch._record_durable_lineage(tmp_path / "nonexistent\x00bad", "t", {"status": "x"})

--- a/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
@@ -479,6 +479,50 @@ def test_create_split_followups_no_chunks():
     assert result == []
 
 
+def test_create_split_followups_respects_work_ceiling():
+    # F4: scope-split must honor the global ceiling like create_follow_up does.
+    from types import SimpleNamespace
+
+    client = _make_client(create_id="child-1")
+    client.list_issues.return_value = [
+        {"id": str(i), "state": {"name": "Ready for AI"}, "labels": [{"name": "source: board_worker"}]}
+        for i in range(5)
+    ]
+    parent = {"id": "P", "name": "Big", "labels": [{"name": "repo: web"}]}
+    settings = SimpleNamespace(max_open_fleet_tasks=3, max_descendants_per_root=0)
+    result = outcomes.create_split_followups(client, parent, settings, ["a.py", "b.py"], "r")
+    assert result == []
+    client.create_issue.assert_not_called()
+
+
+def test_create_split_followups_respects_root_cap():
+    # F4: scope-split must honor the per-root descendant cap.
+    from types import SimpleNamespace
+
+    client = _make_client(create_id="child-1")
+    client.list_issues.return_value = [
+        {"id": str(i), "state": {"name": "Ready for AI"}, "labels": [{"name": "lineage-root: P"}]}
+        for i in range(4)
+    ]
+    parent = {"id": "P", "name": "Big", "labels": [{"name": "repo: web"}]}
+    settings = SimpleNamespace(max_open_fleet_tasks=0, max_descendants_per_root=4)
+    result = outcomes.create_split_followups(client, parent, settings, ["a.py", "b.py"], "r")
+    assert result == []
+
+
+def test_create_split_followups_stamps_lineage_root():
+    # F4: split children carry lineage-root so they are countable by the cap.
+    client = _make_client(create_id="child-1")
+    parent = {
+        "id": "P",
+        "name": "Big",
+        "labels": [{"name": "repo: web"}, {"name": "lineage-root: ROOT-7"}],
+    }
+    outcomes.create_split_followups(client, parent, None, ["a.py"], "r")
+    labels = client.create_issue.call_args.kwargs["label_names"]
+    assert "lineage-root: ROOT-7" in labels  # propagated from parent
+
+
 def test_create_split_followups_happy():
     client = _make_client(create_id="child-1")
     parent = {
@@ -497,6 +541,7 @@ def test_create_split_followups_happy():
     labels = client.create_issue.call_args.kwargs["label_names"]
     assert "task-kind: goal" in labels
     assert "source: scope-split" in labels
+    assert "lineage-root: P" in labels  # falls back to parent_id when no root label
     assert "source: campaign-x" in labels  # inherited
     assert "source: board_worker" in [
         lbl for lbl in labels

--- a/tests/unit/entrypoints/test_controller_liveness.py
+++ b/tests/unit/entrypoints/test_controller_liveness.py
@@ -65,3 +65,61 @@ def test_main_returns_nonzero_when_unhealthy(tmp_path: Path):
 def test_main_returns_zero_when_absent(tmp_path: Path):
     rc = main(["--status-dir", str(tmp_path), "--role", "spec_hygiene"])
     assert rc == 0
+
+
+# ── F2: enforcement (SIGTERM stalled supervisor so the watchdog revives it) ─────
+
+
+def test_signal_restart_sends_sigterm(tmp_path, monkeypatch):
+    import signal as _signal
+
+    from operations_center.entrypoints.controller_liveness import signal_restart
+
+    pidf = tmp_path / "spec.pid"
+    pidf.write_text("4242")
+    killed = {}
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.update(pid=pid, sig=sig))
+    assert signal_restart(pidf) is True
+    assert killed == {"pid": 4242, "sig": _signal.SIGTERM}
+
+
+def test_signal_restart_missing_pidfile_is_noop(tmp_path):
+    from operations_center.entrypoints.controller_liveness import signal_restart
+
+    assert signal_restart(tmp_path / "nope.pid") is False
+
+
+def test_main_enforce_kills_on_stall(tmp_path, monkeypatch):
+    # live-but-stalled heartbeat + --enforce → returns 1 AND signals the pid
+    write_heartbeat(tmp_path, "spec_hygiene", success=True, now=_NOW - timedelta(hours=1))
+    for i in range(6):
+        write_heartbeat(
+            tmp_path, "spec_hygiene", success=False, error="wedged",
+            now=_NOW - timedelta(seconds=60 - i),
+        )
+    pidf = tmp_path / "spec.pid"
+    pidf.write_text("999")
+    killed = {}
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.update(pid=pid))
+    # freeze now so the stall is observed
+    import operations_center.entrypoints.controller_liveness as cl
+    monkeypatch.setattr(cl, "check_controller_liveness",
+                        lambda *a, **k: cl.LivenessVerdict("spec_hygiene", "stalled", "x"))
+    rc = cl.main(["--status-dir", str(tmp_path), "--role", "spec_hygiene",
+                  "--enforce", "--pid-file", str(pidf)])
+    assert rc == 1
+    assert killed == {"pid": 999}
+
+
+def test_main_enforce_healthy_does_not_kill(tmp_path, monkeypatch):
+    # main() uses real wall-clock now, so write a genuinely-recent heartbeat.
+    from datetime import datetime as _dt
+
+    write_heartbeat(tmp_path, "spec_hygiene", success=True, now=_dt.now(UTC))
+    pidf = tmp_path / "spec.pid"
+    pidf.write_text("999")
+    killed = {}
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.update(pid=pid))
+    rc = main(["--status-dir", str(tmp_path), "--role", "spec_hygiene",
+               "--enforce", "--pid-file", str(pidf)])
+    assert rc == 0 and killed == {}

--- a/tests/unit/entrypoints/test_heartbeat.py
+++ b/tests/unit/entrypoints/test_heartbeat.py
@@ -16,6 +16,7 @@ from operations_center.entrypoints.heartbeat import (
     is_live,
     read_heartbeat,
     success_stalled,
+    touch_liveness,
     write_heartbeat,
 )
 
@@ -65,6 +66,51 @@ class TestWriteRead:
 
     def test_read_missing_returns_none(self, tmp_path: Path):
         assert read_heartbeat(tmp_path, "nope") is None
+
+
+class TestTouchLiveness:
+    """R1: the in-task liveness refresh must NOT stamp progress."""
+
+    def test_preserves_progress_fields(self, tmp_path: Path):
+        t0 = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+        # three failing cycles → counter at 3, success frozen
+        write_heartbeat(tmp_path, "goal", success=True, now=t0)
+        for i in range(1, 4):
+            write_heartbeat(
+                tmp_path, "goal", success=False, error="boom", now=t0 + timedelta(minutes=i)
+            )
+        # a long task now runs and refreshes liveness every 60s
+        touch_liveness(tmp_path, "goal", now=t0 + timedelta(minutes=4))
+        hb = read_heartbeat(tmp_path, "goal")
+        # liveness advanced...
+        assert datetime.fromisoformat(hb["at"]) == t0 + timedelta(minutes=4)
+        assert hb["status"] == "executing"
+        # ...but progress is UNTOUCHED: counter not reset, success not stamped
+        assert hb["consecutive_failures"] == 3
+        assert hb["last_success_at"] == t0.isoformat()
+        assert hb["last_error"] == "boom"
+
+    def test_busy_failing_lane_stays_detectable(self, tmp_path: Path):
+        # Reproduce the bug class: a lane that fails real tasks while its in-task
+        # heartbeat fires. Progress must still age so the stall is catchable.
+        t0 = datetime(2026, 6, 22, 12, 0, 0, tzinfo=UTC)
+        write_heartbeat(tmp_path, "goal", success=True, now=t0)
+        for i in range(1, 7):
+            # mid-task liveness pings (the old bug stamped success here)
+            touch_liveness(tmp_path, "goal", now=t0 + timedelta(minutes=i, seconds=30))
+            # then the cycle fails cleanly
+            write_heartbeat(
+                tmp_path, "goal", success=False, error="task failed", now=t0 + timedelta(minutes=i, seconds=59)
+            )
+        hb = read_heartbeat(tmp_path, "goal")
+        assert hb["consecutive_failures"] == 6
+        assert hb["last_success_at"] == t0.isoformat()  # frozen at the last real success
+        assert success_stalled(
+            hb,
+            now=t0 + timedelta(hours=1),
+            max_success_age_seconds=1800,
+            min_consecutive_failures=5,
+        )
 
 
 class TestStallDetection:

--- a/tests/unit/lineage/test_conformance.py
+++ b/tests/unit/lineage/test_conformance.py
@@ -91,3 +91,27 @@ def test_durable_tier_does_not_rescue_untracked_lineage(tmp_path: Path):
         durable_lineage_ids=store.durable_lineage_ids(),
     )
     assert _run_completeness(chain) is Completeness.EXPIRED
+
+
+def test_durable_code_computed_edge_becomes_steerable(tmp_path: Path):
+    # A1: once an edge is backed by the durable tier it is attested (chained +
+    # durable + causal), so a CODE-COMPUTED edge becomes steerable — the model is
+    # no longer inert-by-construction.
+    runs, state = _corpus(tmp_path)
+    store = DurableLineageStore(tmp_path / "ledger.jsonl")
+    store.append(lineage_id_for_task(_OLD_TASK), "board_worker", {"step": "done"})
+    chain = build_chain(
+        _OLD_TASK,
+        runs_root=runs,
+        state_dir=state,
+        now=_NOW,
+        durable_lineage_ids=store.durable_lineage_ids(),
+    )
+    steerable_kinds = {e.kind for e in chain.steerable_edges()}
+    assert "executed_as" in steerable_kinds  # task->run, code-computed, now attested
+
+
+def test_without_durable_backing_nothing_is_steerable(tmp_path: Path):
+    runs, state = _corpus(tmp_path)
+    chain = build_chain(_FRESH_TASK, runs_root=runs, state_dir=state, now=_NOW)
+    assert chain.steerable_edges() == ()

--- a/tests/unit/lineage/test_durable.py
+++ b/tests/unit/lineage/test_durable.py
@@ -98,3 +98,29 @@ def test_non_json_native_payload_survives_verify(tmp_path: Path):
     reloaded = DurableLineageStore(p)
     assert reloaded.verify()
     assert reloaded.durable_lineage_ids() == {"lin-a"}
+
+
+# ── F1 producer ────────────────────────────────────────────────────────────────
+
+
+def test_record_task_completion_writes_typed_fields(tmp_path: Path):
+    from operations_center.lineage.durable import record_task_completion
+
+    record_task_completion(
+        tmp_path,
+        "task-abc-123456",
+        {"run_id": "r1", "status": "succeeded", "pull_request_url": "https://x/pull/9",
+         "goal_text": "SECRET"},
+    )
+    store = DurableLineageStore(tmp_path / "state" / "lineage" / "ledger.jsonl")
+    assert store.durable_lineage_ids() == {lineage_id_for_task("task-abc-123456")}
+    payload = store.entries[0].payload
+    assert payload["status"] == "succeeded" and payload["pr_url"] == "https://x/pull/9"
+    assert "goal_text" not in payload  # free text never recorded
+
+
+def test_record_task_completion_is_best_effort(tmp_path: Path):
+    from operations_center.lineage.durable import record_task_completion
+
+    # an unwritable path must not raise (returns None)
+    assert record_task_completion(tmp_path / "bad\x00path", "t", {"status": "x"}) is None

--- a/tests/unit/lineage/test_durable.py
+++ b/tests/unit/lineage/test_durable.py
@@ -59,3 +59,42 @@ def test_missing_file_is_empty(tmp_path: Path):
 def test_lineage_id_for_task_matches_fleet_format():
     # mirrors outcomes.py: f"lin-{task_id[:12]}" (first 12 chars, hyphens incl.)
     assert lineage_id_for_task("11111111-2222-3333") == "lin-11111111-222"
+
+
+# ── R3 concurrency + R4 canonicalization ──────────────────────────────────────
+
+
+def test_reload_under_lock_prevents_lost_writes(tmp_path: Path):
+    # Two stores constructed BEFORE any append both hold stale empty snapshots.
+    # Because append reloads under the lock, the second writer sees the first's
+    # entry and chains after it — neither write is lost.
+    p = tmp_path / "ledger.jsonl"
+    a = DurableLineageStore(p)
+    b = DurableLineageStore(p)
+    a.append("lin-a", "auth", {"x": 1})
+    b.append("lin-b", "auth", {"y": 2})
+    reloaded = DurableLineageStore(p)
+    assert reloaded.verify()
+    assert {e.lineage_id for e in reloaded.entries} == {"lin-a", "lin-b"}
+
+
+def test_same_lineage_concurrent_appenders_chain(tmp_path: Path):
+    p = tmp_path / "ledger.jsonl"
+    a = DurableLineageStore(p)
+    b = DurableLineageStore(p)
+    a.append("lin-x", "auth", {"n": 1})
+    b.append("lin-x", "auth", {"n": 2})  # reloads, chains off a's tip
+    reloaded = DurableLineageStore(p)
+    assert reloaded.verify()
+    assert len([e for e in reloaded.entries if e.lineage_id == "lin-x"]) == 2
+
+
+def test_non_json_native_payload_survives_verify(tmp_path: Path):
+    # A tuple value + non-str key would hash differently after a JSON reload;
+    # canonicalization-before-hashing keeps verify() true.
+    p = tmp_path / "ledger.jsonl"
+    store = DurableLineageStore(p)
+    store.append("lin-a", "auth", {"items": (1, 2), 3: "x"})
+    reloaded = DurableLineageStore(p)
+    assert reloaded.verify()
+    assert reloaded.durable_lineage_ids() == {"lin-a"}

--- a/tests/unit/lineage/test_models.py
+++ b/tests/unit/lineage/test_models.py
@@ -79,3 +79,19 @@ def test_node_and_chain_serialize():
     payload = chain.as_dict()
     assert payload["task_id"] == "t"
     assert payload["nodes"][0]["attributes"] == {"k": "v"}
+
+
+def test_display_view_vs_steering_split():
+    # A2: humans see free text via display_view; lanes must use steerable_facts
+    # which strips it. Pin both halves of the split in one place.
+    from operations_center.lineage.steering import steerable_facts
+
+    task = LineageNode("task:t", "task", default_trust(provenance=Provenance.TEXT_DERIVED),
+                       attributes={"goal_text": "SECRET-MARKER"})
+    chain = LineageChain(task_id="t", nodes=(task,), edges=())
+    # human display surfaces the free text...
+    assert "SECRET-MARKER" in __import__("json").dumps(chain.display_view(), default=str)
+    # ...but the steering path never does
+    assert "SECRET-MARKER" not in __import__("json").dumps(
+        [f.attributes for f in steerable_facts(chain)], default=str
+    )


### PR DESCRIPTION
## Summary

Remediates the findings from the architecture / functionality-gap / robustness
audit of the execution-lineage arc (PRs #388, #389). Every fix is tested; full
unit suite green; custodian + D12 + X2 clean.

## Robustness (the live ones first)
- **R1 (HIGH, live)** — the in-task heartbeat thread stamped `success=True` every
  60s and the poll loop wrote success unconditionally, so a lane busy-failing real
  tasks hid behind fresh heartbeats (re-creating the stall blind spot the arc was
  built to close). New `touch_liveness()` (liveness-only); the poll loop now
  records the **actual** `dispatch_issue` outcome.
- **R2 (HIGH)** — `ContainmentRequiredError`/`EgressContainmentRequiredError` were
  caught by nobody: an opted-in-but-unavailable sandbox **stranded the task in
  Running** (board_worker) and **aborted the whole worklist** (reviewer). Now
  caught → clean `fail_task` (board) / skip-one-PR (reviewer). The reviewer also
  now applies `maybe_netns` — egress confinement was silently skipped for the
  least-trusted executor.
- **R3** — durable ledger append is now `flock` + `O_APPEND` + reload-under-lock
  (no lost writes, no fixed-tmp clobber, no O(n²) rewrite). **R4** — payload
  canonicalized before hashing (non-JSON-native payloads survive reload-verify).
  **R5** — `build_all` scans run dirs once.

## Functionality gaps
- **F1** — the durable tier had no production writer (A5 was inert).
  `record_task_completion` is now called on every successful dispatch (typed
  fields only). **F2** — `controller_liveness` was invoked by nothing (surface 10
  still open). It gained an `--enforce` mode and is now **called from the watchdog
  loop** (incl. `spec:spec_hygiene`), SIGTERMing a live-but-stalled supervisor so
  the revive restarts it. **F4** — `create_split_followups` bypassed the ceiling +
  per-root cap and stamped no `lineage-root`; now honors both.

## Architecture
- **A1** — `Order` was never `CAUSAL` anywhere, so `is_steerable()` was provably
  always False. A durable-backed edge is now **attested** (integrity CHAINED +
  completeness DURABLE + order CAUSAL via `attested_trust`), so a code-computed
  durable edge can be steerable — the 4-dimension model is no longer inert.
- **A2** — added `LineageChain.display_view()` (sanctioned human path) +
  regression test that free text reaches display but never `steerable_facts`.
- **A3** — documented the read/write split: projection only reads; the
  durable/integrity tier is the isolated attestation authority and sole writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)