### PR TITLE
feat(arc): close the 4 open-gap minimal deltas + inert inventory

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8392,3 +8392,28 @@ timeout dropped by the TeamExecutor adapter; lineage CLI unreachable from
 operations-center.sh; policy/ risk engine fed risk_level=low on every live task;
 capability probe imports bare repograph not the live platform_manifest.capabilities
 path). No code changed. Awaiting operator direction.
+
+## 2026-06-24 — Closed the 4 open-gap minimal deltas + inert-machinery inventory
+
+Finished the 4 Osprey/Praetorian open-gap specs (branch gaps/close-four-minimal):
+- Gap 2 (visualization): WON'T-BUILD UI; wired the trust-tree CLI in via an
+  operations-center.sh `lineage` verb + operations-center-lineage console script.
+- Gap 3 (risk-tier): WON'T-BUILD ladder; shipped an OPT-IN default-OFF sensitive-path
+  ack merge gate (ReviewerSettings.require_sensitive_path_ack + _sensitive_path_ack_ok
+  in pr_review_watcher; sensitive_path_patterns in policy/defaults as single source;
+  sensitive_paths_in_diff in verdict; unit tests).
+- Gap 4 (capability): DEFER dormant; replaced the rot-trap test with activation-contract
+  tests + a probe-target docstring note.
+- Gap 1 (timeout): investigation flipped it to operator-decision — request.timeout_seconds
+  (300 default) is honored by openclaw but overridden by dag's settings (3600); forcing
+  dag to honor it would regress 3600->300. Shipped a de-silencing comment only.
+All 4 specs moved open->resolved.
+
+Plus: a background inert-garbage sweep found 12 more built-but-inert items, captured in
+INERT_MACHINERY_INVENTORY.md. Headline (spot-verified): per-task allowed_paths write-scope
+is never enforced at the patch gate (operator gets only the static blocklist). Systemic
+theme: the live path drops most per-task ExecutionRequest constraints for env/settings.
+All wire-or-delete operator decisions; nothing bulk-acted.
+
+236 unit tests green across touched areas. Every new control is opt-in/additive — no live
+fleet behavior change.

--- a/.console/log.md
+++ b/.console/log.md
@@ -8379,3 +8379,16 @@ tasks that currently retry forever now terminate after 3 clean code failures).
 
 Removed backticks from failure_category VALUE words in CODE_FAILURE_RETRY_CAP.md
 (they are enum string values, not code symbols — OC8).
+
+## 2026-06-24 — Four open-gap adversarial specs (LEFT OPEN, unmerged)
+
+Specced the 4 remaining Osprey/Praetorian open gaps adversarially and left them
+open on this branch (not merged, not implemented): CONTEXT_DISCIPLINE.md,
+LINEAGE_VISUALIZATION.md, RISK_TIERED_APPROVAL.md, RUNTIME_CAPABILITY_ENFORCEMENT.md.
+Each ran steelman -> 2 adversarial rounds -> minimal real delta -> disposition.
+Pattern: every "gap" is mostly already-built; the real delta in each is a small
+fail-closed/observability fix, and each surfaced a concrete latent defect (per-task
+timeout dropped by the TeamExecutor adapter; lineage CLI unreachable from
+operations-center.sh; policy/ risk engine fed risk_level=low on every live task;
+capability probe imports bare repograph not the live platform_manifest.capabilities
+path). No code changed. Awaiting operator direction.

--- a/docs/design/CONTEXT_DISCIPLINE.md
+++ b/docs/design/CONTEXT_DISCIPLINE.md
@@ -1,0 +1,147 @@
+---
+status: open
+---
+
+# Context Discipline
+
+**Status: OPEN — specced adversarially, decision pending. Do NOT implement
+unprompted.** This maps Praetorian's "bounded context / controlled memory
+transfer / context lifecycle" primitive onto OC. One of four open-gap specs from
+the Osprey/Praetorian arc; see also
+[Lineage Visualization](./LINEAGE_VISUALIZATION.md),
+[Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md),
+[Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md), and the
+master [Execution Lineage & Determinism Boundary](./EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md).
+
+**Headline verdict:** WON'T-BUILD as a subsystem. ~80% of "context discipline"
+is already present under other names; the remainder is one tiny fail-closed fix
+(Delta A) and one cross-repo turn-cap that is the operator's call (Delta B). Most
+of what *looks* like a context-discipline gap is the SBX-off-by-default decision
+in disguise.
+
+## Current real state
+
+How OC lanes acquire / bound / transfer context today:
+
+- **Acquire.** `board_worker` does not build the LLM prompt. It claims one Plane
+  issue, extracts a goal string (`board_worker/_text.py`), nonce-fences the
+  untrusted part (`dispatch.py` → `injection.py` `wrap_untrusted_goal`), and
+  appends trusted scaffolding (Definition-of-Done, output contract, ≤5 prior
+  rejection hints). The real prompt is assembled downstream in the external
+  **TeamExecutor** repo, whose `cwd` is a full clone of the branch tips — so the
+  dominant "context" is the working tree the agent reads at will, not the prompt
+  string.
+- **Bound — weakly, on the wrong axis.**
+  - `max_turns` is **vaporware in OC** (zero hits in `src/`); it is a field in
+    TeamExecutor's `team.yaml` that is loaded but **never appended to the `claude`
+    CLI argv**. The agentic loop has no turn cap.
+  - The only enforced runtime bound is a **wall clock** (static 3600s).
+    Host-level rlimit wall-cap (`OC_RLIMIT_WALL_SEC`) is off-by-default +
+    fail-open.
+  - `max_files` / `max_lines` bound the output **diff** post-hoc — a commit gate,
+    not an input-context cap.
+  - **No token budget anywhere** (`RunTelemetry.llm_input_tokens` is
+    reporting-only).
+  - The one real in-run context bound lives in TeamExecutor:
+    `summarizer.py` `_TOKEN_THRESHOLD = 4000` summarizes a prior stage before
+    carrying it forward.
+- **Transfer.** Across tasks: effectively none (fresh temp dir + clone + process
+  per issue; lineage is recorded after success as a display-only read-model,
+  never fed back into a prompt). The `cl`/ContextLifecycle subsystem does
+  anchored persistence + an advisory honor-system gate and contains **zero** size
+  machinery; its hydrate path is skipped entirely for the claude/opus backends OC
+  runs. (This confirms the prior "consolidation middle DORMANT" — it was never
+  built; only field slots exist.)
+
+**Verified for this spec:** `backends/team_executor/adapter.py` `_run_once` calls
+`runner.run(goal_text=..., invocation_id=...)` and **drops
+`request.timeout_seconds`** — the per-task timeout an operator sets is silently
+ignored by the LLM executors.
+
+## Steelman (the strongest case there IS a gap)
+
+1. **Unbounded agentic loop = real cost/divergence exposure.** `max_turns`
+   unwired + per-task timeout dead → a single hard/ambiguous task can burn the
+   full 3600s; nothing caps turns or tokens. The textbook Praetorian
+   "unbounded context → runaway."
+2. **Context laundering past the fence.** The board nonce-fence is real, but
+   untrusted content re-enters unfenced via (a) the agent reading arbitrary repo
+   files (incl. any in-repo `CLAUDE.md`) and (b) TeamExecutor's cross-stage
+   summary text concatenated into the next goal outside any fence. Fenced data →
+   model output → unfenced carried context is a genuine laundering channel.
+3. **The "load-bearing" control is off.** `injection.py` declares the fence
+   non-load-bearing and names "the worker's sandbox / capability-reduction" as
+   the real control — but sandbox, egress netns, and rlimits are all
+   off-by-default + fail-open. So by default neither the fence nor its backstop
+   constrains the agent.
+
+## Adversarial round 1
+
+Bounded-context here is a **quality/cost concern, not a determinism/safety
+primitive**, and the safety slices already have owners:
+
+- **Unbounded loop / cost** is not a subsystem problem; it is one dead field. The
+  fix (wire `max_turns` into the `claude` argv) lives in **TeamExecutor**, not
+  OC. Building an OC-side context-budget manager to fix a missing CLI flag in
+  another repo is wrong-layer + over-engineering. The 3600s wall-clock already
+  bounds the runaway, crudely.
+- **Laundering.** The board fence is *explicitly* defense-in-depth, never
+  load-bearing. Re-fencing the cross-stage summary adds a second non-load-bearing
+  layer — defeated by the same instruction-via-data. Per "capability-reduction
+  beats detection," more fencing is the pattern the priors rank *below* reducing
+  capability. The correct control is the sandbox + egress containment (SBX axis),
+  already designed and wired, just defaulted off.
+- **Sandbox off-by-default** is the genuinely load-bearing fact — but it is the
+  *known* SBX posture decision, not a context gap. Re-litigating it under a
+  "context discipline" banner is mislabeling an owned, deliberately-deferred
+  decision.
+
+## Adversarial round 2
+
+What survives is narrow and tiny:
+
+- The unwired turn cap is a real defect, but the OC-side move is
+  **deletion/honesty**, not addition — stop carrying a dead `max_turns` /
+  per-task `timeout_seconds` that lie about being enforced. The actual fix is
+  cross-repo (TeamExecutor argv).
+- The laundering channel is real, but a measured **size** budget does nothing to
+  close it — a 4000-token summary of a malicious instruction still carries the
+  instruction. Bounding size is orthogonal to bounding trust; the only capability
+  reduction is the sandbox (off by default). So this collapses back into the SBX
+  deferral and gives **zero** independent justification for a context-budget
+  mechanism.
+- **One thing genuinely survives:** OC ships a per-task `timeout_seconds` the LLM
+  executors silently ignore — a **fail-open lie**. An operator who sets a tight
+  bound on a suspect run gets no enforcement and no signal. This is OC's own
+  layer (it owns the work-order → adapter handoff) and is covered by nothing
+  else.
+
+## Minimal real delta
+
+- **Delta A — BUILD-minimal (~3-5 lines).** In
+  `backends/team_executor/adapter.py`, thread `request.timeout_seconds` (when
+  set) into `TeamExecutorRunner.run()`, falling back to the static setting only
+  when unset (mirror the dag/critique adapter pattern). Turns an existing
+  fail-open (operator sets a bound, nothing enforces it) into a real per-task
+  wall-clock bound. If the external Runner signature lacks the param, the honest
+  alternative is to **delete the dead `timeout_seconds` plumbing** so the
+  contract stops promising an unenforced bound.
+- **Delta B — NEEDS-OPERATOR-DECISION (cross-repo).** Wire `max_turns` into
+  TeamExecutor's `claude` argv (`--max-turns <role.max_turns>`). The genuine
+  bounded-context win, but it lives in TeamExecutor and crosses the cross-repo /
+  code-failure line — the operator's call to file there.
+
+Explicitly **not** built: no context-budget manager, no token-ceiling enforcer,
+no eviction/retention policy, no re-fencing of summaries or repo reads, no new CL
+"consolidation middle."
+
+## Disposition
+
+| Item | Disposition | Why |
+|---|---|---|
+| Greenfield context-discipline subsystem | **WON'T-BUILD** | ~80% already exists; remainder is wrong-layer or redundant-with-SBX. |
+| Per-task `timeout_seconds` ignored by LLM executors | **BUILD-minimal (Delta A)** | A real OC-layer fail-open; ~3-5 lines. |
+| `max_turns` unwired into the agent CLI | **NEEDS-OPERATOR-DECISION (Delta B)** | The real win, but lives in TeamExecutor; crosses the cross-repo line. |
+| Cross-stage summary / repo-file injection laundering | **DEFER → fold into SBX** | Bounding size ≠ bounding trust; the real fix is the (owned, deferred) sandbox/egress. |
+
+**Left open** pending the operator's bigger-picture decision on this arc.

