### PR TITLE
feat(execution): wire per-task allowed_paths + max_changed_files live (wire-all S1)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8417,3 +8417,14 @@ All wire-or-delete operator decisions; nothing bulk-acted.
 
 236 unit tests green across touched areas. Every new control is opt-in/additive — no live
 fleet behavior change.
+
+## 2026-06-24 — Wire-all S1: per-task allowed_paths + max_changed_files (live)
+
+First stage of wiring the inert per-task constraints (INERT_MACHINERY_INVENTORY.md
+items 1, 8). WorkspaceManager now ENFORCES request.allowed_paths at the pre-commit gate
+(fail-closed, reuses ChangedFilePolicyChecker) and honors request.max_changed_files in
+_diff_oversized (min with the global cap). Both fail-safe: empty allowed_paths / None
+max_changed_files = current behavior, so normal + self-modify tasks are unaffected; only
+spec-author (which sets allowed_paths=["docs/specs/"], max_changed_files=1) becomes
+scope-enforced — its intended guard. Live-behavior change → needs fleet restart.
+timeout_seconds (contract+adapters) and the validation pair are follow-up stages. 138 green.

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -347,7 +347,7 @@ class WorkspaceManager:
         # the executor going wide. Operators set OPS_CENTER_MAX_FILES /
         # OPS_CENTER_MAX_LINES higher when intentionally shipping a large
         # refactor; default is conservative.
