### PR TITLE
fix(spec_hygiene): emit liveness-vs-success heartbeat (close surface-10 residual)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8343,3 +8343,7 @@ the exact scenario D2 was built for. spec_hygiene now writes the shared success/
 failure schema via write_heartbeat (success on a completed cycle, success=False
 on a cycle exception), so a crash-looping maintenance loop ages last_success_at
 and is caught + restarted by the watchdog. Surface 10 now fully closed.
+
+## 2026-06-23 — T2 fix for spec_hygiene heartbeat test
+
+Added the missing assert to test_none_status_dir_is_noop (custodian T2).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8334,3 +8334,12 @@ durable/integrity tier is the isolated attestation authority (the only writer).
 Moved the F1 durable producer from dispatch.py into lineage/durable.py as
 record_task_completion (dispatch back under the 500-line C29 limit; producer now
 lives with the tier). Moved its tests to test_durable.py with asserts (T2).
+
+## 2026-06-23 — spec_hygiene heartbeat schema (close F2 residual)
+
+spec_hygiene wrote an old at/status-only heartbeat, so the external controller-
+liveness check (F2) could only catch it when fully DEAD, not live-but-stalled —
+the exact scenario D2 was built for. spec_hygiene now writes the shared success/
+failure schema via write_heartbeat (success on a completed cycle, success=False
+on a cycle exception), so a crash-looping maintenance loop ages last_success_at
+and is caught + restarted by the watchdog. Surface 10 now fully closed.

--- a/src/operations_center/entrypoints/spec_hygiene/main.py
+++ b/src/operations_center/entrypoints/spec_hygiene/main.py
@@ -35,6 +35,7 @@ from operations_center.maintenance import (
     MaintenanceRegistry,
     MaintenanceResult,
 )
+from operations_center.entrypoints.heartbeat import write_heartbeat
 from operations_center.entrypoints.maintenance.board_unblock_task import BoardUnblockTask
 from operations_center.entrypoints.maintenance.drift_monitor_task import DriftMonitorTask
 from operations_center.entrypoints.maintenance.egress_probe import EgressProbeTask
@@ -616,24 +617,22 @@ class SpecHygieneTask:
         )
 
 
-def _write_heartbeat(status_dir: Path | None) -> None:
+def _write_heartbeat(status_dir: Path | None, *, success: bool = True, error: str | None = None) -> None:
+    """Write the spec_hygiene heartbeat using the shared liveness-vs-success
+    schema, so a crash-looping maintenance loop ages ``last_success_at`` and is
+    catchable by the external controller-liveness check (surface 10). Previously
+    spec_hygiene wrote an old at/status-only heartbeat, so the one watcher whose
+    own stall the in-loop HeartbeatStallTask can't see was itself only detectable
+    when fully dead — not when live-but-stalled."""
     if status_dir is None:
         return
-    try:
-        hb = status_dir / "heartbeat_spec_hygiene.json"
-        hb.write_text(
-            json.dumps(
-                {
-                    "role": "spec_hygiene",
-                    "at": datetime.now(UTC).isoformat(),
-                    "status": "idle",
-                },
-                ensure_ascii=False,
-            ),
-            encoding="utf-8",
-        )
-    except OSError:
-        pass
+    write_heartbeat(
+        status_dir,
+        "spec_hygiene",
+        status="idle" if success else "error",
+        success=success,
+        error=error,
+    )
 
 
 def _log_maintenance_result(result: MaintenanceResult) -> None:
@@ -751,11 +750,13 @@ def main() -> None:
             return
         cycle = 0
         while True:
-            _write_heartbeat(args.status_dir)
             try:
                 results = registry.run_due(_build_ctx())
                 for r in results:
                     _log_maintenance_result(r)
+                # The maintenance LOOP completed a cycle (individual task failures
+                # are captured as MaintenanceResults, not exceptions) → success.
+                _write_heartbeat(args.status_dir, success=True)
             except Exception as exc:
                 logger.error(
                     json.dumps(
@@ -763,6 +764,7 @@ def main() -> None:
                         ensure_ascii=False,
                     )
                 )
+                _write_heartbeat(args.status_dir, success=False, error=str(exc))
             cycle += 1
             time.sleep(sd.poll_interval_seconds)
     finally:

--- a/tests/unit/entrypoints/test_spec_hygiene_heartbeat.py
+++ b/tests/unit/entrypoints/test_spec_hygiene_heartbeat.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""spec_hygiene now writes the shared liveness-vs-success heartbeat schema, so a
+crash-looping maintenance loop is catchable by the external controller-liveness
+check (surface 10) — not just when fully dead."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from operations_center.entrypoints.controller_liveness import check_controller_liveness
+from operations_center.entrypoints.heartbeat import read_heartbeat
+from operations_center.entrypoints.spec_hygiene.main import _write_heartbeat
+
+
+def test_success_writes_new_schema(tmp_path: Path):
+    _write_heartbeat(tmp_path, success=True)
+    hb = read_heartbeat(tmp_path, "spec_hygiene")
+    assert hb["consecutive_failures"] == 0
+    assert hb["last_success_at"] == hb["at"]
+    assert hb["last_error"] is None
+
+
+def test_failure_ages_progress_and_is_stall_detectable(tmp_path: Path):
+    _write_heartbeat(tmp_path, success=True)
+    for _ in range(6):
+        _write_heartbeat(tmp_path, success=False, error="loop wedged")
+    hb = read_heartbeat(tmp_path, "spec_hygiene")
+    assert hb["consecutive_failures"] == 6
+    assert hb["last_error"] == "loop wedged"
+    # the external check can now see a LIVE-but-stalled spec_hygiene
+    from datetime import UTC, datetime, timedelta
+
+    verdict = check_controller_liveness(
+        tmp_path,
+        role="spec_hygiene",
+        now=datetime.now(UTC) + timedelta(hours=1),
+        max_liveness_seconds=999999,  # still "live"
+    )
+    assert verdict.status == "stalled"
+    assert verdict.needs_restart
+
+
+def test_none_status_dir_is_noop():
+    _write_heartbeat(None, success=True)  # must not raise

--- a/tests/unit/entrypoints/test_spec_hygiene_heartbeat.py
+++ b/tests/unit/entrypoints/test_spec_hygiene_heartbeat.py
@@ -42,4 +42,4 @@ def test_failure_ages_progress_and_is_stall_detectable(tmp_path: Path):
 
 
 def test_none_status_dir_is_noop():
-    _write_heartbeat(None, success=True)  # must not raise
+    assert _write_heartbeat(None, success=True) is None  # must not raise


### PR DESCRIPTION
Follow-up to #390. Post-restart verification surfaced an honest residual: spec_hygiene wrote an old at/status-only heartbeat, so controller_liveness (F2) could only catch it when fully DEAD, not live-but-stalled — the exact scenario D2/F2 target (a maintenance loop crash-looping while its at stays fresh).

Fix: spec_hygiene now writes the shared liveness-vs-success schema via write_heartbeat (success on a completed cycle; success=False on a cycle exception), so a crash-looping loop ages last_success_at and the watchdog's controller_liveness --enforce restarts it. Surface 10 fully closed.

Tests: tests/unit/entrypoints/test_spec_hygiene_heartbeat.py (incl. an end-to-end assertion that a live-but-stalled spec_hygiene is now detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)