--- a/docs/design/CONTEXT_DISCIPLINE.md
+++ b/docs/design/CONTEXT_DISCIPLINE.md
@@ -1,11 +1,16 @@
 ---
-status: open
+status: resolved
 ---
 
 # Context Discipline
 
-**Status: OPEN — specced adversarially, decision pending. Do NOT implement
-unprompted.** This maps Praetorian's "bounded context / controlled memory
+**Status: RESOLVED (2026-06-24).** WON'T-BUILD the subsystem (~80% already
+exists). Investigation reshaped the one candidate "fix": `request.timeout_seconds`
+defaults to 300 (proposal constraint), `openclaw` honors it, `dag` overrides with
+the 3600 settings value — the backends disagree on authority, and forcing `dag` to
+honor the request would *regress* live tasks 3600→300. So this shipped a
+de-silencing comment in `dag_executor/adapter.py`, not a risky change. See
+Resolution below. This maps Praetorian's "bounded context / controlled memory
 transfer / context lifecycle" primitive onto OC. One of four open-gap specs from
 the Osprey/Praetorian arc; see also
 [Lineage Visualization](./LINEAGE_VISUALIZATION.md),
@@ -144,4 +149,15 @@ no eviction/retention policy, no re-fencing of summaries or repo reads, no new C
 | `max_turns` unwired into the agent CLI | **NEEDS-OPERATOR-DECISION (Delta B)** | The real win, but lives in TeamExecutor; crosses the cross-repo line. |
 | Cross-stage summary / repo-file injection laundering | **DEFER → fold into SBX** | Bounding size ≠ bounding trust; the real fix is the (owned, deferred) sandbox/egress. |
 
-**Left open** pending the operator's bigger-picture decision on this arc.
+## Resolution (2026-06-24)
+
+- **WON'T-BUILD** the context-discipline subsystem — confirmed.
+- **Shipped:** a de-silencing comment in `dag_executor/adapter.py` documenting why
+  it uses the settings timeout (not `request.timeout_seconds`) and that the
+  authority question is open. No live behavior change.
+- **Operator decision (recorded):** are per-task proposal constraints authoritative
+  over backend settings? This one question governs timeout AND the dropped
+  `allowed_paths` / `max_changed_files` / `validation_commands` — tracked as the
+  systemic theme in [Inert Machinery Inventory](./INERT_MACHINERY_INVENTORY.md).
+- **Cross-repo (recorded):** wire `max_turns` into TeamExecutor's `claude` argv
+  (team_executor is not even installed in this env).

