### PR TITLE
feat(execution): wire per-task timeout + validation constraints (wire-all S1b+S1c)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8442,3 +8442,8 @@ Completes the per-task ExecutionRequest constraints (INERT_MACHINERY_INVENTORY i
   _run_baseline_validation now returns the summary.
 Defaults verified None. 275 touched-area tests green; full-suite failures are pre-existing on main (doc/fixture
 env tests, reproduce on f72c402a — CI excludes them via default addopts). Live-behavior change → fleet restart.
+
+## 2026-06-24 — S1b+S1c custodian fixes
+
+Renamed BaselineValidationFailed -> BaselineValidationError (ruff N818); added explicit asserts
+to the two require_clean "proceeds" tests (T2). No logic change. 66 workspace tests green.

--- a/.console/log.md
+++ b/.console/log.md
@@ -8428,3 +8428,17 @@ max_changed_files = current behavior, so normal + self-modify tasks are unaffect
 spec-author (which sets allowed_paths=["docs/specs/"], max_changed_files=1) becomes
 scope-enforced — its intended guard. Live-behavior change → needs fleet restart.
 timeout_seconds (contract+adapters) and the validation pair are follow-up stages. 138 green.
+
+## 2026-06-24 — Wire-all S1b+S1c: timeout + validation per-task constraints (live)
+
+Completes the per-task ExecutionRequest constraints (INERT_MACHINERY_INVENTORY item 6 + Gap-1 timeout).
+- timeout_seconds: Optional[int]=None across OcExecutionRequest/ExecutionConstraints/PlanningContext; the 5
+  backend adapters (dag, direct_local, aider_local, critique, openclaw) honor request.timeout_seconds when set,
+  else fall back to backend settings — no 300<3600 regression (live path injects explicit values).
+- validation_commands: WorkspaceManager._run_baseline_validation prefers request.validation_commands when set
+  (shim over repo_cfg), else the current repo-config path (zero live callers set it today).
+- require_clean_validation: Optional[bool]=None; baseline FAILED/ERROR aborts prepare() ONLY when the request
+  explicitly opted in (is True). None (every live task) = current behavior — fail-safe on the self-modifying fleet.
+  _run_baseline_validation now returns the summary.
+Defaults verified None. 275 touched-area tests green; full-suite failures are pre-existing on main (doc/fixture
+env tests, reproduce on f72c402a — CI excludes them via default addopts). Live-behavior change → fleet restart.

--- a/src/operations_center/backends/aider_local/adapter.py
+++ b/src/operations_center/backends/aider_local/adapter.py
@@ -72,7 +72,11 @@ class AiderLocalBackendAdapter:
 
         try:
             command = self._build_command(message_file)
-            run_result = self._run(command=command, repo_path=repo_path)
+            run_result = self._run(
+                command=command,
+                repo_path=repo_path,
+                timeout_seconds=request.timeout_seconds,
+            )
         finally:
             try:
                 os.unlink(message_file)
@@ -139,13 +143,29 @@ class AiderLocalBackendAdapter:
         command += self._settings.extra_args
         return command
 
-    def _run(self, *, command: list[str], repo_path: Path) -> "_AiderLocalRunResult":
+    def _run(
+        self,
+        *,
+        command: list[str],
+        repo_path: Path,
+        timeout_seconds: int | None = None,
+    ) -> "_AiderLocalRunResult":
         env = os.environ.copy()
         # Ollama does not use OPENAI_API_KEY; set a dummy to avoid aider warnings
         if not env.get("OPENAI_API_KEY"):
             env["OPENAI_API_KEY"] = "sk-local-ollama"
 
         artifact_dir = tempfile.mkdtemp(prefix="aider-local-")
+
+        # S1b: an explicit per-task timeout (resolved by execute()) wins; when
+        # None, fall back to the backend settings timeout (treating <=0 as None).
+        effective_timeout = timeout_seconds
+        if effective_timeout is None:
+            effective_timeout = (
+                self._settings.timeout_seconds
+                if self._settings.timeout_seconds and self._settings.timeout_seconds > 0
+                else None
+            )
 
         invocation = RuntimeInvocation(
             invocation_id=_short_id(),
@@ -154,9 +174,7 @@ class AiderLocalBackendAdapter:
             working_directory=str(repo_path),
             command=list(command),
             environment=dict(env),
-            timeout_seconds=self._settings.timeout_seconds
-            if self._settings.timeout_seconds and self._settings.timeout_seconds > 0
-            else None,
+            timeout_seconds=effective_timeout,
             artifact_directory=artifact_dir,
         )
 

--- a/src/operations_center/backends/critique_executor/adapter.py
+++ b/src/operations_center/backends/critique_executor/adapter.py
@@ -85,7 +85,13 @@ class CritiqueExecutorBackendAdapter:
             critic_backend_efforts={"codex_cli": profile["codex_cli"]["effort"]},
             max_rounds=self._settings.max_rounds,
             working_dir=working_dir,
-            timeout_seconds=self._settings.timeout_seconds,
+            # S1b: per-task request.timeout_seconds wins; else backend settings.
+            # request defaults to None (no override) so live tasks are unchanged.
+            timeout_seconds=(
+                request.timeout_seconds
+                if request.timeout_seconds is not None
+                else (self._settings.timeout_seconds or None)
+            ),
             worker_backend=self._settings.worker_backend,
         )
 

