### PR TITLE
feat(board): code-failure retry cap — terminate clean code-failure loops (N=3)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8374,3 +8374,8 @@ no operator escalation — the proposer may re-raise later) — deliberately NOT
 convergence-stall/ProposalRejectionStore path the adversarial review rejected. Docs:
 CODE_FAILURE_RETRY_CAP.md. Full suite 8119 green. Default ON at N=3 (behavior change:
 tasks that currently retry forever now terminate after 3 clean code failures).
+
+## 2026-06-24 — OC8 doc fix
+
+Removed backticks from failure_category VALUE words in CODE_FAILURE_RETRY_CAP.md
+(they are enum string values, not code symbols — OC8).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8361,3 +8361,16 @@ human-semantic veto + human-in-per-correction-loop). Fix = arm the EXISTING
 self-healing count caps for clean code failures (small outcomes.py/board_unblock
 change), NOT lineage. Lineage read-model stays display-only. Linked from the
 determinism-boundary spec (DC7).
+
+## 2026-06-24 — Code-failure retry cap (fixes the SIGKILL-only retry-count bug)
+
+retry-count was SIGKILL-only, so clean code failures (validation_failed/no_changes)
+never armed any cap and looped forever, draining the exec budget. Added a dedicated
+code-fail-count label counter: handle_failure increments it on a clean code failure
+(NOT transient/env/scope_too_wide/unknown, NOT on kill — those use retry-count);
+board_unblock Rule 1 cancels when code-fail-count >= settings.code_failure_retry_cap
+(default N=3, 0=disabled). Cancel is SELF-HEALING (frees budget, no permanent veto,
+no operator escalation — the proposer may re-raise later) — deliberately NOT the
+convergence-stall/ProposalRejectionStore path the adversarial review rejected. Docs:
+CODE_FAILURE_RETRY_CAP.md. Full suite 8119 green. Default ON at N=3 (behavior change:
+tasks that currently retry forever now terminate after 3 clean code failures).

--- a/docs/design/CODE_FAILURE_RETRY_CAP.md
+++ b/docs/design/CODE_FAILURE_RETRY_CAP.md
@@ -40,13 +40,13 @@ A dedicated `code-fail-count:` label counter, parallel to `retry-count:`:
 
 1. **Producer** — `handle_failure` increments `code-fail-count` when a CLEAN
    (no-signal) failure has a category in `_CODE_FAILURE_CATEGORIES`. Default set:
-   `{validation_failed, no_changes}` — the canonical "the approach isn't working
-   and won't converge by re-running the same thing" cases. Deliberately EXCLUDES
-   transient/env categories (`backend_error`, `timeout`, `budget_exhausted`,
-   `routing_error`, `conflict` — self-resolving or handled by convergence-stall),
-   `scope_too_wide` (handled by the split path), and `unknown` (too ambiguous —
-   the founding incident was a misclassified env fault, so we never terminate on
-   `unknown`). Configurable.
+   the two failure_category values "validation_failed" and "no_changes" — the
+   canonical "the approach isn't working and won't converge by re-running the same
+   thing" cases. Deliberately EXCLUDES transient/env categories (backend_error,
+   timeout, budget_exhausted, routing_error, conflict — self-resolving or handled
+   by convergence-stall), scope_too_wide (handled by the split path), and unknown
+   (too ambiguous — the founding incident was a misclassified env fault, so we
+   never terminate on the unknown category). Configurable.
 
 2. **Terminal** — board_unblock Rule 1 gains a third cancel condition:
    `code-fail-count >= settings.code_failure_retry_cap`. It runs in the same