-        oversized = self._diff_oversized(ws)
+        oversized = self._diff_oversized(ws, request)
         if oversized is not None:
             n_files, n_lines, file_list = oversized
             logger.warning(
@@ -501,6 +501,29 @@ class WorkspaceManager:
             if result.blocked_paths:
                 blocked_msg = f"\nBlocked paths: {', '.join(result.blocked_paths)}"
             return False, f"Patch validation failed: {result.reason}{blocked_msg}"
+        # Per-task write-scope allowlist — was inert (the static blocklist ran, but
+        # request.allowed_paths never reached the diff). Wired here, fail-CLOSED, but
+        # ONLY when the proposal set a non-empty allowlist: find_violations() fail-opens
+        # on an empty list, so normal/self-modify tasks (which set none) are unaffected.
+        if request.allowed_paths:
+            from operations_center.application.scope_policy import ChangedFilePolicyChecker
+
+            names = subprocess.run(
+                ["git", "diff", "--cached", "--name-only"],
+                cwd=ws,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout.splitlines()
+            changed = [n.strip() for n in names if n.strip()]
+            violations = ChangedFilePolicyChecker().find_violations(
+                changed, list(request.allowed_paths)
+            )
+            if violations:
+                return False, (
+                    f"Patch touches paths outside the task allowlist "
+                    f"{list(request.allowed_paths)}: {', '.join(violations)}"
+                )
         return True, None
 
     def _warn_cross_repo_impact(self, ws: Path, request: ExecutionRequest) -> None:
@@ -560,7 +583,9 @@ class WorkspaceManager:
 
     # ── helpers ──────────────────────────────────────────────────────────────
 
-    def _diff_oversized(self, ws: Path) -> tuple[int, int, list[str]] | None:
+    def _diff_oversized(
+        self, ws: Path, request: ExecutionRequest
+    ) -> tuple[int, int, list[str]] | None:
         """Return (files, lines, file_list) when the staged diff exceeds caps.
 
         Returns None when within bounds. file_list is sorted alphabetically
@@ -598,7 +623,12 @@ class WorkspaceManager:
 
         for m in re.finditer(r"(\d+)\s+(?:insertion|deletion)", proc.stdout):
             n_lines += int(m.group(1))
-        if n_files > self._max_files or n_lines > self._max_lines:
+        # Per-task max_changed_files (when the proposal set it) can only TIGHTEN the
+        # operator's global file cap, never loosen it. None (normal tasks) = global cap.
+        effective_max_files = self._max_files
+        if request.max_changed_files is not None:
+            effective_max_files = min(self._max_files, request.max_changed_files)
+        if n_files > effective_max_files or n_lines > self._max_lines:
             return n_files, n_lines, file_list
         return None
 

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -405,7 +405,7 @@ def test_diff_oversized_within_bounds(tmp_path):
         return _fake_completed(0)
 
     with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
-        assert mgr._diff_oversized(ws) is None
+        assert mgr._diff_oversized(ws, _make_request(ws)) is None
 
 
 def test_diff_oversized_exceeds_files(tmp_path):
@@ -421,7 +421,7 @@ def test_diff_oversized_exceeds_files(tmp_path):
         return _fake_completed(0)
 
     with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
-        out = mgr._diff_oversized(ws)
+        out = mgr._diff_oversized(ws, _make_request(ws))
     assert out is not None
     n_files, n_lines, file_list = out
     assert n_files == 3
@@ -443,7 +443,7 @@ def test_diff_oversized_exceeds_lines(tmp_path):
         return _fake_completed(0)
 
     with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
-        out = mgr._diff_oversized(ws)
+        out = mgr._diff_oversized(ws, _make_request(ws))
     assert out is not None
     assert out[1] == 14  # 10 + 4
 
@@ -459,7 +459,7 @@ def test_diff_oversized_calledprocesserror_returns_none(tmp_path):
         return _fake_completed(0)
 
     with mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run):
-        assert mgr._diff_oversized(ws) is None
+        assert mgr._diff_oversized(ws, _make_request(ws)) is None
 
 
 # ── _has_new_commits ─────────────────────────────────────────────────────────

--- a/tests/unit/execution/test_workspace_per_task_constraints.py
+++ b/tests/unit/execution/test_workspace_per_task_constraints.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Per-task ExecutionRequest constraints are now load-bearing (wire-all stage 1).
+
+`allowed_paths` (write-scope allowlist) and `max_changed_files` were populated on
+the request but ignored by the live commit gate. These exercise the wiring:
+honored when the proposal sets them, no-op (current behavior) when unset/empty.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from operations_center.contracts.execution import ExecutionRequest
+from operations_center.execution import workspace as ws_mod
+from operations_center.execution.workspace import WorkspaceManager
+
+
+def _make_request(ws: Path, **overrides) -> ExecutionRequest:
+    data = dict(
+        proposal_id="p",
+        decision_id="d",
+        goal_text="g",
+        repo_key="acme/widget",
+        clone_url="https://github.com/acme/widget.git",
+        base_branch="main",
+        task_branch="goal/x",
+        workspace_path=ws,
+    )
+    data.update(overrides)
+    return ExecutionRequest(**data)
+
+
+def _completed(stdout: str = ""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _git_ws(tmp_path) -> Path:
+    ws = tmp_path / "ws"
+    (ws / ".git").mkdir(parents=True)
+    return ws
+
+
+# ── max_changed_files ─────────────────────────────────────────────────────────
+
+
+def _oversized_run(name_only: str, shortstat: str):
+    def run(cmd, *a, **k):
+        if cmd[:4] == ["git", "diff", "--cached", "--shortstat"]:
+            return _completed(shortstat)
+        if cmd[:4] == ["git", "diff", "--cached", "--name-only"]:
+            return _completed(name_only)
+        return _completed()
+
+    return run
+
+
+def test_diff_oversized_honors_per_task_max_changed_files(tmp_path):
+    ws = _git_ws(tmp_path)
+    mgr = WorkspaceManager(max_files=50, max_lines=2000)  # generous global caps
+    run = _oversized_run("a.py\nb.py\nc.py\n", " 3 files changed, 4 insertions(+)")
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=run):
+        # per-task cap of 2 < 3 changed -> oversized despite the generous global cap
+        out = mgr._diff_oversized(ws, _make_request(ws, max_changed_files=2))
+        assert out is not None and out[0] == 3
+        # unset (None) -> rides the global cap -> not oversized (current behavior)
+        assert mgr._diff_oversized(ws, _make_request(ws)) is None
+
+
+def test_diff_oversized_per_task_cap_only_tightens(tmp_path):
+    ws = _git_ws(tmp_path)
+    mgr = WorkspaceManager(max_files=2, max_lines=2000)  # tight global cap
+    run = _oversized_run("a.py\nb.py\nc.py\n", " 3 files changed, 1 insertion(+)")
+    with mock.patch.object(ws_mod.subprocess, "run", side_effect=run):
+        # a per-task cap of 100 cannot LOOSEN the global cap of 2 -> still oversized
+        out = mgr._diff_oversized(ws, _make_request(ws, max_changed_files=100))
+        assert out is not None and out[0] == 3
+
+
+# ── allowed_paths ─────────────────────────────────────────────────────────────
+
+
+def _validate_run(diff_text: str, name_only: str):
+    def run(cmd, *a, **k):
+        if cmd[:4] == ["git", "diff", "--cached", "--name-only"]:
+            return _completed(name_only)
+        if cmd[:3] == ["git", "diff", "--cached"]:
+            return _completed(diff_text)
+        return _completed()
+
+    return run
+
+
+def _validate(mgr, ws, req, diff_text, name_only):
+    with (
+        mock.patch.object(
+            mgr._patch_applier,
+            "validate",
+            return_value=SimpleNamespace(success=True, blocked_paths=None, reason=None),
+        ),
+        mock.patch.object(
+            ws_mod.subprocess, "run", side_effect=_validate_run(diff_text, name_only)
+        ),
+    ):
+        return mgr._validate_patch_before_commit(ws, req)
+
+
+def test_validate_rejects_path_outside_allowlist(tmp_path):
+    ws = _git_ws(tmp_path)
+    mgr = WorkspaceManager()
+    ok, msg = _validate(
+        mgr,
+        ws,
+        _make_request(ws, allowed_paths=["docs/specs/"]),
+        "diff --git a/src/x.py b/src/x.py\n+code\n",
+        "src/x.py\n",
+    )
+    assert ok is False
+    assert "outside the task allowlist" in msg and "src/x.py" in msg
+
+
+def test_validate_allows_path_within_allowlist(tmp_path):
+    ws = _git_ws(tmp_path)
+    mgr = WorkspaceManager()
+    ok, msg = _validate(
+        mgr,
+        ws,
+        _make_request(ws, allowed_paths=["docs/specs/"]),
+        "diff --git a/docs/specs/y.md b/docs/specs/y.md\n+spec\n",
+        "docs/specs/y.md\n",
+    )
+    assert ok is True and msg is None
+
+
+def test_validate_empty_allowlist_skips_enforcement(tmp_path):
+    ws = _git_ws(tmp_path)
+    mgr = WorkspaceManager()
+    # allowed_paths defaults [] -> no restriction (current behavior preserved)
+    ok, msg = _validate(
+        mgr,
+        ws,
+        _make_request(ws),
+        "diff --git a/anything.py b/anything.py\n+x\n",
+        "anything.py\n",
+    )
+    assert ok is True and msg is None


### PR DESCRIPTION
Wire-all stage 1 — makes two previously-inert per-task ExecutionRequest constraints LOAD-BEARING (INERT_MACHINERY_INVENTORY items 1, 8).

## What
- **allowed_paths** — `WorkspaceManager._validate_patch_before_commit` now enforces the per-task write-scope allowlist (fail-CLOSED) by reusing the previously-dead `ChangedFilePolicyChecker`. A staged file outside the allowlist blocks the commit (no push).
- **max_changed_files** — `_diff_oversized` now honors the per-task cap (`min` with the global cap; can only tighten, never loosen).

## Fail-safe by construction
- `allowed_paths` empty -> `find_violations` fail-opens -> no restriction.
- `max_changed_files` None -> rides the global cap.
- So normal goal/improve tasks and the fleet's own self-modify tasks (which set neither) are UNAFFECTED. Only **spec-author** (sets `allowed_paths=["docs/specs/"]`, `max_changed_files=1`) becomes scope-enforced — its intended guard.

## Live-fleet note
Live-behavior change -> needs a fleet restart to take effect. After restart, a spec-author run that writes outside `docs/specs/` fails closed (POLICY_BLOCKED) instead of pushing (it is designed to write only `docs/specs/`).

138 unit tests green (new `test_workspace_per_task_constraints.py` + existing suite). Custodian clean.

🤖 Generated with Claude Code