### PR TITLE
chore(deps): pin capability plane to PM v1.1.0 + RepoGraph v0.3.0 tags

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-06-24 — RELEASE: cut PM v1.1.0 + RepoGraph v0.3.0, pin capability deps to tags
+
+The capability plane was consumed via bare-SHA pins because no plane-bearing release tag
+existed. Cut the first plane-bearing tags on both upstreams — PlatformManifest **v1.1.0**
+(`17095f433`, ships `platform_manifest.capabilities` + `data/capabilities.yaml`; v1.0.0 is
+planeless) and RepoGraph **v0.3.0** (`e0b205e`, ships the `CapabilityRegistry`; v0.2.x are
+planeless) — and moved OC's pins from the SHAs to the tags: `platform-manifest @ …@v1.1.0`
+and the `[tool.uv] override-dependencies` `repograph @ …@v0.3.0`. **Code-neutral**: the tags
+resolve to the exact verified commits OC is already deployed against. Verified in a fresh
+tag-built venv (`uv pip install` honoring the override): plane loads 34 edges, `board_unblock`
+owner resolves to `operations_center`, the gate proceeds for OperationsCenter / refuses a wrong
+owner, full `tests/unit` green (8183 passed). No proactive fleet deploy required (identical
+commits); the live venv converges to tag-provenance on the next restart's `ensure_venv`
+re-sync, which the tag-built install proves works.
+
 ## 2026-06-22 — HARDEN: 3 top gaps from the fresh guide-vs-harness adversarial audit
 
 Closes the three highest-priority findings the fresh audit (vs the harness-engineering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ build-backend = "setuptools.build_meta"
 # `repograph` in this venv otherwise comes transitively from context-lifecycle,
 # which pins the PLANELESS repograph@v0.2.0 (no CapabilityRegistry). A
 # [tool.uv.sources] entry is insufficient — uv honors the transitive consumer's
-# own version pin; only override-dependencies wins. Pinned to RepoGraph e0b205e
-# (#7, descendant of v0.2.1) which ships the capabilities plane. No release tag
-# carries the plane yet; bump to the first plane-bearing tag when one exists.
+# own version pin; only override-dependencies wins. Pinned to RepoGraph v0.3.0
+# (e0b205e, #7) — the first release tag carrying the capabilities plane (the
+# v0.2.x tags are planeless).
 [tool.uv]
 override-dependencies = [
-  "repograph @ git+https://github.com/ProtocolWarden/RepoGraph.git@e0b205e1c92ba840595f528b52be423e10c6a31b",
+  "repograph @ git+https://github.com/ProtocolWarden/RepoGraph.git@v0.3.0",
 ]
 
 [project]
@@ -32,12 +32,11 @@ dependencies = [
   "source-registry @ git+https://github.com/ProtocolWarden/SourceRegistry.git",
   "rxp @ git+https://github.com/ProtocolWarden/RxP.git",
   "core-runner @ git+https://github.com/ProtocolWarden/CoreRunner.git",
-  # Capabilities plane (C2 runtime enforcement). Pinned to the plane-bearing
-  # PlatformManifest commit (17095f433 — descendant of v1.0.0) which ships
-  # src/platform_manifest/capabilities.py + data/capabilities.yaml. No release
-  # tag carries the plane yet (v1.0.0 is planeless), so this is a bare SHA pin;
-  # bump to the first plane-bearing tag when one exists.
-  "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@17095f433a086aee1668f88b7a5597d669c0786b",
+  # Capabilities plane (C2 runtime enforcement). Pinned to PlatformManifest
+  # v1.1.0 (17095f433) — the first release tag shipping
+  # src/platform_manifest/capabilities.py + data/capabilities.yaml (v1.0.0 is
+  # planeless).
+  "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.1.0",
   # ADR 0002 P4 — dispatcher CL wrap.
   "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.3.1",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.


### PR DESCRIPTION
Cuts the first **plane-bearing release tags** on both upstreams and moves OC's capability-plane pins from bare SHAs to those tags.

## Tags cut
- **PlatformManifest v1.1.0** → `17095f433` — first tag shipping `platform_manifest.capabilities` + `data/capabilities.yaml` (v1.0.0 is planeless). Includes the `legacy_names`→`canonical_name` topology schema change.
- **RepoGraph v0.3.0** → `e0b205e` — first tag shipping the `CapabilityRegistry` (v0.2.x are planeless).

## Pin change (this PR)
- `platform-manifest @ …@17095f433` → `@v1.1.0`
- `[tool.uv] override-dependencies` `repograph @ …@e0b205e` → `@v0.3.0`

**Code-neutral**: each tag resolves to the exact verified commit the fleet is already deployed against (#401) — a reproducibility/provenance change, not a behavior change.

## Verification (fresh tag-built venv, `uv pip install -e '.[dev]'` honoring the `[tool.uv]` override)
- `uv pip freeze` confirms `@v1.1.0 → 17095f433`, `@v0.3.0 → e0b205e`
- plane loads **34 edges**; `resolve_owner(board_unblock) → operations_center`
- gate proceeds for `OperationsCenter`, refuses a wrong owner
- full `tests/unit` green — **8183 passed, 5 skipped, 2 xfailed**

No proactive fleet deploy required (identical commits); the live venv converges to tag-provenance on the next restart's `ensure_venv` re-sync, which the tag-built install proves works.

🤖 Generated with Claude Code