--- a/docs/design/CODE_FAILURE_RETRY_CAP.md
+++ b/docs/design/CODE_FAILURE_RETRY_CAP.md
@@ -1,0 +1,80 @@
+---
+status: implemented
+---
+
+# Code-Failure Retry Cap
+
+**Status:** implemented. Closes the loop identified in the 3-round adversarial
+review of [Lineage Steering Consumer](./LINEAGE_STEERING_CONSUMER.md) §1 — the
+*right* fix for the real bug that review surfaced.
+
+## Problem
+
+`retry-count` is incremented **only on SIGKILL** (`outcomes.py` handle_failure,
+`dispatch.py` kill path). A *clean* code failure — the executor exits normally
+with `success=false` and `failure_category=validation_failed` (tests/lint failed)
+— never touches the counter. So:
+
+- `_MAX_FOLLOW_UP_RETRIES` and board_unblock's Rule-1 cancel (both count-gated)
+  never arm for code failures.
+- board_unblock Rules 3/8 recycle the Blocked task back to Ready (the
+  executor-exit-code exclusion doesn't fire for clean failures).
+
+**Net:** a task that fails the same way forever has no terminal — it loops and
+drains the shared execution budget that gates proposals for healthy work.
+
+## Why NOT the convergence-stall / lineage brake (rejected)
+
+The adversarial review rejected routing this through `detect_convergence_stall` /
+`ProposalRejectionStore`: that store is a **permanent, human-semantic veto** (no
+TTL, checked first as a permanent human "no"), the `failure_category` trigger is
+agent-gameable and was the *misclassified* root of the founding ~190× incident,
+and escalating a recurring per-task correction to a human violates the
+self-healing invariant. See the decision record. This design instead arms the
+**existing self-healing, expiring** count cap — no permanent veto, no human
+escalation, no lineage machinery.
+
+## Design
+
+A dedicated `code-fail-count:` label counter, parallel to `retry-count:`:
+
+1. **Producer** — `handle_failure` increments `code-fail-count` when a CLEAN
+   (no-signal) failure has a category in `_CODE_FAILURE_CATEGORIES`. Default set:
+   `{validation_failed, no_changes}` — the canonical "the approach isn't working
+   and won't converge by re-running the same thing" cases. Deliberately EXCLUDES
+   transient/env categories (`backend_error`, `timeout`, `budget_exhausted`,
+   `routing_error`, `conflict` — self-resolving or handled by convergence-stall),
+   `scope_too_wide` (handled by the split path), and `unknown` (too ambiguous —
+   the founding incident was a misclassified env fault, so we never terminate on
+   `unknown`). Configurable.
+
+2. **Terminal** — board_unblock Rule 1 gains a third cancel condition:
+   `code-fail-count >= settings.code_failure_retry_cap`. It runs in the same
+   already-non-terminal pass that cancels SIGKILL-exhausted tasks, so it fires
+   while the task is Blocked, BEFORE Rule 8 would re-promote it. Cancel → the task
+   leaves the loop and frees the budget.
+
+3. **N** — `Settings.code_failure_retry_cap: int = 3` (0 = disabled). Default 3
+   matches the existing board caps. See header for the tradeoff.
+
+## Why this is self-healing (not a veto)
+
+Cancel sets state `Cancelled` — it does NOT write `ProposalRejectionStore` and
+does NOT escalate to the operator ledger. The proposer may re-raise the work
+after its dedup window if it is still relevant; if the underlying cause was fixed
+meanwhile (new model, dependency bump, fixed flaky check), the next attempt
+succeeds. So the loop is bounded to N attempts *per proposal cycle*
+(self-healing), not forbidden forever (the rejected veto). This satisfies the
+self-healing invariant: no human in the per-correction loop.
+
+## Honest residuals
+
+- **Coarse, not same-signature.** Like the SIGKILL cap, this counts ANY code
+  failure in the set, not N-identical. A genuinely-progressing task (each attempt
+  fixing a different sub-bug, still red) can be cancelled at N. N=3 gives margin;
+  same-signature grouping was deliberately rejected as complexity (and is
+  agent-gameable). Accepted tradeoff.
+- **Agent-influenceable category.** `failure_category` is classified from agent
+  stdout; an agent could force early self-cancel (self-DoS, operator-visible) or
+  vary its category to evade. The conservative default set + cancel-not-veto
+  bounds the blast radius to the agent's own task.

--- a/docs/design/LINEAGE_STEERING_CONSUMER.md
+++ b/docs/design/LINEAGE_STEERING_CONSUMER.md
@@ -96,7 +96,8 @@ permanent veto, NOT human escalation, NOT lineage machinery:
 This is a SEPARATE small change (a retry-cap fix), tracked on its own, gated on the
 operator confirming the behavior change (tasks that currently retry forever would
 terminate after N) — it is consequential and is the operator's call, but it is the
-*right* lever, not the lineage brake.
+*right* lever, not the lineage brake. **IMPLEMENTED** as
+[Code-Failure Retry Cap](./CODE_FAILURE_RETRY_CAP.md) (N=3 default).
 
 ## 2. What is explicitly NOT worth building
 

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -540,6 +540,13 @@ class Settings(BaseModel):
     # so a single runaway root cannot consume the whole global budget even when
     # each generation is individually under the per-lineage retry cap. 0 = off.
     max_descendants_per_root: int = 0
+    # Code-failure retry cap. board_unblock cancels a task once it has accrued
+    # this many CLEAN code failures (validation_failed/no_changes) — retry-count
+    # is SIGKILL-only, so without this a task that keeps failing the same test/lint
+    # re-runs forever and drains the exec budget. Cancel is self-healing (frees the
+    # budget, no permanent veto; the proposer may re-raise later). 0 = disabled.
+    # See docs/design/CODE_FAILURE_RETRY_CAP.md.
+    code_failure_retry_cap: int = 3
     # Synchronous capability-owner check (C2, determinism surface 1). When set,
     # owner-bearing capabilities (board_unblock) verify exactly-one-owner from the
     # registry at invocation and refuse on ambiguity, instead of trusting the

--- a/src/operations_center/entrypoints/board_worker/labels.py
+++ b/src/operations_center/entrypoints/board_worker/labels.py
@@ -61,15 +61,25 @@ def has_label(labels: list, value: str) -> bool:
     return False
 
 
-def retry_count_from_labels(labels: list) -> int:
+def count_from_labels(labels: list, prefix: str) -> int:
+    """Parse the integer value of a ``<prefix>: N`` counter label (0 if absent)."""
+    prefix = prefix.lower()
     for lab in labels:
         name = (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip().lower()
-        if name.startswith("retry-count:"):
+        if name.startswith(prefix):
             try:
                 return int(name.split(":", 1)[1].strip())
             except ValueError:
                 return 0
     return 0
+
+
+def retry_count_from_labels(labels: list) -> int:
+    return count_from_labels(labels, "retry-count:")
+
+
+def code_failure_count_from_labels(labels: list) -> int:
+    return count_from_labels(labels, "code-fail-count:")
 
 
 def add_label(client, issue: dict, new_label: str) -> None:
@@ -96,12 +106,13 @@ def add_label(client, issue: dict, new_label: str) -> None:
         )
 
 
-def increment_retry_count(client, issue: dict) -> None:
-    """Bump retry-count label by 1 (adds 'retry-count: 1' if absent).
+def increment_count_label(client, issue: dict, prefix: str) -> None:
+    """Bump a ``<prefix> N`` counter label by 1 (adds ``<prefix> 1`` if absent).
 
-    Removes the old retry-count: N and adds retry-count: N+1 so
-    board_unblock Rule 1 can cancel tasks that SIGKILL repeatedly.
+    Removes the old ``<prefix> N`` and adds ``<prefix> N+1`` so board_unblock
+    Rule 1 can cancel tasks that exhaust a count cap.
     """
+    label_prefix = prefix.rstrip()  # e.g. "retry-count:"
     existing = [
         (lab.get("name", "") if isinstance(lab, dict) else str(lab)).strip()
         for lab in issue.get("labels", [])
@@ -110,19 +121,32 @@ def increment_retry_count(client, issue: dict) -> None:
     current = 0
     filtered = []
     for label in existing:
-        if label.lower().startswith("retry-count:"):
+        if label.lower().startswith(label_prefix.lower()):
             try:
                 current = int(label.split(":", 1)[1].strip())
             except ValueError:
                 pass
         else:
             filtered.append(label)
-    filtered.append(f"retry-count: {current + 1}")
+    filtered.append(f"{label_prefix} {current + 1}")
     try:
         client.update_issue_labels(str(issue["id"]), filtered)
     except Exception as exc:
         logger.warning(
-            "board_worker: failed to increment retry-count for task_id=%s — %s",
+            "board_worker: failed to increment %s for task_id=%s — %s",
+            label_prefix,
             issue.get("id"),
             exc,
         )
+
+
+def increment_retry_count(client, issue: dict) -> None:
+    """Bump retry-count by 1 so board_unblock Rule 1 can cancel SIGKILL loops."""
+    increment_count_label(client, issue, "retry-count:")
+
+
+def increment_code_failure_count(client, issue: dict) -> None:
+    """Bump code-fail-count by 1 so board_unblock Rule 1 can cancel a clean
+    code-failure loop (CODE_FAILURE_RETRY_CAP). retry-count is SIGKILL-only, so a
+    clean test/lint failure would otherwise re-run forever."""
+    increment_count_label(client, issue, "code-fail-count:")

--- a/src/operations_center/entrypoints/board_worker/outcomes.py
+++ b/src/operations_center/entrypoints/board_worker/outcomes.py
@@ -20,6 +20,7 @@ from .labels import (
     STATE_READY,
     STATE_REVIEW,
     add_label,
+    increment_code_failure_count,
     increment_retry_count,
     label_value,
     retry_count_from_labels,
@@ -29,6 +30,15 @@ from .work_ceiling import ceiling_reached, root_descendant_cap_reached
 logger = logging.getLogger(__name__)
 
 _MAX_FOLLOW_UP_RETRIES = 3
+
+# Clean (no-signal) failure categories that count toward the code-failure retry
+# cap — the "the approach isn't working and won't converge by re-running the same
+# thing" cases. Deliberately EXCLUDES transient/env categories (backend_error,
+# timeout, budget_exhausted, routing_error, conflict — self-resolving or handled
+# by detect_convergence_stall), scope_too_wide (handled by the split path), and
+# unknown (too ambiguous — the founding ~190× incident was a MISCLASSIFIED env
+# fault, so we never terminate on unknown). See CODE_FAILURE_RETRY_CAP.md.
+_CODE_FAILURE_CATEGORIES = frozenset({"validation_failed", "no_changes"})
 _TERMINAL_STATE_NAMES = {"cancelled", "done"}
 
 
@@ -482,6 +492,11 @@ def handle_failure(
             add_label(client, issue, f"executor-signal: {executor_signal}")
             if "sigkill" in executor_signal.lower():
                 increment_retry_count(client, issue)
+        elif category in _CODE_FAILURE_CATEGORIES:
+            # Clean code failure (no kill signal): count it so board_unblock's
+            # self-healing cancel can terminate a same-approach loop that would
+            # otherwise re-run forever — retry-count above is SIGKILL-only.
+            increment_code_failure_count(client, issue)
     except Exception as exc:
         logger.warning(
             "board_worker[%s]: post-failure transition failed task_id=%s — %s",

--- a/src/operations_center/entrypoints/maintenance/board_unblock.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock.py
@@ -238,6 +238,7 @@ _SELF_MODIFY_APPROVED_LABEL = "self-modify: approved"
 _THIN_GOAL_LABEL = "thin-goal"
 _SIGKILL_SIGNAL_PREFIX = "executor-signal:"  # value checked separately
 _RETRY_COUNT_PREFIX = "retry-count:"
+_CODE_FAIL_COUNT_PREFIX = "code-fail-count:"  # CODE_FAILURE_RETRY_CAP
 _BLOCKED_BY_PREFIX = "blocked-by:"
 _ORIGINAL_TASK_PREFIX = "original-task-id:"
 _SOURCE_AUTONOMY_LABEL = "source: autonomy"
@@ -294,6 +295,16 @@ def _retry_count(labels: list[str]) -> int:
         return 0
 
 
+def _code_fail_count(labels: list[str]) -> int:
+    raw = _label_value(labels, _CODE_FAIL_COUNT_PREFIX)
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
 def _blocker_task_id(labels: list[str]) -> str | None:
     return _label_value(labels, _BLOCKED_BY_PREFIX)
 
@@ -311,6 +322,7 @@ def _apply_rules(
     clean_blocked_min_minutes: int,
     mem_available_gb: float,
     cooldown_skip_reason: str | None = None,
+    code_failure_retry_cap: int = 0,
 ) -> list[dict[str, Any]]:
     id_state = _build_id_state_map(issues)
     actions = []
@@ -329,12 +341,25 @@ def _apply_rules(
             is_sigkill_exhausted = (
                 "sigkill" in executor_signal_val.lower() and _retry_count(labels) >= 3
             )
-            if is_dead or is_sigkill_exhausted:
-                reason = (
-                    "labelled dead-remediation"
-                    if is_dead
-                    else "≥3 SIGKILL retries with no safe path"
-                )
+            # CODE_FAILURE_RETRY_CAP: a clean code-failure loop (test/lint that
+            # keeps failing) — retry-count never arms for it, so cancel here once
+            # the dedicated code-fail counter hits the cap. Self-healing: Cancel
+            # frees the budget without a permanent veto; the proposer may re-raise
+            # later if still relevant.
+            is_code_fail_exhausted = (
+                code_failure_retry_cap > 0
+                and _code_fail_count(labels) >= code_failure_retry_cap
+            )
+            if is_dead or is_sigkill_exhausted or is_code_fail_exhausted:
+                if is_dead:
+                    reason = "labelled dead-remediation"
+                elif is_sigkill_exhausted:
+                    reason = "≥3 SIGKILL retries with no safe path"
+                else:
+                    reason = (
+                        f"≥{code_failure_retry_cap} clean code failures "
+                        f"(code-fail-count={_code_fail_count(labels)}) — approach not converging"
+                    )
                 actions.append(
                     {
                         "task_id": task_id,

--- a/src/operations_center/entrypoints/maintenance/board_unblock_task.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock_task.py
@@ -319,6 +319,9 @@ class BoardUnblockTask:
                     stale_running_hours=self._stale_running_hours,
                     clean_blocked_min_minutes=self._clean_blocked_min_minutes,
                     mem_available_gb=mem_gb,
+                    code_failure_retry_cap=int(
+                        getattr(self._settings, "code_failure_retry_cap", 0) or 0
+                    ),
                 )
                 if a.get("task_id") not in reconciled_ids
             ]

--- a/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
@@ -648,6 +648,58 @@ def test_handle_failure_executor_exit_and_signal_sigkill():
     assert any("retry-count: 1" in lbl for lbl in applied)
 
 
+def _all_update_labels(client) -> list[str]:
+    return [lbl for c in client.update_issue_labels.mock_calls for lbl in c.args[1]]
+
+
+def test_handle_failure_clean_code_failure_increments_code_fail_count():
+    # CODE_FAILURE_RETRY_CAP: a clean validation_failed (no kill signal) bumps the
+    # dedicated counter so board_unblock can later cancel the loop.
+    client = _make_client()
+    issue = {"id": "c1", "labels": []}
+    outcomes.handle_failure(
+        client, issue, "goal", "goal", {"failure_category": "validation_failed"}, _make_settings()
+    )
+    assert "code-fail-count: 1" in _all_update_labels(client)
+
+
+def test_handle_failure_transient_category_does_not_count():
+    # Env/transient categories are NOT code failures — must not bump the counter.
+    for cat in ("backend_error", "timeout", "unknown", "scope_too_wide"):
+        client = _make_client()
+        issue = {"id": "c2", "labels": []}
+        outcomes.handle_failure(
+            client, issue, "goal", "goal", {"failure_category": cat}, _make_settings()
+        )
+        assert not any("code-fail-count" in lbl for lbl in _all_update_labels(client)), cat
+
+
+def test_handle_failure_sigkill_uses_retry_not_code_fail():
+    client = _make_client()
+    issue = {"id": "c3", "labels": []}
+    outcomes.handle_failure(
+        client,
+        issue,
+        "goal",
+        "goal",
+        {"failure_category": "validation_failed", "executor_signal": "SIGKILL"},
+        _make_settings(),
+    )
+    labels = _all_update_labels(client)
+    assert any("retry-count" in lbl for lbl in labels)
+    # the elif means a kill does NOT also bump code-fail-count
+    assert not any("code-fail-count" in lbl for lbl in labels)
+
+
+def test_handle_failure_code_fail_count_accrues():
+    client = _make_client()
+    issue = {"id": "c4", "labels": [{"name": "code-fail-count: 2"}]}
+    outcomes.handle_failure(
+        client, issue, "goal", "goal", {"failure_category": "no_changes"}, _make_settings()
+    )
+    assert "code-fail-count: 3" in _all_update_labels(client)
+
+
 def test_handle_failure_exit_code_zero_no_signal():
     client = _make_client()
     issue = {"id": "g5", "labels": []}

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
@@ -308,6 +308,33 @@ def test_rule1_skips_terminal_state():
     assert not _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
 
 
+# Rule 1 — CODE_FAILURE_RETRY_CAP cancel
+def test_rule1_code_fail_exhausted_cancels():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["task-kind: goal", "code-fail-count: 3"])],
+        code_failure_retry_cap=3,
+    )
+    a = _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+    assert a and "clean code failures" in a[0]["reason"]
+    assert a[0]["to_state"] == "Cancelled"
+
+
+def test_rule1_code_fail_under_cap_not_cancelled():
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["code-fail-count: 2"], updated_at=_FRESH)],
+        code_failure_retry_cap=3,
+    )
+    assert not _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+
+
+def test_rule1_code_fail_cap_disabled_by_default():
+    # default cap is 0 (disabled) → even an exhausted counter is not cancelled
+    actions = _run(
+        [_issue("1", state="Blocked", labels=["code-fail-count: 9"], updated_at=_FRESH)]
+    )
+    assert not _by_rule(actions, "DEAD_REMEDIATION_CANCEL")
+
+
 # ---------------------------------------------------------------------------
 # Rule 2 — INVESTIGATE_DEPRIORITISE
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the production bug the 3-round adversarial review of the lineage steering
consumer surfaced: **`retry-count` is incremented only on SIGKILL**, so a task
that keeps failing the same test/lint (clean exit, `failure_category=validation_failed`)
never arms any cap and **re-runs forever**, draining the shared exec budget that
gates proposals for healthy work.

## Design (the *right* lever, not the lineage brake)

A dedicated `code-fail-count:` label counter, parallel to `retry-count:`:

- **Producer** — `handle_failure` bumps `code-fail-count` on a CLEAN (no-signal)
  failure whose category is in `_CODE_FAILURE_CATEGORIES` (default
  `{validation_failed, no_changes}`). Excludes transient/env categories,
  `scope_too_wide` (split path), `unknown` (the founding ~190× incident was a
  *misclassified* env fault — never terminate on unknown), and kills (those use
  `retry-count`).
- **Terminal** — board_unblock Rule 1 gains a third cancel condition:
  `code-fail-count >= settings.code_failure_retry_cap`. It cancels the Blocked
  task before Rule 8 would re-promote it.
- **N = 3** (default; `0` disables). Matches the existing board caps; tolerates one
  flaky-test false positive + a genuine retry + a final attempt.

## Why this is self-healing (not the rejected veto)

Cancel → `Cancelled`. It does **not** write `ProposalRejectionStore` and does
**not** escalate to the operator ledger — the rejected convergence-stall path was a
*permanent human-semantic veto* that violates the self-healing invariant. Here the
loop is bounded to N attempts *per proposal cycle*; the proposer may re-raise later
if still relevant (and if the underlying cause was fixed meanwhile, it succeeds).

## Tests
`handle_failure` increments on clean code failure / not on transient/env / not on
kill / accrues; board_unblock Rule 1 cancels at cap / not under cap / disabled at 0.
Full unit suite 8119 green; custodian/OC8 clean.

## Note: default ON
Per "implement the fix," this defaults to **N=3 ON** — a behavior change: tasks that
currently retry forever now terminate after 3 clean code failures. Set
`code_failure_retry_cap: 0` to disable, or tune N. Spec:
`docs/design/CODE_FAILURE_RETRY_CAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)