--- a/src/operations_center/backends/dag_executor/adapter.py
+++ b/src/operations_center/backends/dag_executor/adapter.py
@@ -94,13 +94,16 @@ class DAGExecutorBackendAdapter:
             runner = DAGExecutorRunner(
                 artifacts_dir=artifacts_dir,
                 working_directory=str(workspace),
-                # Timeout authority is an OPEN operator decision (CONTEXT_DISCIPLINE.md):
-                # we use the backend SETTINGS timeout, not request.timeout_seconds —
-                # the latter defaults to 300s from proposal.constraints and would cut
-                # tasks below the operator-configured value. The openclaw adapter honors
-                # the request instead, so backends disagree on which is authoritative;
-                # aligning them changes live task runtimes, so it is not a silent fix.
-                timeout_seconds=self._settings.timeout_seconds or None,
+                # Timeout authority (resolved, S1b): an explicit per-task
+                # request.timeout_seconds wins; otherwise fall back to the
+                # operator-configured backend settings timeout. request defaults
+                # to None now (no per-task override), so live tasks that omit it
+                # keep using the settings timeout — no 3600->300 regression.
+                timeout_seconds=(
+                    request.timeout_seconds
+                    if request.timeout_seconds is not None
+                    else (self._settings.timeout_seconds or None)
+                ),
                 worker_backend=worker_backend,
             )
             if workflow_path.exists():

--- a/src/operations_center/backends/direct_local/adapter.py
+++ b/src/operations_center/backends/direct_local/adapter.py
@@ -60,7 +60,12 @@ class DirectLocalBackendAdapter:
             goal=request.goal_text,
             constraints=request.constraints_text or "",
         )
-        result = self._run(command=command, repo_path=repo_path, env=env)
+        result = self._run(
+            command=command,
+            repo_path=repo_path,
+            env=env,
+            timeout_seconds=request.timeout_seconds,
+        )
 
         # G-V04 — guard against false success when the upstream backend
         # printed a capacity-exhaustion notice and exited 0.
@@ -140,11 +145,26 @@ class DirectLocalBackendAdapter:
         return command, env
 
     def _run(
-        self, *, command: list[str], repo_path: Path, env: dict[str, str]
+        self,
+        *,
+        command: list[str],
+        repo_path: Path,
+        env: dict[str, str],
+        timeout_seconds: int | None = None,
     ) -> "_DirectLocalRunResult":
         # Per-call artifact dir so ER's stdout/stderr capture doesn't
         # pollute the workspace.
         artifact_dir = tempfile.mkdtemp(prefix="direct-local-")
