### PR TITLE
feat(capability): activate runtime ownership enforcement live (cross-repo)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8477,3 +8477,16 @@ across conventions without over-matching different repos -> the gate is now SAFE
 needs (cross-repo, recorded): a plane-bearing repograph release (OC's transitive repograph@v0.2.0 is planeless) +
 PM topology compat (the plane-bearing PM commit dropped legacy_names, breaking OC impact-analysis). Behavior-neutral
 on the live fleet (capability path dormant; CI/test-only otherwise) -> no urgent deploy.
+
+## 2026-06-24 — Capability enforcement ACTIVATED (cross-repo)
+
+Full activation of C2 (operator: "drive the full activation, cross-repo and all"). Bumped OC deps to consume the
+plane-bearing upstream commits: platform-manifest -> 17095f433 (ships capabilities.py + data/capabilities.yaml);
+repograph -> e0b205e via [tool.uv] override-dependencies (the planeless repograph@v0.2.0 came transitively via
+context-lifecycle; only an override wins). The plane now loads (34 edges). Reconciled the 6-test blast radius from
+PM's topology evolution (legacy_names dropped -> canonical_name/runtime_role; CxRP consumers 3->6) MEANINGFULLY (no
+test deletions). SAFETY-verified vs the real registry: board_unblock -> PROCEED (operations_center matches
+OperationsCenter via #400's _norm_owner), wrong owner -> REFUSE; all 12 capabilities resolve to exactly one owner.
+Enabled require_capability_owner default True (fail-open -> can't deadlock). Full tests/unit 8183 passed, 0 failed.
+DEPLOY NOTE: needs a LIVE VENV RE-SYNC (uv sync with the override) + restart; the deployed gate degrades safely until
+then. Bare-SHA pins (no plane-bearing tag exists on PM/RepoGraph yet).

--- a/.console/log.md
+++ b/.console/log.md
@@ -8490,3 +8490,11 @@ OperationsCenter via #400's _norm_owner), wrong owner -> REFUSE; all 12 capabili
 Enabled require_capability_owner default True (fail-open -> can't deadlock). Full tests/unit 8183 passed, 0 failed.
 DEPLOY NOTE: needs a LIVE VENV RE-SYNC (uv sync with the override) + restart; the deployed gate degrades safely until
 then. Bare-SHA pins (no plane-bearing tag exists on PM/RepoGraph yet).
+
+## 2026-06-24 — Capability activation: deploy-mechanism fix + T3
+
+ensure_venv now uses `uv pip install` (not plain pip) so the fleet's venv honors pyproject [tool.uv]
+override-dependencies (the plane-bearing repograph e0b205e). Plain pip silently dropped it -> the deployed plane
+would stay dormant AND repograph would downgrade to planeless on every pyproject change. Gated the live-registry
+tests with a declarative skipif on plane availability (custodian T3, not a per-test runtime skip). Verified: in the
+activated venv the live tests run+pass (27); planeless -> skip.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,21 @@
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
+# Force the capabilities-plane RepoGraph fleet-wide. The plane lives in
+# platform_manifest.capabilities, which re-exports CapabilityRegistry /
+# load_capability_registry from `repograph`. PlatformManifest does NOT declare
+# repograph as a dependency (it path-imports a sibling checkout), so the only
+# `repograph` in this venv otherwise comes transitively from context-lifecycle,
+# which pins the PLANELESS repograph@v0.2.0 (no CapabilityRegistry). A
+# [tool.uv.sources] entry is insufficient — uv honors the transitive consumer's
+# own version pin; only override-dependencies wins. Pinned to RepoGraph e0b205e
+# (#7, descendant of v0.2.1) which ships the capabilities plane. No release tag
+# carries the plane yet; bump to the first plane-bearing tag when one exists.
+[tool.uv]
+override-dependencies = [
+  "repograph @ git+https://github.com/ProtocolWarden/RepoGraph.git@e0b205e1c92ba840595f528b52be423e10c6a31b",
+]
+
 [project]
 name = "operations-center"
 version = "0.1.0"
@@ -17,7 +32,12 @@ dependencies = [
   "source-registry @ git+https://github.com/ProtocolWarden/SourceRegistry.git",
   "rxp @ git+https://github.com/ProtocolWarden/RxP.git",
   "core-runner @ git+https://github.com/ProtocolWarden/CoreRunner.git",
-  "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.0.0",
+  # Capabilities plane (C2 runtime enforcement). Pinned to the plane-bearing
+  # PlatformManifest commit (17095f433 — descendant of v1.0.0) which ships
+  # src/platform_manifest/capabilities.py + data/capabilities.yaml. No release
+  # tag carries the plane yet (v1.0.0 is planeless), so this is a bare SHA pin;
+  # bump to the first plane-bearing tag when one exists.
+  "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@17095f433a086aee1668f88b7a5597d669c0786b",
   # ADR 0002 P4 — dispatcher CL wrap.
   "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.3.1",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -61,7 +61,9 @@ ensure_venv() {
   fi
   if [[ ! -f "${BOOTSTRAP_STAMP}" || "${ROOT_DIR}/pyproject.toml" -nt "${BOOTSTRAP_STAMP}" ]]; then
     "${VENV_DIR}/bin/python" -m pip install --upgrade pip
-    "${VENV_DIR}/bin/python" -m pip install -e '.[dev]'
+    # uv (not plain pip): honors pyproject [tool.uv] override-dependencies — the
+    # capabilities-plane repograph pin (e0b205e) that plain pip silently drops.
+    uv pip install --python "${VENV_DIR}/bin/python" -e '.[dev]'
     touch "${BOOTSTRAP_STAMP}"
   fi
 }

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -638,10 +638,15 @@ class Settings(BaseModel):
     # Synchronous capability-owner check (C2, determinism surface 1). When set,
     # owner-bearing capabilities (board_unblock) verify exactly-one-owner from the
     # registry at invocation and refuse on ambiguity, instead of trusting the
-    # async Custodian lint. DORMANT-by-environment: OC's pinned repograph wheel has
-    # no capabilities plane, so the registry is unavailable and the guard degrades
-    # (proceeds) until that becomes a runtime dependency. False = off (default).
-    require_capability_owner: bool = False
+    # async Custodian lint. LIVE as of the capabilities-plane pin: OC now depends
+    # on the plane-bearing platform-manifest (capabilities.py + data/
+    # capabilities.yaml) and an override-pinned plane-bearing repograph, so the
+    # registry loads and the guard is load-bearing — board_unblock resolves to
+    # owner operations_center (matches self_repo_key OperationsCenter convention-
+    # insensitively → PROCEED). Remains fail-open by construction: an unavailable
+    # registry DEGRADES (proceeds) rather than halting self-healing (§0.1), so
+    # enabling it by default cannot deadlock the board_unblock lane. True = on.
+    require_capability_owner: bool = True
 
     def plane_token(self) -> str:
         return os.environ[self.plane.api_token_env]

--- a/tests/unit/execution/test_coordinator_er_wiring.py
+++ b/tests/unit/execution/test_coordinator_er_wiring.py
@@ -228,7 +228,14 @@ class TestLifecycleWiring:
 class TestRepoGraphWiring:
     def test_default_loader_resolves_canonical(self) -> None:
         graph = load_default_repo_graph()
-        assert graph.resolve("ControlPlane").canonical_name == "OperationsCenter"
+        # The default (platform-only) loader resolves by canonical_name,
+        # case-insensitively. The v1 manifest schema dropped free-text
+        # legacy_names (canonical_name/runtime_role; aliases now surface only via
+        # the indexed public_alias), so the historical "ControlPlane" label no
+        # longer resolves — assert that explicitly so this guards the resolver.
+        assert graph.resolve("OperationsCenter").canonical_name == "OperationsCenter"
+        assert graph.resolve("operationscenter").canonical_name == "OperationsCenter"
+        assert graph.resolve("ControlPlane") is None
 
     def test_default_loader_is_cached(self) -> None:
         a = load_default_repo_graph()

--- a/tests/unit/execution/test_coordinator_impact_hook.py
+++ b/tests/unit/execution/test_coordinator_impact_hook.py
@@ -139,9 +139,16 @@ class TestContractRepoImpactLogged:
             set(ci["public_affected"])
         )
 
-    def test_legacy_alias_resolves_in_repo_key(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_canonical_repo_key_resolves_in_impact_hook(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # The impact hook resolves request.repo_key through the graph's name
+        # index (canonical_name / repo_id, case-insensitive). The v1 manifest
+        # schema dropped free-text legacy_names, so the historical
+        # "ExecutionContractProtocol" label no longer resolves to CxRP — drive
+        # the hook with the canonical name instead and assert it still fires.
         graph = build_effective_repo_graph()
-        bundle = _bundle("ExecutionContractProtocol")
+        bundle = _bundle("CxRP")
         adapter = _RecordingAdapter(_success(bundle))
         coord = ExecutionCoordinator(
             adapter_registry=_Registry(adapter),
@@ -152,6 +159,22 @@ class TestContractRepoImpactLogged:
             outcome = coord.execute(bundle, _runtime())
         assert any("contract change in CxRP" in rec.message for rec in caplog.records)
         assert outcome.record.metadata.get("contract_impact", {}).get("target") == "CxRP"
+
+    def test_dropped_legacy_alias_is_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The removed legacy alias resolves to nothing now, so the hook stays
+        # silent (no contract-impact metadata) — same path as an unknown repo.
+        graph = build_effective_repo_graph()
+        bundle = _bundle("ExecutionContractProtocol")
+        adapter = _RecordingAdapter(_success(bundle))
+        coord = ExecutionCoordinator(
+            adapter_registry=_Registry(adapter),
+            policy_engine=_allow(),
+            repo_graph=graph,
+        )
+        with caplog.at_level(logging.INFO):
+            outcome = coord.execute(bundle, _runtime())
+        assert all("contract change" not in rec.message for rec in caplog.records)
+        assert "contract_impact" not in (outcome.record.metadata or {})
 
 
 class TestLeafRepoSilent:

--- a/tests/unit/propagation/test_propagation_library.py
+++ b/tests/unit/propagation/test_propagation_library.py
@@ -268,10 +268,19 @@ class TestPropagatorEndToEnd:
         )
         graph = build_effective_repo_graph()
         record = prop.propagate(target_repo_id="cxrp", target_version="v1", graph=graph)
-        # CxRP has 3 platform consumers — tasks for each
-        assert len(creator.calls) == 3
+        # CxRP has 6 platform consumers — the three top-level repos plus the
+        # three executor backends (TeamExecutor/DAGExecutor/CritiqueExecutor that
+        # depends_on_contracts_from CxRP) — one task each.
+        assert len(creator.calls) == 6
         consumer_canonicals = {o.consumer_canonical for o in record.outcomes}
-        assert {"OperationsCenter", "SwitchBoard", "OperatorConsole"}.issubset(consumer_canonicals)
+        assert {
+            "OperationsCenter",
+            "SwitchBoard",
+            "OperatorConsole",
+            "TeamExecutor",
+            "DAGExecutor",
+            "CritiqueExecutor",
+        }.issubset(consumer_canonicals)
         # All landed in BACKLOG (not promoted)
         assert all(call["promote_to_ready"] is False for call in creator.calls)
         # Each body contains the parent-link block

--- a/tests/unit/test_capability_ownership.py
+++ b/tests/unit/test_capability_ownership.py
@@ -2,9 +2,13 @@
 # Copyright (C) 2026 ProtocolWarden
 """Tests for the synchronous capability-owner check (Phase C2, surface 1).
 
-The registry is dormant-by-environment in OC today, so these exercise the
-mechanism against a fake registry plus the degrade/no-op paths that govern its
-real behavior.
+Most cases exercise the mechanism against a fake registry plus the degrade/no-op
+paths that govern its behavior. With the capabilities-plane pin now in OC's deps
+(plane-bearing platform-manifest + override-pinned plane-bearing repograph), the
+guard is LIVE: ``TestLiveRegistryActivation`` loads the REAL registry and asserts
+board_unblock proceeds against it (skipped where the plane is absent, e.g. an
+unbumped venv, so the activation contract is checked where it can be and never
+false-fails where it can't).
 """
 
 from __future__ import annotations
@@ -282,3 +286,95 @@ def test_resolves_owner_from_live_platform_manifest_registry(monkeypatch):
         )
         is True
     )
+
+
+# ── live activation: the REAL plane is pinned into OC's deps ─────────────────────
+#
+# These do NOT monkeypatch the loader — they exercise the registry that actually
+# ships in OC's environment via platform_manifest.capabilities. Skipped (not
+# failed) where the plane is absent, so the suite stays green on an unbumped venv
+# while still pinning the live activation where the plane is present.
+
+
+def _live_registry():
+    from operations_center.capability_ownership import load_capability_registry
+
+    return load_capability_registry()
+
+
+class TestLiveRegistryActivation:
+    def test_real_registry_loads_with_edges(self):
+        reg = _live_registry()
+        if reg is None:
+            pytest.skip("capabilities plane not installed in this environment")
+        assert hasattr(reg, "edges")
+        assert len(reg.edges) > 0
+
+    def test_board_unblock_proceeds_against_real_registry(self):
+        # The exact gate the live board_unblock self-heal lane runs:
+        # action_id='board_unblock', expected_owner=self_repo_key ('OperationsCenter').
+        # Must PROCEED (the registry owns board_unblock as operations_center, which
+        # matches convention-insensitively).
+        reg = _live_registry()
+        if reg is None:
+            pytest.skip("capabilities plane not installed in this environment")
+        assert (
+            verify_owner_or_degrade(
+                "board_unblock", required=True, expected_owner="OperationsCenter"
+            )
+            is True
+        )
+
+    def test_board_unblock_owner_is_operations_center(self):
+        reg = _live_registry()
+        if reg is None:
+            pytest.skip("capabilities plane not installed in this environment")
+        # Convention-insensitive: registry uses repo_id 'operations_center'.
+        from operations_center.capability_ownership import _norm_owner
+
+        assert _norm_owner(resolve_owner(reg, "board_unblock")) == _norm_owner(
+            "OperationsCenter"
+        )
+
+    def test_wrong_owner_refuses_against_real_registry(self):
+        # The gate is genuinely load-bearing, not a no-op: a different expected
+        # owner must REFUSE even against the real registry.
+        reg = _live_registry()
+        if reg is None:
+            pytest.skip("capabilities plane not installed in this environment")
+        assert (
+            verify_owner_or_degrade(
+                "board_unblock", required=True, expected_owner="Custodian"
+            )
+            is False
+        )
+
+
+# ── enforcement default: require_capability_owner is now ON ──────────────────────
+
+
+def test_require_capability_owner_default_is_true():
+    # The capabilities plane is pinned into OC's deps, so the synchronous owner
+    # check is enabled by default. Fail-open by construction: an unavailable
+    # registry still degrades (proceeds), so a True default cannot deadlock the
+    # board_unblock lane. Asserted via the declared field default (Settings has
+    # required plane/git fields, so we check the default without instantiating).
+    from operations_center.config.settings import Settings
+
+    assert Settings.model_fields["require_capability_owner"].default is True
+
+
+def test_require_capability_owner_true_on_constructed_settings():
+    # Belt-and-suspenders: a fully constructed Settings carries the True default.
+    from operations_center.config.settings import GitSettings, PlaneSettings, Settings
+
+    s = Settings(
+        plane=PlaneSettings(
+            base_url="http://x",
+            api_token_env="T",
+            workspace_slug="w",
+            project_id="p",
+        ),
+        git=GitSettings(),
+    )
+    assert s.require_capability_owner is True

--- a/tests/unit/test_capability_ownership.py
+++ b/tests/unit/test_capability_ownership.py
@@ -302,22 +302,27 @@ def _live_registry():
     return load_capability_registry()
 
 
+_PLANE_AVAILABLE = _live_registry() is not None
+
+
+@pytest.mark.skipif(
+    not _PLANE_AVAILABLE,
+    reason="capabilities plane not installed in this environment (probe returned None)",
+)
 class TestLiveRegistryActivation:
+    """Runs only where the real capabilities plane is installed (the activated env);
+    gated declaratively by a plane-availability probe, not a per-test runtime skip."""
+
     def test_real_registry_loads_with_edges(self):
         reg = _live_registry()
-        if reg is None:
-            pytest.skip("capabilities plane not installed in this environment")
         assert hasattr(reg, "edges")
         assert len(reg.edges) > 0
 
     def test_board_unblock_proceeds_against_real_registry(self):
         # The exact gate the live board_unblock self-heal lane runs:
         # action_id='board_unblock', expected_owner=self_repo_key ('OperationsCenter').
-        # Must PROCEED (the registry owns board_unblock as operations_center, which
-        # matches convention-insensitively).
-        reg = _live_registry()
-        if reg is None:
-            pytest.skip("capabilities plane not installed in this environment")
+        # PROCEEDs (registry owns board_unblock as operations_center, matched
+        # convention-insensitively).
         assert (
             verify_owner_or_degrade(
                 "board_unblock", required=True, expected_owner="OperationsCenter"
@@ -326,22 +331,15 @@ class TestLiveRegistryActivation:
         )
 
     def test_board_unblock_owner_is_operations_center(self):
-        reg = _live_registry()
-        if reg is None:
-            pytest.skip("capabilities plane not installed in this environment")
-        # Convention-insensitive: registry uses repo_id 'operations_center'.
         from operations_center.capability_ownership import _norm_owner
 
-        assert _norm_owner(resolve_owner(reg, "board_unblock")) == _norm_owner(
+        assert _norm_owner(resolve_owner(_live_registry(), "board_unblock")) == _norm_owner(
             "OperationsCenter"
         )
 
     def test_wrong_owner_refuses_against_real_registry(self):
-        # The gate is genuinely load-bearing, not a no-op: a different expected
-        # owner must REFUSE even against the real registry.
-        reg = _live_registry()
-        if reg is None:
-            pytest.skip("capabilities plane not installed in this environment")
+        # Genuinely load-bearing: a different expected owner REFUSES even against
+        # the real registry.
         assert (
             verify_owner_or_degrade(
                 "board_unblock", required=True, expected_owner="Custodian"

--- a/tests/unit/test_impact_analysis.py
+++ b/tests/unit/test_impact_analysis.py
@@ -36,13 +36,18 @@ class TestPlatformContractImpact:
         g = build_effective_repo_graph()
         assert compute_contract_impact(g, "ghost-repo") is None
 
-    def test_legacy_alias_resolves(self) -> None:
+    def test_canonical_and_repo_id_resolve(self) -> None:
         g = build_effective_repo_graph()
-        # ExecutionContractProtocol is the historical label for CxRP.
-        summary = compute_contract_impact(g, "ExecutionContractProtocol")
-        assert summary is not None
-        assert summary.target.canonical_name == "CxRP"
-        assert summary.has_impact()
+        # The v1 manifest schema dropped free-text legacy_names, so the
+        # historical "ExecutionContractProtocol" label for CxRP no longer
+        # resolves (returns None — pass-through). Resolution is by canonical_name
+        # and repo_id (case-insensitive); both must reach CxRP and report impact.
+        for name in ("CxRP", "cxrp"):
+            summary = compute_contract_impact(g, name)
+            assert summary is not None
+            assert summary.target.canonical_name == "CxRP"
+            assert summary.has_impact()
+        assert compute_contract_impact(g, "ExecutionContractProtocol") is None
 
     def test_non_contract_repo_has_no_consumers(self) -> None:
         g = build_effective_repo_graph()
@@ -115,8 +120,19 @@ class TestEffectiveGraphWithProject:
         summary = compute_contract_impact(g, "CxRP")
         assert summary is not None
         names = {n.canonical_name for n in summary.affected}
-        assert {"OperationsCenter", "SwitchBoard", "OperatorConsole", "VFAApi"} == names
-        assert len(summary.public_affected) == 3
+        # Platform CxRP consumers now include the three executor backends
+        # (TeamExecutor/DAGExecutor/CritiqueExecutor depends_on_contracts_from
+        # CxRP), plus the private project consumer.
+        assert {
+            "OperationsCenter",
+            "SwitchBoard",
+            "OperatorConsole",
+            "TeamExecutor",
+            "DAGExecutor",
+            "CritiqueExecutor",
+            "VFAApi",
+        } == names
+        assert len(summary.public_affected) == 6
         assert len(summary.private_affected) == 1
 
 
@@ -211,15 +227,19 @@ class TestEffectiveGraphWithWorkScope:
         summary = compute_contract_impact(g, "CxRP")
         assert summary is not None
         names = {n.canonical_name for n in summary.affected}
-        # Public platform consumers PLUS both private include consumers
+        # Public platform consumers (incl. the three executor backends that
+        # depends_on_contracts_from CxRP) PLUS both private include consumers
         assert {
             "OperationsCenter",
             "SwitchBoard",
             "OperatorConsole",
+            "TeamExecutor",
+            "DAGExecutor",
+            "CritiqueExecutor",
             "ProjectAAPI",
             "ProjectBAPI",
         } == names
-        assert len(summary.public_affected) == 3
+        assert len(summary.public_affected) == 6
         assert len(summary.private_affected) == 2
         # Privates are both Visibility.PRIVATE
         assert all(n.visibility is Visibility.PRIVATE for n in summary.private_affected)


### PR DESCRIPTION
Full cross-repo activation of runtime capability enforcement (C2), authorized by the operator ("drive the full activation, cross-repo and all").

## What
- Bump deps to the plane-bearing upstream commits: `platform-manifest` → `17095f433` (ships the capabilities plane); `repograph` → `e0b205e` via `[tool.uv] override-dependencies` (the transitive `repograph@v0.2.0` via context-lifecycle is planeless; only an override wins).
- `ensure_venv` switches plain pip → **uv** so the fleet's venv honors the override (plain pip silently drops it).
- Reconcile PM topology evolution (legacy_names → canonical_name/runtime_role; CxRP consumers 3→6) — 6 impact-analysis tests updated meaningfully (no deletions).
- Enable `require_capability_owner = True`.

## Safety
Gate verified vs the REAL registry: `board_unblock` → PROCEED (`operations_center` matches `OperationsCenter` via #400's `_norm_owner`), wrong owner → REFUSE; all 12 capabilities one-owner. Fail-open → a True default cannot deadlock. Full `tests/unit` 8183 pass (live-registry tests skipif-gated). Custodian clean.

## Deploy
Live activation needs a venv re-sync (uv) + restart; the gate degrades safely until then.

🤖 Generated with Claude Code