--- a/docs/design/INERT_MACHINERY_INVENTORY.md
+++ b/docs/design/INERT_MACHINERY_INVENTORY.md
@@ -1,0 +1,76 @@
+---
+status: open
+---
+
+# Inert Machinery Inventory
+
+**Status: OPEN backlog — triage, do not bulk-act.** A standing inventory of
+*built-but-inert* machinery in OC: code that looks like coverage but is dead,
+dormant, unwired, or fed a constant, so it enforces/does nothing on the live
+path. Born from the Osprey/Praetorian arc finding that "the gap is never absence;
+it's present-but-dead machinery that looks present." See the four resolved gap
+specs: [Context Discipline](./CONTEXT_DISCIPLINE.md),
+[Lineage Visualization](./LINEAGE_VISUALIZATION.md),
+[Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md),
+[Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md).
+
+Each entry is classified:
+- **ROTTED** — was meant to work, silently doesn't; an operator could believe a
+  control is active when it is not. (Most dangerous.)
+- **DEAD** — built + (often) tested, but no live caller; should be wired or deleted.
+- **DORMANT-OK** — correct fail-safe opt-in; leave it, but make the dormancy
+  observable so it can't rot into silence.
+
+Most dispositions are **wire-or-delete operator decisions**, not unilateral
+edits. Verify each "no caller / fed-constant / dropped" claim before acting (grep
+returning only def + tests/serialization = candidate).
+
+## Systemic theme — per-task constraints are largely theater
+
+The execution boundary (`execution/handoff.py`) faithfully populates
+`ExecutionRequest` with per-task constraints from the proposal — `allowed_paths`,
+`max_changed_files`, `validation_commands`, `require_clean_validation`,
+`timeout_seconds` — but the **live execution path ignores most of them** in favor
+of static env/settings values. So an operator who tightens a per-task constraint
+often gets no enforcement and no signal. This is one coherent decision, not five
+bugs: **should per-task proposal constraints be authoritative over backend
+settings?** Resolve it once; items 1, 6, 8, and Gap-1 (timeout) are its faces.
+
+## Ranked backlog (most-dangerous first)
+
+| # | What | Where | Class | Disposition |
+|---|------|-------|-------|-------------|
+| 1 | **Per-task write allowlist `allowed_paths` is never enforced at the patch gate** — operator sets a scope allowlist, gets only the static danger-blocklist (`_BLOCKED_BASENAMES`). The one allowlist checker `ChangedFilePolicyChecker` has zero non-test callers; the live adapter drops `request.allowed_paths`. *(spot-verified: set at handoff.py:93, no enforcement reader.)* | `execution/workspace.py:498` → `adapters/workspace/patch_applier.py:272` (validate() takes no allowed_paths); `application/scope_policy.py` (uncalled) | ROTTED | Pass `request.allowed_paths` into the pre-commit validate (or wire `ChangedFilePolicyChecker`); else delete the per-task allowlist plumbing. **Highest priority — a security-shaped control that silently does nothing.** |
+| 2 | **`RuntimeBindingPolicy` (per-task model-tier selection) is dead** — coordinator defaults it to None; the advertised activation method from_defaults_with_runtime_policy() **does not exist** (the only reference is a comment). So `request.runtime_binding` stays None and tier is always the static team default. | `policy/runtime_binding_policy.py`; `execution/coordinator.py:101,116` | DEAD | Add the missing constructor + pass it in `execute/main.py`, or delete module + `config/runtime_binding_policy.yaml` and stop advertising opus/sonnet/haiku tiers. |
+| 3 | **Recovery loop is permanently single-attempt** — `RecoveryPolicy()` defaults `max_attempts=1`, no config wires it up, so retry/backoff/RATE_LIMIT-`retry_after`/budget-checker code is unreachable. (`policy.py:84` even shapes `_ALWAYS_REFUSE` to dodge a hollow-return static check — a "looks-implemented" tell.) | `execution/coordinator.py:121`; `execution/recovery_loop/*` | DEAD | Wire `settings.recovery.*` → `RecoveryPolicy` in `execute/main.py`, or drop the unused checkers + document the loop as single-shot. |
+| 4 | **`QueueHealingEngine` (5-rule blocked-queue healer) is never run** — its only consumer is the `operations-center-triage-scan` verb, which is NOT registered in `spec_hygiene` maintenance and invoked by no systemd unit / watchdog. | `queue_healing/engine.py:12`; `maintenance/triage_scan.py:303` | DEAD | Register a QueueHealingTask wrapper in the maintenance loop, or delete `queue_healing/` + the verb. |
+| 5 | **`recovery/` (parked-state machine, store, 21-field telemetry) + `recovery_policies/` budget tracker — built, test-covered, never wired** — full reference set is the packages + a single isolation test. | `recovery/parked.py`, `recovery/telemetry.py`, `recovery_policies/budget.py` | DEAD | Build the intended parking/oversight consumer (a maintenance task), or delete both packages + the test. |
+| 6 | **Per-request `validation_commands` / `require_clean_validation` dropped** — live validation keys off `repo_cfg.validation_commands`; `request.require_clean_validation` has no execution-path reader. | `execution/handoff.py:97` set; `execution/workspace.py:694` uses repo_cfg | ROTTED | Prefer `request.validation_commands` when present, or remove the per-request fields. (Face of the systemic theme.) |
+| 7 | **`effective_validation_profile` ("standard/elevated/critical") gates nothing** — computed + stored, only reader is a display string in `explain.py`. | `policy/engine.py:589`; `policy/models.py:253` | ROTTED | Map profile→commands at the enforcement site, or delete `required_profile`. |
+| 8 | **Per-task `max_changed_files` ignored** — only the global env caps `OPS_CENTER_MAX_FILES/_LINES` are live; `spec_author` even passes `--max-changed-files` into a field nothing reads. | `execution/handoff.py:94` set; `execution/workspace.py:563` uses `self._max_files` | DEAD | Prefer `request.max_changed_files` when set, or drop the field. (Face of the systemic theme.) |
+| 9 | **`policy/validate.py:validate_config` has no production caller** — it IS exercised in `tests/unit/policy/test_defaults.py:149`, but nothing calls it at config-load time, so a misconfigured live PolicyConfig (bad access_mode, duplicate repo_key) is never caught. | `policy/validate.py:25` | ROTTED | Call it where PolicyConfig is loaded and fail-closed; else accept it as a test-only invariant and document that. |
+| 10 | **`key_proxy/` (cloud-key-injecting reverse proxy) orphaned** — superseded by the SNI egress proxy (subscription auth); no script/unit/spawn references it. | `entrypoints/key_proxy/main.py:119` | ROTTED | Delete the package, or document why retained. |
+| 11 | **`maintenance/audit_close_receipts.py:main` fully orphaned** — unlike every sibling maintenance module, no `[project.scripts]` verb, no runbook, no spawn. | `entrypoints/maintenance/audit_close_receipts.py:79` | DEAD | Add the verb if wanted, else delete. |
+| 12 | **`proposal.priority` fed-a-constant and unread** — dispatch never passes `--priority` (defaults "normal"); no executor-path consumer alters routing on it. | `worker/main.py:50`; `proposal_builder.py:54` | DEAD | Wire priority into queue ordering, or drop it from the proposal. |
+
+## Lower-confidence / observability notes
+
+- **`limit_classifier.models_affected`** (`backends/limit_classifier.py:115`): a no-op ternary (both branches identical) with zero callers — dead + dead-ternary.
+- **`EgressProbeTask`** (`maintenance/egress_probe.py:118`) is registered but `run_once` returns `skipped` whenever `OC_EGRESS_PROXY` is unset — the *correct* DORMANT-OK fail-open, but **verify the env var is set on the live fleet**; if not, the egress-boundary assertion is permanently silent. Emit an observable "probe skipped — proxy unconfigured" signal so dormancy isn't silent. Same observability caveat for `OutcomeFlaggerTask`/`DriftMonitorTask` injection seams (`outcome_source`/`extractor` wired by no production code).
+- **`escalation` adapter** (`adapters/escalation.py:post_escalation`): only live caller is the manual `autonomy-cycle` verb, so escalation never fires autonomously — reachable, not strictly inert.
+
+## How to work this backlog
+
+1. **Resolve the systemic theme first** (1, 6, 8, Gap-1 timeout): one operator
+   decision — per-task constraints authoritative, or not? — then make the
+   adapters consistent in one change instead of four.
+2. **Item 1 (`allowed_paths`) is the priority regardless** — it is the only one
+   shaped like a *security* control that silently enforces nothing. Spec it as a
+   dedicated, opt-in fail-closed gate (mirror the sensitive-path ack gate's
+   shape), not a bulk wire-up.
+3. **The DEAD subsystems (2, 4, 5, 10, 11)** are each a clean *wire-or-delete*
+   operator call. Defaulting to delete is healthy: a tested-but-unwired subsystem
+   is a maintenance liability and a "looks-covered" trap, not an asset.
+4. Whatever is kept dormant, make it **loud** (an observable skipped/degraded
+   signal), per the [Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md)
+   resolution — silent dormancy is how this list grew.

