### PR TITLE
fix(routing): omit null constraints from SwitchBoard /route (unblocks ALL planning)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,17 @@
+## 2026-06-25 — FIX: SwitchBoard 422 — omit null constraints from the routing payload
+
+Unblocking the goal lane (#387) exposed that EVERY task crash-looped at planning: the worker
+POSTs its proposal to SwitchBoard `/route`, which 422'd because OC sent
+`constraints.timeout_seconds` / `require_clean_validation` / `max_changed_files` = **null**.
+SwitchBoard's `TaskProposal` declares those non-nullable with defaults (300 / True); it wants
+them **omitted**, not null. The nulls came from wire-all S1bc (#396) making the fields
+`Optional[...]=None` — that fixed OC's internal handling but broke the OC→SwitchBoard wire, and
+the OPEN_PR_GATE deadlock masked it (planning never ran). Fix: `routing/client.py` `select_lane`
+serializes with `model_dump(mode="json", exclude_none=True)` so unset constraints fall back to
+SwitchBoard's defaults. Verified 422→200 against live SwitchBoard. OC's own executor is
+unaffected (it reads the original proposal, not SwitchBoard's echo). Regression test added: the
+routing payload must omit null constraints while preserving concrete falsy values (False / []).
+
 ## 2026-06-24 — FIX: unblock goal-lane #387 (extraction-health-dashboard) — real asserts + console hygiene
 
 #387 (goal/42275c3a, extraction-health-dashboard) had been OPEN and stuck ~2.5 days on the

--- a/src/operations_center/routing/client.py
+++ b/src/operations_center/routing/client.py
@@ -62,7 +62,13 @@ class HttpLaneRoutingClient:
 
     def select_lane(self, proposal: OcPlanningProposal) -> OcRoutingDecision:
         try:
-            response = self._client.post("/route", json=proposal.model_dump(mode="json"))
+            # exclude_none: OC's ExecutionConstraints made timeout_seconds /
+            # require_clean_validation / max_changed_files Optional (wire-all S1bc),
+            # but SwitchBoard's TaskProposal declares them non-nullable with defaults
+            # (300 / True). Sending null 422s every proposal; omitting the unset
+            # fields lets SwitchBoard apply its defaults. None == "unset" == default.
+            payload = proposal.model_dump(mode="json", exclude_none=True)
+            response = self._client.post("/route", json=payload)
             response.raise_for_status()
         except httpx.ConnectError as exc:
             raise SwitchBoardUnavailableError(

--- a/tests/unit/routing/test_client.py
+++ b/tests/unit/routing/test_client.py
@@ -116,6 +116,38 @@ def test_http_client_serializes_canonical_proposal() -> None:
     assert seen["goal_text"] == "Fix lint errors in src/"
 
 
+def test_http_client_omits_none_constraints() -> None:
+    """OC's ExecutionConstraints made timeout_seconds / require_clean_validation /
+    max_changed_files Optional (wire-all S1bc), but SwitchBoard's TaskProposal declares
+    them non-nullable with defaults. The client must OMIT unset (None) fields via
+    exclude_none so SwitchBoard applies its defaults rather than 422ing on null."""
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(200, json=_stub_cxrp_response())
+
+    client = HttpLaneRoutingClient(
+        "http://switchboard.local", transport=httpx.MockTransport(handler)
+    )
+    # _ctx() sets no timeout/validation overrides -> those constraints are None.
+    proposal = build_proposal(_ctx())
+    try:
+        client.select_lane(proposal)
+    finally:
+        client.close()
+
+    constraints = seen.get("constraints") or {}
+    # Null-valued optionals must be omitted (SwitchBoard 422s on explicit null).
+    assert "timeout_seconds" not in constraints
+    assert "require_clean_validation" not in constraints
+    assert "max_changed_files" not in constraints
+    # exclude_none must NOT drop concrete falsy values (False / []).
+    assert constraints.get("skip_baseline_validation") is False
+    # and no explicit null leaks through anywhere at the top level.
+    assert None not in seen.values()
+
+
 def test_http_client_from_env_prefers_operations_center_specific_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
**Unblocks ALL autonomous planning.** Clearing the goal-lane deadlock (#387) exposed that every task was crash-looping at planning with a SwitchBoard `422` — masked for ~2.5 days because the `OPEN_PR_GATE` deadlock never let planning run.

## Root cause
The worker POSTs its `OcPlanningProposal` to SwitchBoard's `/route`. SwitchBoard 422'd every proposal because OC sent `constraints.timeout_seconds`, `require_clean_validation`, and `max_changed_files` as **`null`**. SwitchBoard's `ExecutionConstraints` declares those **non-nullable with defaults** (300 / True) — it wants them *omitted*, not null.

Those nulls came from **wire-all S1bc (#396)**, which made the fields `Optional[...]=None`. That fixed OC's internal handling but silently broke the OC→SwitchBoard wire.

## Fix
`routing/client.py` `select_lane` serializes with `model_dump(mode="json", exclude_none=True)` so unset constraints fall back to SwitchBoard's defaults (`None == "unset" == default`).

- Verified **422 → 200** against live SwitchBoard (returns a real lane decision).
- OC's own executor is unaffected — it reads the original proposal object, not SwitchBoard's echo.
- Regression test added: routing payload must omit null constraints while preserving concrete falsy values (`False` / `[]`).

🤖 Generated with Claude Code