+
+        # S1b: an explicit per-task timeout (resolved by execute()) wins; when
+        # None, fall back to the backend settings timeout (treating <=0 as None).
+        effective_timeout = timeout_seconds
+        if effective_timeout is None:
+            effective_timeout = (
+                self._settings.timeout_seconds
+                if self._settings.timeout_seconds and self._settings.timeout_seconds > 0
+                else None
+            )
 
         invocation = RuntimeInvocation(
             invocation_id=_short_id(),
@@ -153,9 +173,7 @@ class DirectLocalBackendAdapter:
             working_directory=str(repo_path),
             command=list(command),
             environment=dict(env),
-            timeout_seconds=self._settings.timeout_seconds
-            if self._settings.timeout_seconds and self._settings.timeout_seconds > 0
-            else None,
+            timeout_seconds=effective_timeout,
             artifact_directory=artifact_dir,
         )
 

--- a/src/operations_center/backends/openclaw/mapper.py
+++ b/src/operations_center/backends/openclaw/mapper.py
@@ -94,7 +94,12 @@ def map_request(
         repo_path=Path(request.workspace_path),
         task_branch=request.task_branch,
         run_mode=resolved_mode,
-        timeout_seconds=request.timeout_seconds,
+        # S1b: an explicit per-task timeout wins; else fall back to the
+        # OpenClawPreparedRun default (300s). OpenClawPreparedRun.timeout_seconds
+        # is a non-optional int, so a None request must not pass through.
+        timeout_seconds=(
+            request.timeout_seconds if request.timeout_seconds is not None else 300
+        ),
         validation_commands=list(request.validation_commands),
         metadata=metadata,
     )

--- a/src/operations_center/contracts/common.py
+++ b/src/operations_center/contracts/common.py
@@ -39,18 +39,24 @@ class ExecutionConstraints(BaseModel):
         default=None,
         description="Execution is aborted if more files than this are changed. None = unlimited.",
     )
