### PR TITLE
feat(ci,capability): gate reviewer integration tests + harden capability-owner comparison

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8460,3 +8460,20 @@ tests green; the 11 integration/reviewer failures pre-exist on origin/main (veri
 
 ## 2026-06-24 — C29 trim
 Compacted the dispatch.py priority comment to a 1-line inline note (503 -> 499 lines, under the C29 limit).
+
+## 2026-06-24 — Reviewer integration tests in CI + capability-owner naming fix (the 2 open threads)
+
+Thread 2 (DONE): the 11 tests/integration/reviewer failures were ONE drifted fixture — tests/verdicts/conftest.py
+mock_settings() left require_branch_protection/require_sensitive_path_ack unset, so the bare MagicMock auto-created
+them truthy and flipped the #388 self-merge gate ON in tests -> merge refused. Fixed the fixture (set them False,
+mirroring REVIEWER_CFG + prod defaults); added a reviewer-integration CI job so the hermetic suite is gated and
+can't drift again. 101 pass.
+
+Thread 1 (dangerous halt-blocker REMOVED; full activation still cross-repo): verify_owner_or_degrade compared
+owner != expected_owner by exact string — but the registry owns board_unblock as `operations_center` (RepoGraph
+repo_id) while OC passes self_repo_key `OperationsCenter`, so enabling require_capability_owner would REFUSE ->
+halt board_unblock every cycle. Added _norm_owner (lowercase + strip non-alphanumerics) so the same repo matches
+across conventions without over-matching different repos -> the gate is now SAFE to enable. Full activation still
+needs (cross-repo, recorded): a plane-bearing repograph release (OC's transitive repograph@v0.2.0 is planeless) +
+PM topology compat (the plane-bearing PM commit dropped legacy_names, breaking OC impact-analysis). Behavior-neutral
+on the live fleet (capability path dormant; CI/test-only otherwise) -> no urgent deploy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,34 @@ jobs:
         # collection-count assertions.
         run: pytest -q tests/test_pr_review_watcher.py -p no:flaky-detection
 
+  reviewer-integration:
+    name: Reviewer integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Run reviewer integration tests
+        # tests/integration/reviewer exercises the verdict-consolidation +
+        # merge-decision state machine (happy path, CI-green gate, verdict
+        # override, timeout recovery, safety paths, instrumentation) end-to-end
+        # through pr_review_watcher._phase1. Despite living under tests/integration/,
+        # these are HERMETIC: the GitHub and Plane clients are fully mocked
+        # (tests/verdicts/conftest.py), so there are NO live services and NO
+        # network — they run in <1s. The blanket "integration/ needs live services,
+        # run on demand" policy that excludes the rest of tests/integration/ from CI
+        # let this suite DRIFT against the evolving self-merge gates (e.g. the
+        # require_branch_protection fail-closed gate added in #388). This dedicated
+        # job runs them on every PR so they cannot rot again.
+        # -p no:flaky-detection — see the "Test (pytest)" job (plugin is opt-in;
+        # its pytest11 entry point imports the observer package before coverage
+        # instrumentation). Isolated from tests/unit so it cannot perturb the
+        # doc-accuracy suite's collection-count assertions.
+        run: pytest -q tests/integration/reviewer -p no:flaky-detection
+
   performance:
     name: Performance regression tests
     runs-on: ubuntu-latest

--- a/src/operations_center/capability_ownership.py
+++ b/src/operations_center/capability_ownership.py
@@ -54,6 +54,16 @@ def _edge_is_owns(edge: object) -> bool:
     return str(getattr(kind, "value", kind)).lower() == "owns"
 
 
+def _norm_owner(repo_id: object) -> str:
+    """Normalize a repo identifier for owner comparison so the SAME repo matches
+    across naming conventions — RepoGraph's snake_case repo_id ``operations_center``
+    vs OC's PascalCase ``self_repo_key`` ``OperationsCenter``. Lowercases and drops
+    all non-alphanumerics, so the gate does NOT false-refuse (and halt the critical
+    board_unblock self-heal lane) on a pure casing/separator difference, while still
+    distinguishing genuinely different repos (``custodian`` != ``operationscenter``)."""
+    return "".join(ch for ch in str(repo_id).lower() if ch.isalnum())
+
+
 def resolve_owner(registry: object, action_id: str) -> str:
     """Return the single owner repo_id of ``action_id`` or raise.
 
@@ -170,9 +180,11 @@ def verify_owner_or_degrade(
     * registry unavailable → DEGRADE (proceed) with an observable warning; never
       halt critical self-healing on a missing registry (§0.1).
     * registry available + exactly one owner (matching ``expected_owner`` if
-      given) → proceed.
-    * registry available + ambiguous owner, or owner ≠ expected → REFUSE
-      (fail-closed): this is the real integrity violation worth blocking on.
+      given — compared convention-insensitively, see ``_norm_owner``) → proceed.
+    * registry available + ambiguous owner, or a genuinely DIFFERENT owner →
+      REFUSE (fail-closed): the real integrity violation worth blocking on. A pure
+      casing/convention difference (``operations_center`` vs ``OperationsCenter``)
+      is NOT a refusal — that would falsely halt the self-heal lane.
     """
 
     if not required:
@@ -197,7 +209,7 @@ def verify_owner_or_degrade(
             action_id,
         )
         return False
-    if expected_owner is not None and owner != expected_owner:
+    if expected_owner is not None and _norm_owner(owner) != _norm_owner(expected_owner):
         logger.error(
             "capability_ownership: REFUSING %r — owner %r != expected %r",
             action_id,

--- a/tests/unit/test_capability_ownership.py
+++ b/tests/unit/test_capability_ownership.py
@@ -114,6 +114,32 @@ def test_owner_match_proceeds():
     )
 
 
+def test_owner_match_is_convention_insensitive():
+    # The registry uses RepoGraph's repo_id casing (operations_center); OC's gate
+    # passes self_repo_key ("OperationsCenter"). Same repo — the gate must NOT refuse
+    # on the casing/separator difference (else require_capability_owner halts
+    # board_unblock every cycle).
+    reg = _registry(("board_unblock", "operations_center", "owns"))
+    assert (
+        verify_owner_or_degrade(
+            "board_unblock", required=True, expected_owner="OperationsCenter", registry=reg
+        )
+        is True
+    )
+
+
+def test_owner_normalization_does_not_overmatch():
+    # A genuinely different repo still refuses — normalization collapses convention,
+    # not identity.
+    reg = _registry(("board_unblock", "Custodian", "owns"))
+    assert (
+        verify_owner_or_degrade(
+            "board_unblock", required=True, expected_owner="OperationsCenter", registry=reg
+        )
+        is False
+    )
+
+
 def test_load_activates_when_loader_present(monkeypatch):
     # Activation contract: if an importable module exposes load_capability_registry,
     # the guard USES it and leaves dormancy — guards against the rot where the probe

--- a/tests/verdicts/conftest.py
+++ b/tests/verdicts/conftest.py
@@ -312,7 +312,15 @@ def mock_settings(
             allowed_reviewer_logins=[],
             max_self_review_loops=max_self_review_loops,
             max_fix_attempts=max_fix_attempts,
+            max_fix_strategy_level=2,
             bot_comment_marker="<!-- operations-center:bot -->",
+            # Opt-in self-merge gates default OFF (mirrors tests/test_pr_review_watcher.py
+            # REVIEWER_CFG and the production default). A bare MagicMock would otherwise
+            # auto-create these as truthy attributes, spuriously activating the
+            # require_branch_protection / sensitive-path fail-closed gates against an
+            # unverifiable mocked protection state and blocking every merge-path test.
+            require_branch_protection=False,
+            require_sensitive_path_ack=False,
         ),
         repos={repo_key: repo_cfg},
         plane=MagicMock(


### PR DESCRIPTION
Addresses the two open threads from the wire-all close.

## Thread 2 — gate reviewer integration tests in CI
The 11 `tests/integration/reviewer` failures were ONE drifted fixture: `tests/verdicts/conftest.py` `mock_settings()` left `require_branch_protection`/`require_sensitive_path_ack` unset, so the bare `MagicMock` auto-created them truthy → the #388 self-merge gate flipped ON in tests → merge refused. Fixed the fixture; added a `reviewer-integration` CI job so the hermetic suite is gated and can't drift again. **101 pass.**

## Thread 1 — capability-owner halt fix (the dangerous blocker)
`verify_owner_or_degrade` compared `owner != expected_owner` by exact string, but the registry owns `board_unblock` as `operations_center` (RepoGraph repo_id) while OC passes `self_repo_key="OperationsCenter"` — so enabling `require_capability_owner` would REFUSE → **halt board_unblock every cycle**. Added `_norm_owner` (lowercase + strip non-alphanumerics) so the same repo matches across conventions without over-matching different repos. The gate is now safe to enable. **Full activation still blocked cross-repo** (planeless transitive repograph + a PM topology incompatibility) — recorded.

Behavior-neutral on the live fleet (capability path dormant; CI/test-only otherwise). 21+101 tests green; custodian clean.

🤖 Generated with Claude Code