--- a/docs/design/LINEAGE_VISUALIZATION.md
+++ b/docs/design/LINEAGE_VISUALIZATION.md
@@ -1,0 +1,121 @@
+---
+status: open
+---
+
+# Lineage / Operational-Graph Visualization
+
+**Status: OPEN — specced adversarially, decision pending. Do NOT implement
+unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+[Context Discipline](./CONTEXT_DISCIPLINE.md),
+[Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md),
+[Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md), and the
+master [Execution Lineage & Determinism Boundary](./EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md).
+
+**Headline verdict:** WON'T-BUILD a UI/visual surface. The lineage read-model
+already renders as a human-readable trust-labeled tree — the genuine deficiency
+is **discoverability**, not visualization. Fix it by wiring the existing CLI into
+the tool the operator already uses (~3 lines).
+
+## Current real state
+
+- **The read-model already renders for humans.** `lineage/cli.py` `render_chain`
+  prints, per task: the repo, every edge as `src --kind--> dst`, with an honest
+  trust glyph — `[steerable]` vs
+  `[display-only: text-derived, unverified, expired, host-relative]` — steerable
+  edges first, then display-only, then a `steerable edges: N / M` summary.
+  `--json` emits `display_view()`. It renders one task or all (`build_all`).
+- **But it is unreachable in practice (verified).** The only `lineage` mention in
+  `pyproject.toml` is a lint exception (`T201` for the CLI's prints) — there is
+  **no `[project.scripts]` entry**. There is **no `lineage` verb** in
+  `scripts/operations-center.sh`. Invocation is documented only as
+  `python -m operations_center.lineage.cli <task_id>`. (The `--lineage` flags in
+  `tools/loop/controller.py` are ContextLifecycle *session-resume*, unrelated to
+  execution-lineage.)
+- **What the operator routinely looks at shows no lineage:** the status panes
+  (`worker_backend_status` — a rich table of backend cooldowns), per-role
+  `*.status.json`, heartbeat/liveness surfaces. `observer/dashboard.py` is a
+  data-provider (coverage/flaky/latency dicts), served by no entrypoint, with
+  zero lineage content. There is **no HTTP dashboard anywhere** (the only servers
+  are infra: ci_webhook, error_ingest, key_proxy, egress_proxy). No
+  graphviz/mermaid/d3 anywhere in `src/`.
+
+## Steelman
+
+The honest, trust-labeled chain — the one artifact this whole arc produced *for
+humans* — is surfaced nowhere the operator actually looks. It is gated behind a
+`python -m …` incantation that appears in no script, no `--help`, no status pane.
+So the four-dimension trust flags (the entire point of "observable, honest about
+its own trust state") are invisible in practice; when a task misbehaves across
+retries the operator cannot eyeball "task → run → PR → verdict, and which edges
+are display-only vs ground truth" without knowing the chain exists and hand-typing
+a module path. **A read-model a human never reads is, operationally, not
+observable.**
+
+## Adversarial round 1
+
+The steelman conflates "not discoverable" with "not visualized," and only the
+first is true.
+
+- **The read-model IS rendered for humans** — `render_chain` already produces the
+  trust-split tree. The gap is a missing wrapper line so
+  `operations-center.sh lineage <task_id>` works. That is a shell-case arm, not a
+  visualization build.
+- **Who is the consumer of a graph UI?** A single operator, at a terminal that
+  already shows rich tables, does not need a browser graph, a server, a port, an
+  auth surface, and a JS pipeline to read a chain that is **at most ~6 nodes**
+  (task → run → pr → verdict). A box-and-arrows GUI for a 6-node DAG is *less*
+  legible than the existing indented tree and far more to maintain.
+- **It is the highest-entropy, most-forbidden move.** A graph UI is a new
+  long-lived attack surface — exactly what the priors say to avoid. And it would
+  render `display_view()`, which by contract **carries the attacker-controllable
+  `goal_text`**, into a browser (HTML/JS) — manufacturing an XSS/injection sink
+  for adversarial issue-body text that the CLI's plain-stdout rendering does not
+  have. **The visualization would re-introduce the harm the lineage design spent
+  its trust-split removing.**
+
+## Adversarial round 2
+
+Even the surviving "expose the chain as a graph format" idea mostly fails:
+
+- The master spec §7 already pre-rejected a greenfield
+  `OperationalGraphRuntime` / canonical runtime-state authority as the
+  highest-entropy move and a fourth source of truth. A standing graph surface is
+  its read-only face.
+- Directly analogous precedent, resolved one day prior:
+  [LINEAGE_STEERING_CONSUMER](./LINEAGE_STEERING_CONSUMER.md) was killed across 3
+  adversarial rounds with the same logic (standalone subsystem ~90% already
+  covered + adds new harm loses to a small additive delta). Visualization is the
+  same anti-pattern on the display axis.
+- The only sliver with merit — "I can't eyeball *cross-task* lineage roots" — is
+  thin: `build_all` already emits every chain, and grouping repeated failures by
+  lineage-root is the cross-task need already routed to `detect_convergence_stall`
+  as a pending operator decision, not a picture.
+- Format, if ever wanted, is a one-liner (`--format=dot|mermaid` on `cli.py`),
+  not a surface — and even that is speculative (no recorded operator request).
+
+## Minimal real delta
+
+- **Tier 1 — BUILD-minimal (~3 lines), the only thing with present
+  justification.** Add a `lineage` verb to `scripts/operations-center.sh` that
+  shells `python -m operations_center.lineage.cli "$@"`, plus its `usage`/`doctor`
+  line. (Equivalently, a `[project.scripts]` entry
+  `operations-center-lineage = "operations_center.lineage.cli:main"`.) Closes the
+  *actual* gap — the existing trust-labeled tree becomes reachable from the tool
+  the operator already uses — with no new surface, server, or authority.
+- **Tier 2 — DEFER (do not build unprompted).** A `--format=dot|mermaid` branch
+  in `lineage/cli.py:main` emitting graph text to stdout for piping into an
+  external renderer. Still no service. Justified only if an operator says the tree
+  is insufficient for a specific chain.
+
+**Hard stop:** no web service, no daemon, no HTML/JS rendering of
+`display_view()` (it carries attacker-controllable `goal_text`).
+
+## Disposition
+
+| Item | Disposition | Why |
+|---|---|---|
+| Operational graph visualization (a UI/visual surface) | **WON'T-BUILD** | Highest-entropy move; new attack surface for one operator; re-introduces the attacker-text injection sink the lineage design removes. |
+| Lineage CLI unreachable from the operator's tooling | **BUILD-minimal (Tier 1)** | The genuine gap is discoverability; ~3-line `operations-center.sh` verb. |
+| `--format=dot\|mermaid` graph output | **DEFER (Tier 2)** | YAGNI; no operator request on record. |
+
+**Left open** pending the operator's bigger-picture decision on this arc.

--- a/docs/design/LINEAGE_VISUALIZATION.md
+++ b/docs/design/LINEAGE_VISUALIZATION.md
@@ -1,11 +1,13 @@
 ---
-status: open
+status: resolved
 ---
 
 # Lineage / Operational-Graph Visualization
 
-**Status: OPEN — specced adversarially, decision pending. Do NOT implement
-unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+**Status: RESOLVED (2026-06-24).** WON'T-BUILD the UI (it would re-introduce the
+attacker-controllable `goal_text` injection sink). BUILT the Tier-1 discoverability
+fix: the trust-labeled lineage tree is now reachable from operator tooling. See
+Resolution below. One of four open-gap specs from the Osprey/Praetorian arc; see also
 [Context Discipline](./CONTEXT_DISCIPLINE.md),
 [Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md),
 [Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md), and the
@@ -118,4 +120,11 @@ Even the surviving "expose the chain as a graph format" idea mostly fails:
 | Lineage CLI unreachable from the operator's tooling | **BUILD-minimal (Tier 1)** | The genuine gap is discoverability; ~3-line `operations-center.sh` verb. |
 | `--format=dot\|mermaid` graph output | **DEFER (Tier 2)** | YAGNI; no operator request on record. |
 
-**Left open** pending the operator's bigger-picture decision on this arc.
+## Resolution (2026-06-24)
+
+- **WON'T-BUILD** the visualization UI — confirmed (single operator; new attack
+  surface; would render attacker-controllable `goal_text` into a browser).
+- **Shipped (Tier 1):** an `operations-center.sh lineage` verb + an
+  `operations-center-lineage` console script (`pyproject.toml`) → the existing
+  trust-labeled tree CLI is now reachable from operator tooling. No new surface.
+- **Deferred (Tier 2):** a `--format=dot|mermaid` flag — YAGNI, no operator request.

--- a/docs/design/RISK_TIERED_APPROVAL.md
+++ b/docs/design/RISK_TIERED_APPROVAL.md
@@ -1,11 +1,13 @@
 ---
-status: open
+status: resolved
 ---
 
 # Risk-Tiered Approval Ladder
 
-**Status: OPEN — specced adversarially, decision pending. Do NOT implement
-unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+**Status: RESOLVED (2026-06-24).** WON'T-BUILD the general ladder (it duplicates a
+dead-but-existing `policy/` engine and its "high→approve" rung violates the
+self-healing invariant). BUILT the single survivor: an opt-in, default-off
+sensitive-path ack gate. See Resolution below. One of four open-gap specs from the Osprey/Praetorian arc; see also
 [Context Discipline](./CONTEXT_DISCIPLINE.md),
 [Lineage Visualization](./LINEAGE_VISUALIZATION.md),
 [Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md), and the
@@ -139,4 +141,16 @@ task-loss, not stricter review. Wrong layer.
 | Sensitive-path diffs merge through a blast-radius-blind gate | **BUILD-minimal** | One code-computed, fail-closed sensitive-path scope check in `verdict.py`; adds scrutiny without a human gate or router. |
 | The fully-built-but-dead `policy/` engine (fed `risk_level=low`; `REQUIRE_REVIEW` SKIPs) | **NEEDS-OPERATOR-DECISION** | Wire it (real signal + non-skip handler) or mark it dead; today it is neither a gate nor honest dead code. |
 
-**Left open** pending the operator's bigger-picture decision on this arc.
+## Resolution (2026-06-24)
+
+- **WON'T-BUILD** the general risk-tier ladder — confirmed.
+- **Shipped (opt-in, default OFF):** `ReviewerSettings.require_sensitive_path_ack`
+  + `_sensitive_path_ack_ok` in `pr_review_watcher/main.py` (a merge precondition,
+  not a human-in-the-loop tier) + `sensitive_path_patterns()` in `policy/defaults.py`
+  (single source of truth) + `sensitive_paths_in_diff()` in `verdict.py` + unit
+  tests. When enabled, a PR touching CI/migrations/secrets/infra paths is left for
+  the operator unless acked once with a `risk-reviewed` label. Default-off → no
+  live reviewer behavior change until flipped.
+- **Operator decision (recorded):** the fully-built-but-dead `policy/` risk engine
+  (fed `risk_level=low` on every live task; `REQUIRE_REVIEW` silently SKIPs) — wire
+  it or delete it. Tracked in [Inert Machinery Inventory](./INERT_MACHINERY_INVENTORY.md).