-    timeout_seconds: int = Field(
-        default=300,
+    timeout_seconds: Optional[int] = Field(
+        default=None,
         ge=1,
-        description="Wall-clock timeout for the full execution run.",
+        description=(
+            "Wall-clock timeout for the full execution run. None = no per-task "
+            "override; the backend's settings timeout applies."
+        ),
     )
     allowed_paths: list[str] = Field(
         default_factory=list,
         description="Subset of TaskTarget.allowed_paths applied at execution time.",
     )
-    require_clean_validation: bool = Field(
-        default=True,
-        description="If True, execution fails unless all validation commands pass.",
+    require_clean_validation: Optional[bool] = Field(
+        default=None,
+        description=(
+            "If True, execution fails unless baseline validation passes. None = "
+            "no per-task validation gate (baseline failure does not block the run)."
+        ),
     )
     skip_baseline_validation: bool = Field(
         default=False,

--- a/src/operations_center/contracts/execution.py
+++ b/src/operations_center/contracts/execution.py
@@ -73,8 +73,14 @@ class OcExecutionRequest(BaseModel):
     # Constraints (from proposal, propagated)
     allowed_paths: list[str] = Field(default_factory=list)
     max_changed_files: Optional[int] = None
-    timeout_seconds: int = Field(default=300, ge=1)
-    require_clean_validation: bool = True
+    # None = "no per-task override" — adapters fall back to their backend
+    # settings timeout (the live dispatch path injects 3600 explicitly). Only
+    # an explicit, request-level value (ge=1) overrides the backend setting.
+    timeout_seconds: Optional[int] = Field(default=None, ge=1)
+    # None = "no per-task validation gate" — every live task today leaves this
+    # unset, so baseline-validation FAILURE never blocks the run. Only an
+    # explicit True opts a task into the fail-closed baseline gate.
+    require_clean_validation: Optional[bool] = None
     validation_commands: list[str] = Field(default_factory=list)
 
     # Recovery loop signal — see execution/recovery_loop/. Defaults to False

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -36,7 +36,7 @@ from operations_center.contracts.execution import ExecutionRequest, ExecutionRes
 logger = logging.getLogger(__name__)
 
 
-class BaselineValidationFailed(RuntimeError):
+class BaselineValidationError(RuntimeError):
     """Raised from ``WorkspaceManager.prepare`` when baseline validation fails
     and the request opted in via ``require_clean_validation is True``.
 
@@ -319,7 +319,7 @@ class WorkspaceManager:
             and baseline_summary.status
             in (ValidationStatus.FAILED, ValidationStatus.ERROR)
         ):
-            raise BaselineValidationFailed(
+            raise BaselineValidationError(
                 "baseline validation did not pass and require_clean_validation "
                 f"is set: status={baseline_summary.status.value}"
                 + (

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -30,10 +30,20 @@ from pathlib import Path
 
 from operations_center.adapters.git.client import GitClient
 from operations_center.adapters.workspace.patch_applier import PatchApplier
-from operations_center.contracts.enums import FailureReasonCategory
+from operations_center.contracts.enums import FailureReasonCategory, ValidationStatus
 from operations_center.contracts.execution import ExecutionRequest, ExecutionResult
 
 logger = logging.getLogger(__name__)
+
+
+class BaselineValidationFailed(RuntimeError):
+    """Raised from ``WorkspaceManager.prepare`` when baseline validation fails
+    and the request opted in via ``require_clean_validation is True``.
+
+    A ``RuntimeError`` subclass so the coordinator's existing broad
+    prepare-failure handler catches it and produces a clean FAILED
+    ExecutionResult — no new handler wiring required.
+    """
 
 
 # Branch prefixes whose runs should NOT be pushed or PR'd. Improve mode is
@@ -293,12 +303,31 @@ class WorkspaceManager:
         # config (no bootstrap fields set) is a no-op so existing repos
         # see no behavior change.
         self._maybe_bootstrap(ws, request)
-        # Baseline validation — if the repo declares validation_commands and
-        # hasn't opted out via skip_baseline_validation, run them here.
-        # Failure leaves a marker file the coordinator reads (so we don't
-        # mutate the prepare() return shape). The actual abort decision
-        # happens in the coordinator path.
-        self._run_baseline_validation(ws, request)
+        # Baseline validation — if the repo (or the per-task request) declares
+        # validation_commands and hasn't opted out via skip_baseline_validation,
+        # run them here. The summary is also persisted to a marker file.
+        #
+        # S1c gate: a FAILED/ERROR baseline blocks the run ONLY when the request
+        # explicitly opted in via require_clean_validation is True. None (every
+        # live task today) preserves the prior behavior — baseline failure does
+        # not abort. We raise so the coordinator's existing prepare-failure
+        # handler turns it into a clean FAILED ExecutionResult.
+        baseline_summary = self._run_baseline_validation(ws, request)
+        if (
+            request.require_clean_validation is True
+            and baseline_summary is not None
+            and baseline_summary.status
+            in (ValidationStatus.FAILED, ValidationStatus.ERROR)
+        ):
+            raise BaselineValidationFailed(
+                "baseline validation did not pass and require_clean_validation "
+                f"is set: status={baseline_summary.status.value}"
+                + (
+                    f"; {baseline_summary.failure_excerpt}"
+                    if baseline_summary.failure_excerpt
+                    else ""
+                )
+            )
         # Restore .baseline-validation.json to HEAD so create_task_branch can
         # checkout origin/task_branch without "local changes would be overwritten".
         # The file has slipped into several goal-branch commits; baseline validation
@@ -704,30 +733,58 @@ class WorkspaceManager:
             logger.warning("WorkspaceManager: PR creation failed — %s", exc)
             return None
 
-    def _run_baseline_validation(self, ws: Path, request: ExecutionRequest) -> None:
+    def _run_baseline_validation(self, ws: Path, request: ExecutionRequest):
         """Run repo's baseline validation; persist the summary to a marker file.
 
-        We write the result to ``ws/.baseline-validation.json`` so the
-        coordinator (or a later stage) can read it without WorkspaceManager
-        having to thread the contract through. Best-effort — failures here
-        log a warning but don't abort prepare(). The decision to continue
-        on FAILED status is made downstream.
+        We write the result to ``ws/.baseline-validation.json`` so a later stage
+        can read it without WorkspaceManager having to thread the contract
+        through. Best-effort — failures here log a warning but don't abort.
+
+        Returns the ``ValidationSummary`` (or None when there is no repo_cfg /
+        the run crashed) so the caller can apply the per-task
+        ``require_clean_validation`` gate (S1c). The abort decision itself is
+        made in ``prepare()``, not here.
+
+        Command source (S1c): when ``request.validation_commands`` is non-empty,
+        those per-task commands run *instead of* the repo's configured
+        ``validation_commands`` — wrapped in a small shim that still carries the
+        repo's ``validation_timeout_seconds`` and ``skip_baseline_validation``
+        so ``run_baseline_validation`` reads a complete cfg. Empty (every live
+        task today) leaves the repo_cfg path unchanged.
         """
         repo_cfg = self._repo_lookup(request.repo_key)
         if repo_cfg is None:
-            return
+            return None
+
+        # Per-task command override: only when the request explicitly set
+        # validation_commands. The shim mirrors exactly the three attributes
+        # baseline_validation.run_baseline_validation reads off repo_cfg.
+        cfg_for_validation = repo_cfg
+        if request.validation_commands:
+            from types import SimpleNamespace
+
+            cfg_for_validation = SimpleNamespace(
+                validation_commands=list(request.validation_commands),
+                validation_timeout_seconds=getattr(
+                    repo_cfg, "validation_timeout_seconds", 300
+                ),
+                skip_baseline_validation=getattr(
+                    repo_cfg, "skip_baseline_validation", False
+                ),
+            )
+
         try:
             from operations_center.execution.baseline_validation import (
                 run_baseline_validation,
             )
 
-            summary = run_baseline_validation(ws, repo_cfg=repo_cfg)
+            summary = run_baseline_validation(ws, repo_cfg=cfg_for_validation)
         except Exception as exc:
             logger.warning(
                 "WorkspaceManager.prepare: baseline validation crashed — %s",
                 exc,
             )
-            return
+            return None
         try:
             (ws / ".baseline-validation.json").write_text(
                 summary.model_dump_json(),
@@ -735,6 +792,7 @@ class WorkspaceManager:
             )
         except OSError as exc:
             logger.debug("baseline-validation marker write failed — %s", exc)
+        return summary
 
     def _maybe_bootstrap(self, ws: Path, request: ExecutionRequest) -> None:
         """Run repo-bootstrap (venv setup + dev install) when configured.

--- a/src/operations_center/planning/models.py
+++ b/src/operations_center/planning/models.py
@@ -47,12 +47,14 @@ class PlanningContext:
     risk_level: str = "low"  # low / medium / high
     priority: str = "normal"  # low / normal / high / critical
     max_changed_files: Optional[int] = None
-    timeout_seconds: int = 300
+    # None = no per-task timeout override; the backend's settings timeout applies.
+    timeout_seconds: Optional[int] = None
 
     # Validation
     validation_profile_name: str = "default"
     validation_commands: list[str] = field(default_factory=list)
-    require_clean_validation: bool = True
+    # None = no per-task validation gate (baseline failure does not block).
+    require_clean_validation: Optional[bool] = None
 
     # Tracing
     task_id: str = ""

--- a/tests/unit/backends/dag_executor/test_adapter_cov.py
+++ b/tests/unit/backends/dag_executor/test_adapter_cov.py
@@ -415,6 +415,55 @@ def test_runner_artifacts_and_timeout_falsy_become_none(monkeypatch, tmp_path):
     assert seen["timeout_seconds"] is None
 
 
+def test_explicit_request_timeout_overrides_settings(monkeypatch, tmp_path):
+    """S1b: an explicit per-task request.timeout_seconds wins over settings."""
+    seen = {}
+
+    class _Runner:
+        def __init__(self, **kw):
+            seen.update(kw)
+
+        def run_graph(self, spec):
+            return {"status": "succeeded"}
+
+    _install_fake_dag_executor(monkeypatch, runner_cls=_Runner)
+    execution = _execution(selected_backend="claude_code", payload={"status": "succeeded"})
+    _stub_selectors(monkeypatch, execution=execution, invoke_run=True)
+
+    # Backend settings say 3600, but the request explicitly asks for 120.
+    settings = DAGExecutorSettings(artifacts_dir="/art", timeout_seconds=3600)
+    adapter = DAGExecutorBackendAdapter(settings)
+    req = _request(workspace=tmp_path).model_copy(update={"timeout_seconds": 120})
+    adapter.execute_and_capture(req)
+
+    assert seen["timeout_seconds"] == 120
+
+
+def test_none_request_timeout_falls_back_to_settings_no_300_regression(monkeypatch, tmp_path):
+    """S1b regression guard: a request with timeout_seconds=None must fall back
+    to the backend settings timeout (3600), NOT to the old 300 default."""
+    seen = {}
+
+    class _Runner:
+        def __init__(self, **kw):
+            seen.update(kw)
+
+        def run_graph(self, spec):
+            return {"status": "succeeded"}
+
+    _install_fake_dag_executor(monkeypatch, runner_cls=_Runner)
+    execution = _execution(selected_backend="claude_code", payload={"status": "succeeded"})
+    _stub_selectors(monkeypatch, execution=execution, invoke_run=True)
+
+    settings = DAGExecutorSettings(artifacts_dir="/art", timeout_seconds=3600)
+    adapter = DAGExecutorBackendAdapter(settings)
+    req = _request(workspace=tmp_path)  # timeout_seconds defaults to None now
+    assert req.timeout_seconds is None
+    adapter.execute_and_capture(req)
+
+    assert seen["timeout_seconds"] == 3600
+
+
 # --------------------------------------------------------------------------
 # execute_and_capture: error / unavailable / fallback branches
 # --------------------------------------------------------------------------

--- a/tests/unit/contracts/test_common.py
+++ b/tests/unit/contracts/test_common.py
@@ -51,8 +51,9 @@ class TestExecutionConstraints:
     def test_defaults(self):
         c = ExecutionConstraints()
         assert c.max_changed_files is None
-        assert c.timeout_seconds == 300
-        assert c.require_clean_validation is True
+        # S1b/S1c: default to None (no per-task override).
+        assert c.timeout_seconds is None
+        assert c.require_clean_validation is None
         assert c.skip_baseline_validation is False
 
     def test_custom_timeout(self):

--- a/tests/unit/contracts/test_execution.py
+++ b/tests/unit/contracts/test_execution.py
@@ -81,8 +81,10 @@ class TestExecutionRequest:
         r = _minimal_request()
         assert r.allowed_paths == []
         assert r.max_changed_files is None
-        assert r.timeout_seconds == 300
-        assert r.require_clean_validation is True
+        # S1b/S1c: both default to None ("no per-task override") so live tasks
+        # that omit them fall back to backend settings / current behavior.
+        assert r.timeout_seconds is None
+        assert r.require_clean_validation is None
         assert r.validation_commands == []
         assert r.goal_file_path is None
         assert r.constraints_text is None

--- a/tests/unit/contracts/test_proposal.py
+++ b/tests/unit/contracts/test_proposal.py
@@ -58,7 +58,9 @@ class TestTaskProposalConstruction:
         p = _minimal_proposal()
         assert p.priority == Priority.NORMAL
         assert p.risk_level == RiskLevel.LOW
-        assert p.constraints.timeout_seconds == 300
+        # S1b: ExecutionConstraints.timeout_seconds now defaults to None
+        # (no per-task override; backend settings timeout applies).
+        assert p.constraints.timeout_seconds is None
         assert p.branch_policy.push_on_success is True
         assert p.labels == []
         assert p.proposer is None

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -663,6 +663,142 @@ def test_baseline_validation_marker_write_oserror_is_nonfatal(tmp_path):
     assert not (ws / ".baseline-validation.json").exists()
 
 
+# ── S1c: validation_commands per-task override ───────────────────────────────
+
+
+def _capture_baseline_cfg(monkeypatch_modules):
+    """Return (fake_module, captured) where captured['cfg'] holds the repo_cfg
+    passed to run_baseline_validation on the next call."""
+    captured: dict = {}
+
+    def _fake_run(ws, *, repo_cfg):
+        captured["cfg"] = repo_cfg
+        summary = mock.Mock()
+        summary.model_dump_json.return_value = '{"status": "passed"}'
+        return summary
+
+    fake_module = SimpleNamespace(run_baseline_validation=_fake_run)
+    return fake_module, captured
+
+
+def test_request_validation_commands_preferred_over_repo_cfg(tmp_path):
+    """S1c: when the request sets validation_commands, those run instead of the
+    repo_cfg's — wrapped in a shim that still carries the repo's timeout/skip."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    repo_cfg = SimpleNamespace(
+        validation_commands=["repo-cmd"],
+        validation_timeout_seconds=900,
+        skip_baseline_validation=False,
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: repo_cfg)
+    req = _make_request(ws, validation_commands=["task-cmd-1", "task-cmd-2"])
+
+    fake_module, captured = _capture_baseline_cfg(None)
+    with mock.patch.dict(
+        "sys.modules",
+        {"operations_center.execution.baseline_validation": fake_module},
+    ):
+        mgr._run_baseline_validation(ws, req)
+
+    cfg = captured["cfg"]
+    # The per-task commands win …
+    assert list(cfg.validation_commands) == ["task-cmd-1", "task-cmd-2"]
+    # … and the shim still carries the repo's timeout + skip flag (complete cfg).
+    assert cfg.validation_timeout_seconds == 900
+    assert cfg.skip_baseline_validation is False
+
+
+def test_empty_request_validation_commands_uses_repo_cfg(tmp_path):
+    """S1c: an empty request validation_commands (every live task) leaves the
+    repo_cfg path unchanged — the repo_cfg object itself is passed through."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    repo_cfg = SimpleNamespace(
+        validation_commands=["repo-cmd"],
+        validation_timeout_seconds=300,
+        skip_baseline_validation=False,
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: repo_cfg)
+    req = _make_request(ws)  # validation_commands defaults to []
+
+    fake_module, captured = _capture_baseline_cfg(None)
+    with mock.patch.dict(
+        "sys.modules",
+        {"operations_center.execution.baseline_validation": fake_module},
+    ):
+        mgr._run_baseline_validation(ws, req)
+
+    # The exact repo_cfg object is passed unchanged (not the shim).
+    assert captured["cfg"] is repo_cfg
+
+
+# ── S1c: require_clean_validation gate (the risky one) ───────────────────────
+
+
+def _prepare_with_baseline(mgr, req, *, summary):
+    """Drive prepare() with git/subprocess mocked, forcing _run_baseline_validation
+    to return *summary*. Returns nothing; raises if the gate fires."""
+    with (
+        mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)),
+        mock.patch.object(mgr, "_maybe_bootstrap"),
+        mock.patch.object(mgr, "_run_baseline_validation", return_value=summary),
+    ):
+        mgr.prepare(req)
+
+
+def _summary(status: ValidationStatus):
+    from operations_center.contracts.common import ValidationSummary
+
+    return ValidationSummary(status=status)
+
+
+def test_require_clean_none_does_not_block_on_failed_baseline(tmp_path):
+    """S1c behavior-preserving core: require_clean_validation=None (every live
+    task today) must NOT abort even when baseline validation FAILED."""
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws)  # require_clean_validation defaults to None
+    assert req.require_clean_validation is None
+    # No raise — a FAILED baseline is tolerated when the task didn't opt in.
+    _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.FAILED))
+
+
+def test_require_clean_true_blocks_on_failed_baseline(tmp_path):
+    """S1c opt-in: require_clean_validation=True + FAILED baseline aborts prepare."""
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws, require_clean_validation=True)
+    with pytest.raises(ws_mod.BaselineValidationFailed, match="did not pass"):
+        _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.FAILED))
+
+
+def test_require_clean_true_blocks_on_error_baseline(tmp_path):
+    """S1c: ERROR (e.g. baseline command timeout) also blocks when opted in."""
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws, require_clean_validation=True)
+    with pytest.raises(ws_mod.BaselineValidationFailed):
+        _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.ERROR))
+
+
+def test_require_clean_true_proceeds_on_passed_baseline(tmp_path):
+    """S1c: require_clean_validation=True + PASSED baseline proceeds (no raise)."""
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws, require_clean_validation=True)
+    _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.PASSED))
+
+
+def test_require_clean_true_proceeds_when_no_summary(tmp_path):
+    """S1c: when baseline produced no summary (no repo_cfg / crash) the gate is a
+    no-op even if opted in — there's nothing to gate on."""
+    ws = tmp_path / "ws"
+    mgr = WorkspaceManager(git_client=_git_for_prepare())
+    req = _make_request(ws, require_clean_validation=True)
+    _prepare_with_baseline(mgr, req, summary=None)
+
+
 # ── _maybe_bootstrap ─────────────────────────────────────────────────────────
 
 

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -738,13 +738,15 @@ def test_empty_request_validation_commands_uses_repo_cfg(tmp_path):
 
 def _prepare_with_baseline(mgr, req, *, summary):
     """Drive prepare() with git/subprocess mocked, forcing _run_baseline_validation
-    to return *summary*. Returns nothing; raises if the gate fires."""
+    to return *summary*. Returns True when prepare completes (the gate did not
+    fire); raises if it fires."""
     with (
         mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)),
         mock.patch.object(mgr, "_maybe_bootstrap"),
         mock.patch.object(mgr, "_run_baseline_validation", return_value=summary),
     ):
         mgr.prepare(req)
+    return True
 
 
 def _summary(status: ValidationStatus):
@@ -769,7 +771,7 @@ def test_require_clean_true_blocks_on_failed_baseline(tmp_path):
     ws = tmp_path / "ws"
     mgr = WorkspaceManager(git_client=_git_for_prepare())
     req = _make_request(ws, require_clean_validation=True)
-    with pytest.raises(ws_mod.BaselineValidationFailed, match="did not pass"):
+    with pytest.raises(ws_mod.BaselineValidationError, match="did not pass"):
         _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.FAILED))
 
 
@@ -778,7 +780,7 @@ def test_require_clean_true_blocks_on_error_baseline(tmp_path):
     ws = tmp_path / "ws"
     mgr = WorkspaceManager(git_client=_git_for_prepare())
     req = _make_request(ws, require_clean_validation=True)
-    with pytest.raises(ws_mod.BaselineValidationFailed):
+    with pytest.raises(ws_mod.BaselineValidationError):
         _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.ERROR))
 
 
@@ -787,7 +789,7 @@ def test_require_clean_true_proceeds_on_passed_baseline(tmp_path):
     ws = tmp_path / "ws"
     mgr = WorkspaceManager(git_client=_git_for_prepare())
     req = _make_request(ws, require_clean_validation=True)
-    _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.PASSED))
+    assert _prepare_with_baseline(mgr, req, summary=_summary(ValidationStatus.PASSED)) is True
 
 
 def test_require_clean_true_proceeds_when_no_summary(tmp_path):
@@ -796,7 +798,7 @@ def test_require_clean_true_proceeds_when_no_summary(tmp_path):
     ws = tmp_path / "ws"
     mgr = WorkspaceManager(git_client=_git_for_prepare())
     req = _make_request(ws, require_clean_validation=True)
-    _prepare_with_baseline(mgr, req, summary=None)
+    assert _prepare_with_baseline(mgr, req, summary=None) is True
 
 
 # ── _maybe_bootstrap ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Wire-all S1b+S1c: timeout_seconds + require_clean_validation -> Optional[None] (fail-safe); 5 adapters fall back to settings (no 3600->300 regression); validation_commands honored when set; require_clean_validation aborts only on explicit True. **Behavior-neutral on the live fleet** (live path injects explicit timeouts; require_clean_validation None everywhere). INERT item 6 + Gap-1. 275 touched tests green; custodian clean.

🤖 Generated with Claude Code