--- a/docs/design/RISK_TIERED_APPROVAL.md
+++ b/docs/design/RISK_TIERED_APPROVAL.md
@@ -1,0 +1,142 @@
+---
+status: open
+---
+
+# Risk-Tiered Approval Ladder
+
+**Status: OPEN — specced adversarially, decision pending. Do NOT implement
+unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+[Context Discipline](./CONTEXT_DISCIPLINE.md),
+[Lineage Visualization](./LINEAGE_VISUALIZATION.md),
+[Runtime Capability Enforcement](./RUNTIME_CAPABILITY_ENFORCEMENT.md), and the
+master [Execution Lineage & Determinism Boundary](./EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md).
+
+**Headline verdict:** WON'T-BUILD the general ladder — it is an abstraction with
+one concrete instance on an operator-authored single-operator board, it
+duplicates a **dead-but-existing** policy engine, and its "high→human-approve"
+rung re-introduces the per-correction human the self-healing invariant forbids.
+BUILD-minimal the single survivor instead: one code-computed sensitive-path
+scope check.
+
+## Current real state
+
+The premise "identified-but-unbuilt" is **false for the abstraction, true only
+for the wiring**. OC already contains a complete low/medium/high risk-tier engine
+— it is just dead in the live fleet.
+
+- **A full risk-tier policy engine exists but is unwired (verified).**
+  `policy/engine.py` (22 KB) `PolicyEngine.evaluate()` runs ordered guardrail
+  checks producing `ALLOW / ALLOW_WITH_WARNINGS / REQUIRE_REVIEW / BLOCK`.
+  `policy/defaults.py` is literally a risk ladder (high→strict-validation +
+  block-if-unavailable; medium→standard; low→no-block;
+  `require_review_for_risk_levels=["high"]`) plus path-based blast-radius tiering
+  (`.github/workflows/**`, `**/migrations/**`, `*.env`, `**/secrets/**` →
+  review_required; `**/.ssh/**` → block). It is invoked only on the
+  `execute`/`ExecutionCoordinator` plane.
+- **The decisive finding: `risk_level` is hardcoded LOW in the entire live path,
+  so the engine is a no-op tier-of-one (verified).** The live fleet runs
+  `board_worker → dispatch.py → worker.main → execute.main`. `dispatch.py`'s
+  `plan_cmd` passes goal/task-type/execution-mode/repo-key but **never
+  `--risk-level`**; `worker/main.py:49` defaults `--risk-level` to `low`. No
+  classifier, goal-heuristic, or label→risk mapping exists anywhere in the live
+  path. Net: the coordinator evaluates **every live task as low**; the high/medium
+  rungs are unreachable (exercised only by demo + unit tests).
+- **What IS live and tiered (the real graduated handling):** the
+  [Self-Heal Ladder](./SELF_HEAL_LADDER.md) (L0 standard fix → L1 enriched
+  context → L2 decompose-per-concern → L3 rescope, bounded by
+  `max_fix_strategy_level`) graduates *resolving effort*, not action-risk; the
+  code-computed reviewer verdict (`pr_review_watcher/verdict.py` `compute_verdict`,
+  fail-safe to CONCERNS, LGTM-only merge) is uniform-strict (correct); plus the
+  self-merge / branch-protection gate, the admission allowlist, thin-goal block,
+  OPEN_PR_GATE, and per-repo `max_daily_executions`.
+
+So graduated **effort** is live; graduated **action-risk routing** exists as
+built-but-dead code with no risk signal feeding it.
+
+## Steelman
+
+Not "build a new abstraction" — "you already paid for one, and a genuinely
+high-blast-radius action rides the same uniform gate as a one-line typo fix."
+A fleet PR that rewrites `.github/workflows/**` (the CI that gates every *other*
+merge), or `**/migrations/**` (irreversible), or OC's own egress/sandbox
+`config/`, gets exactly the same scrutiny as a docstring fix: one LGTM from the
+same four generic checks (`spec_compliance`, `custodian_findings`,
+`code_quality`, `no_tooling_artifacts`), none of which is blast-radius-aware.
+`policy/defaults.py` already enumerates exactly these sensitive paths as
+review-worthy — the policy plane "knows" they are special; the live plane that
+merges them is blind to that knowledge.
+
+## Adversarial round 1
+
+- **Already-covered, on the axis that matters.** The live graduation is the
+  Self-Heal Ladder (effort) + uniform-strict verdict (every PR clears the same
+  bar). "Build a risk-tier ladder" is either re-deriving existing code or wiring
+  up dead code — and the latter is a much smaller task than "spec a general
+  system."
+- **Operator-authored board → which tasks even have differentiated risk?** The
+  human who knows the blast radius is the one writing the task and can already set
+  per-task risk by **label** (the engine reads `"review_required" in labels`). A
+  general *classifier* solves a problem the operator-authored board doesn't have.
+- **The smuggled human gate (and it's worse than it looks).** A "high→human-
+  approve" rung is exactly the per-correction human the self-healing invariant
+  forbids. And the trap: the existing engine's `REQUIRE_REVIEW` does **not**
+  implement a human handoff — `_policy_blocked_result` returns
+  `status=SKIPPED, success=False`, i.e. it silently **drops the task**. So
+  adopting the ladder as-is gives neither autonomy nor a review queue — it gives
+  silent task-skips on the highest-value work, which self-heal then retries into
+  the same wall. Both versions lose.
+- **Abstraction without a second instance.** There is one plausible high-risk
+  action class (sensitive-path diffs). A general classifier + router + per-tier
+  table for one instance is abstraction-for-its-own-sake; the Self-Heal Ladder
+  earned its generality, a risk-router has not.
+
+## Adversarial round 2
+
+Exactly one thing survives: **sensitive-path diffs merge through the same
+blast-radius-blind gate as trivial diffs.** Attack the survivor — is the fix "add
+a tier system" or "add ONE gate"? It is one gate, and it must obey "resolve the
+concern, never bypass it":
+
+- The ungated action is specific and enumerable — a diff touching the paths
+  `policy/defaults.py` already lists. You don't need a risk *classifier*
+  (goal-text inference, a new injection surface + a misclassify-high-as-low
+  failure mode); you need a **deterministic diff-path check**, model-free and
+  injection-proof — the same shape as the existing `no_tooling_artifacts` check.
+- It fits the existing verdict mechanism with zero new abstraction: one more
+  fail-closed condition in `compute_verdict`, not a router.
+- Crucially it does **not** add a human-in-the-loop tier: "touches a sensitive
+  path → require a stricter deterministic check passes, or an operator
+  `risk-reviewed:` ack label set **once at task-authoring**" keeps the human at
+  the encode-once anchored root. The fleet still self-heals to clear it; it just
+  clears a scope-aware bar on those paths. No `REQUIRE_REVIEW`-skip, no approval
+  queue.
+
+## Minimal real delta
+
+**Specific ungated high-risk action:** a fleet-authored PR whose diff modifies
+blast-radius-controlling paths — `.github/workflows/**`, `**/migrations/**`,
+`**/secrets/**` / `*.env`, and OC's own sandbox/egress `config/` — merges on the
+same generic four-check LGTM as a docstring change.
+
+**Smallest concrete change — one deterministic check, one file:** in
+`pr_review_watcher/verdict.py`, add a **code-side** condition to `compute_verdict`:
+if any changed file matches the sensitive-path globs **and** the PR/task carries
+no operator `risk-reviewed:<area>` ack label, append a synthetic failing check
+(e.g. sensitive-path-unacked) → forces CONCERNS. Reuse the glob set from
+`policy/defaults.py` (import it; single source of truth). Same fail-closed,
+code-computed shape as the existing verdict; uninfluenced by injection; LGTM-only
+merge preserved; the only escape is the encode-once operator ack.
+
+Do **not** wire the dead `policy/` + `ExecutionCoordinator` review-gate into the
+live path for this — its `REQUIRE_REVIEW` silently SKIPs (drops), giving silent
+task-loss, not stricter review. Wrong layer.
+
+## Disposition
+
+| Item | Disposition | Why |
+|---|---|---|
+| General risk-tier approval ladder | **WON'T-BUILD** | Abstraction with one instance; duplicates the dead `policy/` engine; "high→approve" re-introduces the forbidden per-correction human (and the existing tier silently SKIPs). |
+| Sensitive-path diffs merge through a blast-radius-blind gate | **BUILD-minimal** | One code-computed, fail-closed sensitive-path scope check in `verdict.py`; adds scrutiny without a human gate or router. |
+| The fully-built-but-dead `policy/` engine (fed `risk_level=low`; `REQUIRE_REVIEW` SKIPs) | **NEEDS-OPERATOR-DECISION** | Wire it (real signal + non-skip handler) or mark it dead; today it is neither a gate nor honest dead code. |
+
+**Left open** pending the operator's bigger-picture decision on this arc.

--- a/docs/design/RUNTIME_CAPABILITY_ENFORCEMENT.md
+++ b/docs/design/RUNTIME_CAPABILITY_ENFORCEMENT.md
@@ -1,0 +1,148 @@
+---
+status: open
+---
+
+# Runtime Capability Enforcement (C2)
+
+**Status: OPEN — specced adversarially, decision pending. Do NOT implement
+unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+[Context Discipline](./CONTEXT_DISCIPLINE.md),
+[Lineage Visualization](./LINEAGE_VISUALIZATION.md),
+[Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md), and the master
+[Execution Lineage & Determinism Boundary](./EXECUTION_LINEAGE_AND_DETERMINISM_BOUNDARY.md).
+
+**Headline verdict:** DEFER — keep it dormant. Dormant-by-environment is the
+*correct* intended state. The only real risk is **silent rot**: the probe targets
+the wrong module for the live load path, and a test locks in "None forever." Land
+a tiny observability + anti-rot slice so the dormancy is loud; escalate the
+probe-target question.
+
+## Current real state
+
+- **The mechanism exists.** `capability_ownership.py`: `resolve_owner` mirrors
+  RepoGraph's build-time invariant (count `owns` edges, raise on ≠1);
+  `verify_owner_or_degrade` is the gate — no-op when `required=False`, DEGRADE
+  and proceed when the registry is None, REFUSE only on a *loaded* registry with
+  ambiguous/mismatched owner. One call site: `board_unblock_task.py`, guarded by
+  `settings.require_capability_owner` (default `False`) with
+  `expected_owner=self_repo_key`.
+- **Why it is dormant — a version-pin fact (verified).** `load_capability_registry`
+  does `importlib.import_module("repograph")` then
+  `getattr(mod, "load_capability_registry", None)`. In OC's venv `repograph` is
+  installed (v0.2.0, transitively via `platform-manifest@v1.0.0`) but **has no
+  `load_capability_registry`** → returns None. The capabilities plane
+  (`repograph/capabilities/{compiler,validation,…}.py`) lives on RepoGraph **HEAD
+  only**, on no released tag.
+- **The probe targets the wrong module for the live path (verified).**
+  `capability_ownership.py` imports **bare `repograph`** and looks for
+  `repograph.load_capability_registry`. But the real consumer-facing API is
+  `platform_manifest.capabilities.load_capabilities()`, which returns a
+  `CapabilityRegistry` with `.edges` and is what a live OC would call. If the
+  plane ships only through PM's wrapper, OC's probe stays None **forever**.
+- **A graph-level gate already enforces — a different thing than assumed.** Two
+  distinct mechanisms: (1) **exactly-one-owns** is enforced at *build/compile*
+  time in `repograph/capabilities/validation.py` (raises whenever the registry is
+  compiled — a duplicate-owner registry cannot even load); (2) **Custodian CAP1**
+  (`capability_refs.py`) does **not** check owner-count at all — it checks that an
+  owned capability's `invocation.ref` resolves to existing code (rot detection).
+  OC subscribes to CAP1 (`.custodian/config.yaml`); the registry-side CAP1 runs
+  in PM CI.
+
+## Steelman
+
+The async gates are temporally wrong for *prevention*. Build-time validation runs
+when the registry is authored/compiled in PM; CAP1 runs in CI. Both are "code
+acts first; the sweep flags drift later." A maintenance lane (`board_unblock`, a
+fleet-mutating capability) executes between sweeps. If the registry were ever in
+an ambiguous state at the moment it fires, a **synchronous** check refuses *that
+specific privileged mutation* before it touches the fleet — preventive, not
+detective, on the highest-value action.
+
+## Adversarial round 1
+
+- **The threat model is empty in this fleet.** Single operator, operator-authored
+  board, operator-authored registry. For runtime enforcement to *prevent*
+  something the registry must reach ambiguity *while the fleet runs* and
+  `board_unblock` must fire against it. But a duplicate `owns` edge **cannot be
+  loaded** (validation raises at compile), so the REFUSE branch is **unreachable
+  against any registry that successfully loaded**. The only reachable REFUSE is an
+  `expected_owner` mismatch — which fires only if the operator intentionally
+  reassigns ownership in the registry and forgets to update OC's `self_repo_key`:
+  a typo in two operator-controlled files, caught at the next CAP1 sweep, on a
+  task that degrades safely. Not an adversary.
+- **The graph gate already covers the real risk.** The real capability-integrity
+  risk here is **registry rot** (a capability pointing at moved/deleted code) =
+  exactly CAP1, which OC already enforces and PM CI runs cross-repo.
+  Exactly-one-owns is enforced at compile. Runtime adds no integrity check the
+  graph layer doesn't already make structurally true or detect.
+- **"Dormant until the plane ships" is the correct, intended state.** Textbook
+  fail-open opt-in: present + tested, default off, degrades to proceed when input
+  absent, activates when its input ships. It honors the self-healing invariant
+  precisely — a missing registry must never halt `board_unblock`, and it doesn't.
+- **Un-dorming is costly and asymmetric.** To go live you must put a
+  registry-exposing dependency in OC's runtime: either bump `platform-manifest`
+  to a commit whose transitive `repograph` is HEAD-with-plane (**no such release
+  exists**) or vendor RepoGraph HEAD. That adds version coupling (OC blocks on
+  RepoGraph cutting a plane release), supply-chain surface (an unreleased dep on
+  `main`), and a new failure mode — `load_capabilities()` runs the full registry
+  compiler in OC's hot maintenance loop. You add coupling to the most
+  safety-critical self-heal lane to buy prevention of a non-threat.
+
+## Adversarial round 2
+
+What survives is not "make it live" — it is the single concrete defect: **silent
+rot of the dormant mechanism.** Attacked skeptically:
+
+- **The probe can never activate via the live path.** Even on the day RepoGraph
+  ships a plane release and OC bumps it, the probe imports `repograph` and looks
+  for `repograph.load_capability_registry`; the live fleet path is
+  `platform_manifest.capabilities.load_capabilities`. If the plane ships only
+  through PM's wrapper, the guard stays None forever while the operator believes
+  it "activates on input." The test `test_load_returns_none_in_this_environment`
+  **locks in** the dormant result and keeps passing for the wrong reason after the
+  plane ships.
+- **Counter-attack:** the wrong-module risk is conditional on *how* RepoGraph
+  ships the symbol (if it re-exports `load_capability_registry` at top level, bare
+  `import repograph` would find it) — RepoGraph's call, not OC's. That weakens
+  "fix the probe now" to "the probe's assumption is unverifiable until the dep
+  ships." Which lands on: the only defensible delta is making the **dormancy
+  observable**, not changing the probe to chase an unreleased shape.
+- **Does the mechanism deserve to exist?** It is redundant-by-construction
+  (compiler guarantees ≠ambiguous; CAP1 covers rot); load-bearing value ≈ zero.
+  But it is cheap, tested, fail-open, and on the right action; deleting it
+  re-opens the "surface has no synchronous layer" audit finding for no gain. Its
+  presence is fine; its **invisibility** is the liability.
+
+## Minimal real delta
+
+Do **not** "make it live now" (needs an unreleased RepoGraph release or vendoring
+HEAD; adds coupling + a new failure mode to the most critical self-heal lane, to
+prevent a non-threat). The real delta makes dormancy explicit and rot-proof:
+
+- **Primary — BUILD-minimal (~10 lines, observability).** When `required=True`
+  and the registry is None, surface a one-shot `capability_owner_unverifiable`
+  WARN / heartbeat field to the operator console (heartbeat plumbing already
+  pipes OC status out). Goal: an operator who *sets* `require_capability_owner=True`
+  believing it enforces SEES that it is silently degrading. File:
+  `board_unblock_task.py` (emit into existing details/heartbeat) or a `settings.py`
+  validator.
+- **Anti-rot test pin (higher-value half).** Replace/augment
+  `test_load_returns_none_in_this_environment` with a test asserting the
+  **activation contract** — iff a module exposing `load_capability_registry` is
+  importable, the guard transitions out of degrade. As written, the test cements
+  "None forever" and passes for the wrong reason post-ship.
+- **Probe-target — NEEDS-OPERATOR-DECISION (not an unprompted edit).** Record in
+  the docstring that the live registry ships via
+  `platform_manifest.capabilities.load_capabilities`, and that the bare-`repograph`
+  probe is intentional-pending-confirmation of RepoGraph's export shape. Changing
+  the probe target binds OC to a different dependency surface — an operator call.
+
+## Disposition
+
+| Item | Disposition | Why |
+|---|---|---|
+| Make runtime capability enforcement live | **DEFER (keep dormant)** | Dormant-by-environment is correct; redundant with build-time exactly-one-owns + CAP1; no live threat; un-dorming adds coupling to the critical self-heal lane. |
+| Silent rot (probe can't activate via live path; test locks in "None forever") | **BUILD-minimal** | ~10-line observability + an activation-contract test, so dormancy is loud not silent. |
+| Probe target (`repograph` vs `platform_manifest.capabilities`) | **NEEDS-OPERATOR-DECISION** | Binds OC to a dependency surface; decide before any go-live. |
+
+**Left open** pending the operator's bigger-picture decision on this arc.

--- a/docs/design/RUNTIME_CAPABILITY_ENFORCEMENT.md
+++ b/docs/design/RUNTIME_CAPABILITY_ENFORCEMENT.md
@@ -1,11 +1,12 @@
 ---
-status: open
+status: resolved
 ---
 
 # Runtime Capability Enforcement (C2)
 
-**Status: OPEN — specced adversarially, decision pending. Do NOT implement
-unprompted.** One of four open-gap specs from the Osprey/Praetorian arc; see also
+**Status: RESOLVED (2026-06-24).** DEFER — dormant-by-environment is correct.
+SHIPPED the anti-rot guard (the test no longer cements "None forever") + a
+probe-target note. See Resolution below. One of four open-gap specs from the Osprey/Praetorian arc; see also
 [Context Discipline](./CONTEXT_DISCIPLINE.md),
 [Lineage Visualization](./LINEAGE_VISUALIZATION.md),
 [Risk-Tiered Approval](./RISK_TIERED_APPROVAL.md), and the master
@@ -145,4 +146,16 @@ prevent a non-threat). The real delta makes dormancy explicit and rot-proof:
 | Silent rot (probe can't activate via live path; test locks in "None forever") | **BUILD-minimal** | ~10-line observability + an activation-contract test, so dormancy is loud not silent. |
 | Probe target (`repograph` vs `platform_manifest.capabilities`) | **NEEDS-OPERATOR-DECISION** | Binds OC to a dependency surface; decide before any go-live. |
 
-**Left open** pending the operator's bigger-picture decision on this arc.
+## Resolution (2026-06-24)
+
+- **DEFER (keep dormant)** — confirmed correct: redundant with build-time
+  exactly-one-owns + Custodian CAP1, no live threat, un-dorming would add coupling
+  to the critical self-heal lane.
+- **Shipped:** replaced the rot-trap test (`test_load_returns_none_in_this_environment`,
+  which cemented "None forever") with activation-contract tests (loader importable
+  → the guard uses it; absent → None; module absent → None). Added a PROBE TARGET
+  docstring note in `capability_ownership.py`. The existing degrade WARNING already
+  surfaces `capability_owner_unverifiable`.
+- **Operator decision (recorded):** the probe targets bare `repograph` but the live
+  registry ships via `platform_manifest.capabilities` — decide the binding surface
+  before any go-live. Tracked in [Inert Machinery Inventory](./INERT_MACHINERY_INVENTORY.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ operations-center-governance = "operations_center.entrypoints.governance.main:ap
 # {ghost_work,flow,code_health}_audit.md for the catalogs each scanner enforces.
 operations-center-ghost-audit       = "operations_center.entrypoints.ghost_audit.main:main"
 operations-center-flow-audit        = "operations_center.entrypoints.flow_audit.main:main"
+operations-center-lineage           = "operations_center.lineage.cli:main"
 # Cross-repo Custodian sweep — runs custodian-audit against every managed repo
 # with a local checkout and a .custodian.yaml, emits one Plane task per repo
 # with --emit. Read-only against the managed repos; mutates Plane only.

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -200,6 +200,7 @@ Usage:
   scripts/operations-center.sh promote-backlog [--family FAMILY] [--execute]
   scripts/operations-center.sh worker-backend-status [--json]
   scripts/operations-center.sh worker-backend-probe [--json] [--timeout N]
+  scripts/operations-center.sh lineage [TASK-ID] [--json]
   scripts/operations-center.sh watchdog-loop-acquire
   scripts/operations-center.sh watchdog-loop-release
   scripts/operations-center.sh watchdog-loop-status
@@ -971,6 +972,13 @@ PYEOF
     ensure_venv
     load_env_file
     "${VENV_DIR}/bin/python" -m operations_center.entrypoints.worker_backend_probe.main "$@"
+    ;;
+  lineage)
+    # Execution-lineage read-model (trust-labeled, display-only). The CLI was
+    # complete but unreachable from operator tooling — this verb wires it in.
+    ensure_venv
+    load_env_file
+    "${VENV_DIR}/bin/python" -m operations_center.lineage.cli "$@"
     ;;
   plane-doctor)
     ensure_venv

--- a/src/operations_center/backends/dag_executor/adapter.py
+++ b/src/operations_center/backends/dag_executor/adapter.py
@@ -94,6 +94,12 @@ class DAGExecutorBackendAdapter:
             runner = DAGExecutorRunner(
                 artifacts_dir=artifacts_dir,
                 working_directory=str(workspace),
+                # Timeout authority is an OPEN operator decision (CONTEXT_DISCIPLINE.md):
+                # we use the backend SETTINGS timeout, not request.timeout_seconds —
+                # the latter defaults to 300s from proposal.constraints and would cut
+                # tasks below the operator-configured value. The openclaw adapter honors
+                # the request instead, so backends disagree on which is authoritative;
+                # aligning them changes live task runtimes, so it is not a silent fix.
                 timeout_seconds=self._settings.timeout_seconds or None,
                 worker_backend=worker_backend,
             )

--- a/src/operations_center/capability_ownership.py
+++ b/src/operations_center/capability_ownership.py
@@ -17,6 +17,13 @@ an OC runtime dependency. That binding is a dependency-pinning concern OC cannot
 self-resolve; this is the EVAL "blocking-deferred" pattern, not a live enforcement.
 Do not claim it closes surface 1 until the registry actually loads in production.
 
+PROBE TARGET — open operator decision. ``load_capability_registry`` below probes
+bare ``import repograph``, but the live registry actually ships through
+``platform_manifest.capabilities.load_capabilities``. If the capabilities plane
+only ever ships via the platform_manifest wrapper, this probe can never activate —
+so the *activation contract* is pinned by test (not "returns None forever"), and
+which dependency surface OC binds to is an operator decision before any go-live.
+
 Default posture is opt-in + fail-open (§0.1): the guard is a no-op unless
 ``require_capability_owner`` is set, and an unavailable registry degrades rather
 than halting critical self-healing (board_unblock).

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -311,6 +311,12 @@ class ReviewerSettings(BaseModel):
     # self-merging; if not, it refuses and leaves the PR for an operator. False
     # preserves prior behavior (trust GitHub protection blindly).
     require_branch_protection: bool = False
+    # Sensitive-path ack gate (opt-in). When True, a PR whose diff touches a
+    # blast-radius path (CI workflows, migrations, secrets, infra config) is NOT
+    # self-merged unless the operator acked it ONCE with a 'risk-reviewed' label —
+    # extra scrutiny on high-blast-radius diffs without putting a human in the
+    # per-correction loop. False (default) preserves prior behavior.
+    require_sensitive_path_ack: bool = False
 
 
 class RepoSettings(BaseModel):

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -87,8 +87,10 @@ from operations_center.entrypoints.pr_review_watcher.verdict import (
     CONCERNS,
     compute_verdict,
     failing_summary,
+    sensitive_paths_in_diff,
     verdict_schema_prompt,
 )
+from operations_center.policy.defaults import sensitive_path_patterns
 
 logger = logging.getLogger(__name__)
 
@@ -1018,6 +1020,56 @@ def _branch_protection_ok(gh_client, owner: str, repo: str, base_branch: str, se
     return True
 
 
+def _sensitive_path_ack_ok(
+    gh_client,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    pr_data: dict,
+    settings,
+) -> bool:
+    """Opt-in blast-radius gate (mirrors ``_branch_protection_ok``'s shape).
+
+    Returns True (allow merge) unless ``reviewer.require_sensitive_path_ack`` is
+    set AND the PR's diff touches a sensitive path without an operator
+    'risk-reviewed' ack label. The ack is an encode-once root action (label the
+    PR), never a per-correction approval — the fleet still produced the LGTM; this
+    only adds a merge precondition it cannot satisfy by editing code, so a
+    sensitive PR is left for the operator instead of looping a fix.
+
+    Fail-OPEN on its own errors (cannot list files): a gate that can't evaluate
+    must not wedge a clean LGTM merge on a GitHub API hiccup — the operator opted
+    into scrutiny, not into a brittle block.
+    """
+    reviewer = getattr(settings, "reviewer", None)
+    if reviewer is None or not getattr(reviewer, "require_sensitive_path_ack", False):
+        return True
+    for lab in pr_data.get("labels") or []:
+        name = lab.get("name", "") if isinstance(lab, dict) else str(lab)
+        if name.startswith("risk-reviewed"):
+            return True  # operator acked once at the root
+    try:
+        files = gh_client.list_pr_files(owner, repo, pr_number)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "pr_review_watcher: sensitive-path gate could not list files for PR #%d "
+            "— %s; allowing merge (fail-open)",
+            pr_number,
+            exc,
+        )
+        return True
+    hits = sensitive_paths_in_diff(files, sensitive_path_patterns())
+    if hits:
+        logger.error(
+            "pr_review_watcher: PR #%d touches sensitive paths without a "
+            "'risk-reviewed' ack: %s",
+            pr_number,
+            ", ".join(sorted(hits)[:10]),
+        )
+        return False
+    return True
+
+
 def _publish_reviewer_verdict(
     gh_client,
     owner: str,
@@ -1089,6 +1141,16 @@ def _merge_and_done(
             pr_number,
         )
         return  # leave state file — operator must inspect
+    # Sensitive-path ack gate (opt-in; blast-radius scrutiny). No-op unless
+    # reviewer.require_sensitive_path_ack is set. Keeps the human at the
+    # encode-once root (a 'risk-reviewed' label), never the per-correction loop.
+    if not _sensitive_path_ack_ok(gh_client, owner, repo, pr_number, _pr_data, settings):
+        logger.error(
+            "pr_review_watcher: PR #%d not self-merged — sensitive-path ack gate "
+            "failed; leaving for operator",
+            pr_number,
+        )
+        return  # leave state file — operator must inspect/ack
     # Bless this head with reviewer-verdict=success BEFORE merging, so the
     # required status check is satisfied for the fleet's own merge — and so the
     # non-LGTM merge paths (e.g. ci_validated_after_retraction) also clear the

--- a/src/operations_center/entrypoints/pr_review_watcher/verdict.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/verdict.py
@@ -115,6 +115,25 @@ def compute_verdict(checks: object) -> tuple[str, list[str]]:
     return (LGTM, []) if not failing else (CONCERNS, failing)
 
 
+def sensitive_paths_in_diff(changed_files: object, patterns: list[str]) -> list[str]:
+    """Return the subset of ``changed_files`` matching any sensitive-path glob.
+
+    Pure, model-free, injection-proof — it inspects the actual changed-file list,
+    not model output. ``patterns`` come from
+    ``policy.defaults.sensitive_path_patterns`` so the reviewer's blast-radius gate
+    and the policy plane share one source. Matching uses ``fnmatch`` for parity
+    with the policy engine's own path matcher.
+    """
+    import fnmatch
+
+    files = changed_files if isinstance(changed_files, (list, tuple)) else []
+    hits: list[str] = []
+    for f in files:
+        if isinstance(f, str) and any(fnmatch.fnmatch(f, p) for p in patterns):
+            hits.append(f)
+    return hits
+
+
 def failing_summary(checks: object, failing: list[str]) -> str:
     """A human- and fix-pass-readable summary of the failing checks, surfacing the
     model's quoted ``evidence_span`` per check.
@@ -176,5 +195,6 @@ __all__ = [
     "VALID_STATUS",
     "compute_verdict",
     "failing_summary",
+    "sensitive_paths_in_diff",
     "verdict_schema_prompt",
 ]

--- a/src/operations_center/policy/defaults.py
+++ b/src/operations_center/policy/defaults.py
@@ -101,6 +101,13 @@ _BLOCKED_PATHS = [
 ]
 
 
+def sensitive_path_patterns() -> list[str]:
+    """The blast-radius path globs (review-required + always-blocked) as a flat
+    list of fnmatch patterns. Single source of truth shared with the reviewer's
+    opt-in sensitive-path ack gate (pr_review_watcher) so the two never drift."""
+    return [rule.path_pattern for rule in (_SENSITIVE_PATHS + _BLOCKED_PATHS)]
+
+
 # ---------------------------------------------------------------------------
 # Default repo policy (catch-all)
 # ---------------------------------------------------------------------------

--- a/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
+++ b/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
@@ -15,8 +15,10 @@ from operations_center.entrypoints.pr_review_watcher.verdict import (
     LGTM,
     REVIEW_CHECKS,
     compute_verdict,
+    sensitive_paths_in_diff,
     verdict_schema_prompt,
 )
+from operations_center.policy.defaults import sensitive_path_patterns
 
 
 def _all_pass() -> list[dict]:
@@ -126,3 +128,31 @@ class TestFailingSummary:
 
     def test_malformed_checks_safe(self):
         assert "Failed checks" in failing_summary(None, ["x"])
+
+
+class TestSensitivePathsInDiff:
+    """The opt-in blast-radius gate's pure matcher (Gap 3). Model-free: it inspects
+    the real changed-file list, so injection cannot suppress a sensitive hit."""
+
+    def test_matches_blast_radius_paths(self):
+        patterns = sensitive_path_patterns()
+        files = [
+            "src/operations_center/foo.py",
+            ".github/workflows/ci.yml",
+            "db/migrations/0003_add.py",
+            "README.md",
+        ]
+        hits = sensitive_paths_in_diff(files, patterns)
+        assert ".github/workflows/ci.yml" in hits
+        assert "db/migrations/0003_add.py" in hits
+        assert "src/operations_center/foo.py" not in hits
+        assert "README.md" not in hits
+
+    def test_clean_diff_is_empty(self):
+        hits = sensitive_paths_in_diff(["src/a.py", "docs/b.md"], sensitive_path_patterns())
+        assert hits == []
+
+    def test_tolerates_non_list_and_non_str(self):
+        # A malformed file list must never crash the merge gate.
+        assert sensitive_paths_in_diff(None, ["*.env"]) == []
+        assert sensitive_paths_in_diff(["keep", 5, None], ["*"]) == ["keep"]

--- a/tests/unit/policy/test_defaults.py
+++ b/tests/unit/policy/test_defaults.py
@@ -11,7 +11,11 @@ Verifies that DEFAULT_REPO_POLICY and DEFAULT_POLICY_CONFIG are:
 
 from __future__ import annotations
 
-from operations_center.policy.defaults import DEFAULT_POLICY_CONFIG, DEFAULT_REPO_POLICY
+from operations_center.policy.defaults import (
+    DEFAULT_POLICY_CONFIG,
+    DEFAULT_REPO_POLICY,
+    sensitive_path_patterns,
+)
 from operations_center.policy.validate import validate_config
 
 
@@ -152,3 +156,18 @@ class TestDefaultPolicyConfig:
     def test_get_repo_policy_returns_wildcard_for_unknown_repo(self):
         result = DEFAULT_POLICY_CONFIG.get_repo_policy("some-unknown-repo")
         assert result is not None
+
+
+class TestSensitivePathPatterns:
+    """The flat blast-radius glob list shared with the reviewer's opt-in
+    sensitive-path ack gate (single source of truth)."""
+
+    def test_includes_blast_radius_and_blocked_globs(self):
+        patterns = sensitive_path_patterns()
+        assert ".github/workflows/**" in patterns
+        assert "**/migrations/**" in patterns
+        assert "**/.ssh/**" in patterns  # blocked paths included too
+        assert "**/.gnupg/**" in patterns
+
+    def test_all_patterns_are_nonempty_strings(self):
+        assert all(isinstance(p, str) and p for p in sensitive_path_patterns())

--- a/tests/unit/test_capability_ownership.py
+++ b/tests/unit/test_capability_ownership.py
@@ -9,6 +9,7 @@ real behavior.
 
 from __future__ import annotations
 
+import types
 from dataclasses import dataclass
 
 import pytest
@@ -113,8 +114,34 @@ def test_owner_match_proceeds():
     )
 
 
-def test_load_returns_none_in_this_environment():
-    # OC's pinned repograph wheel has no capabilities plane → None (dormant).
-    from operations_center.capability_ownership import load_capability_registry
+def test_load_activates_when_loader_present(monkeypatch):
+    # Activation contract: if an importable module exposes load_capability_registry,
+    # the guard USES it and leaves dormancy — guards against the rot where the probe
+    # can never see the plane (asserting a degenerate "None forever" would mask that).
+    from operations_center import capability_ownership
 
-    assert load_capability_registry() is None
+    sentinel = object()
+    fake = types.SimpleNamespace(load_capability_registry=lambda: sentinel)
+    monkeypatch.setattr("importlib.import_module", lambda name: fake)
+    assert capability_ownership.load_capability_registry() is sentinel
+
+
+def test_load_dormant_when_loader_absent(monkeypatch):
+    # The other half of the contract: an importable module WITHOUT the loader symbol
+    # degrades to None (dormant) — which is the real state in OC's env today.
+    from operations_center import capability_ownership
+
+    fake = types.SimpleNamespace()  # no load_capability_registry attribute
+    monkeypatch.setattr("importlib.import_module", lambda name: fake)
+    assert capability_ownership.load_capability_registry() is None
+
+
+def test_load_dormant_when_module_absent(monkeypatch):
+    # repograph not importable at all → None (never raises into the caller).
+    from operations_center import capability_ownership
+
+    def _raise(name):
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr("importlib.import_module", _raise)
+    assert capability_ownership.load_capability_registry() is None


### PR DESCRIPTION
Finishes the 4 Osprey/Praetorian open-gap specs (adversarially specced, then resolved per their dispositions). All changes are **opt-in / additive — no live fleet behavior change**, no restart needed.

## The four gaps
- **Gap 2 (visualization):** WON'T-BUILD UI; wired the trust-tree CLI in via an `operations-center.sh lineage` verb + `operations-center-lineage` console script (discoverability fix).
- **Gap 3 (risk-tier):** WON'T-BUILD ladder; shipped an **opt-in, default-OFF** sensitive-path ack merge gate (ReviewerSettings.require_sensitive_path_ack + _sensitive_path_ack_ok; single-source sensitive_path_patterns in policy/defaults; pure sensitive_paths_in_diff in verdict; unit tests).
- **Gap 4 (capability):** DEFER (dormant is correct); replaced the rot-trap test with activation-contract tests + a probe-target note.
- **Gap 1 (timeout):** flipped to an operator decision — request.timeout_seconds (300) is honored by openclaw but overridden by dag's settings (3600); forcing consistency would regress live tasks. Shipped a de-silencing comment only.

All 4 specs moved open -> resolved.

## Plus: inert-machinery inventory
A background sweep found 12 more built-but-inert items, captured in docs/design/INERT_MACHINERY_INVENTORY.md. Headline (spot-verified): per-task allowed_paths write-scope is never enforced at the patch gate. Systemic theme: the live path drops most per-task ExecutionRequest constraints for env/settings. All wire-or-delete operator decisions; none acted on here.

236 unit tests green across touched areas; custodian-clean.

🤖 Generated with Claude Code