### PR TITLE
feat(execution): pre-PR custodian gate — don't open custodian-failing PRs

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — HARDEN: pre-PR custodian gate in the executor (prevent bad PRs at source)
+
+The board_worker could produce code with custodian findings (e.g. T2 no-assert tests), open the
+PR anyway, and the required `audit` CI check went red on arrival — the #387 class. Added a
+fail-safe pre-PR gate in `WorkspaceManager.finalize`: AFTER the squash but BEFORE the push, run
+`custodian-multi --repos <workspace> --fail-on-findings`; on a real findings exit (code 1) the
+run returns a FAILED result (`success=False`, `failure_category=POLICY_BLOCKED`, findings in
+`failure_reason`) and NO branch is pushed / PR opened — so no orphan branch, and the
+board_worker routes it to `handle_failure` (BLOCKED/retryable, not a transient-retry category).
+**Fail-safe by construction**: a missing `custodian-multi` binary, a crash, a timeout (180s), or
+any non-findings exit (≥2) DEGRADES to the prior behavior (warn + push + PR) — only a clean
+findings exit blocks. Gated by `settings.pre_pr_custodian_gate` (default True, read via getattr;
+False = prior behavior). `WorkspaceManager` gained an optional `settings` ctor arg, wired through
+`entrypoints/execute/main.py`. 16 new tests (clean→PR, findings→fail+no-push, binary-missing/
+crash→proceed, disabled→skip); full tests/unit/execution green.
+
 ## 2026-06-25 — HARDEN: OPEN_PR_GATE staleness escape (degrade-never-halt)
 
 The goal lane refuses to start a new task while a non-spec PR is open for the repo (serializes

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -657,6 +657,16 @@ class Settings(BaseModel):
     # self-heal can still resolve it). Set to 0 to disable (always-block, prior behavior).
     open_pr_gate_stale_hours: float = 12.0
 
+    # Pre-PR custodian gate (workspace.finalize). When True, the executor runs
+    # custodian-multi on the task workspace AFTER squashing but BEFORE pushing;
+    # if custodian actually runs and reports findings, the run fails (retryable)
+    # and NO branch is pushed / PR opened — so a custodian-failing change can no
+    # longer produce a PR whose required `audit` CI check is red on arrival.
+    # Fail-safe by construction: a missing binary, a crash, or a timeout DEGRADES
+    # to the prior behavior (warn + proceed to push/PR); only a clean findings
+    # exit blocks. False disables the gate entirely → prior (pre-gate) behavior.
+    pre_pr_custodian_gate: bool = True
+
     def plane_token(self) -> str:
         return os.environ[self.plane.api_token_env]
 

--- a/src/operations_center/entrypoints/execute/main.py
+++ b/src/operations_center/entrypoints/execute/main.py
@@ -144,6 +144,9 @@ def main() -> int:
         max_files=_env_int("OPS_CENTER_MAX_FILES"),
         max_lines=_env_int("OPS_CENTER_MAX_LINES"),
         repo_settings_lookup=lambda key: (settings.repos or {}).get(key),
+        # Full Settings object so the pre-PR custodian gate can read
+        # settings.pre_pr_custodian_gate (defaults ON; fail-safe).
+        settings=settings,
     )
     repo_graph = build_effective_repo_graph_from_settings(
         settings,

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -24,13 +24,19 @@ the coordinator without one, preserving the existing pure-coordinator surface.
 from __future__ import annotations
 
 import logging
+import os
+import shutil
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
 from operations_center.adapters.git.client import GitClient
 from operations_center.adapters.workspace.patch_applier import PatchApplier
-from operations_center.contracts.enums import FailureReasonCategory, ValidationStatus
+from operations_center.contracts.enums import (
+    ExecutionStatus,
+    FailureReasonCategory,
+    ValidationStatus,
+)
 from operations_center.contracts.execution import ExecutionRequest, ExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -80,6 +86,8 @@ class WorkspaceManager:
         max_files: int | None = None,
         max_lines: int | None = None,
         repo_settings_lookup: Callable[[str], object] | None = None,
+        settings: object | None = None,
+        oc_root: Path | None = None,
     ) -> None:
         self._git = git_client or GitClient()
         self._token = github_token
@@ -91,6 +99,15 @@ class WorkspaceManager:
         # bootstrap step (C-K3) and the open_pr_default gate (C-K9). Decoupled
         # from the full Settings object so callers can pass a lambda.
         self._repo_lookup = repo_settings_lookup or (lambda _k: None)
+        # Optional full Settings object. Read defensively (getattr with a
+        # default) so the many tests / callers that construct WorkspaceManager
+        # without settings keep working. Used by the pre-PR custodian gate.
+        self._settings = settings
+        # OperationsCenter checkout root — used to resolve the custodian-multi
+        # binary from OC's own venv as a last fallback. Defaults to the repo
+        # root inferred from this module's location (.../src/operations_center/
+        # execution/workspace.py -> repo root).
+        self._oc_root = oc_root or Path(__file__).resolve().parents[3]
         # SBX pre-push applier: validates patches before commit/push
         self._patch_applier = PatchApplier()
 
@@ -316,8 +333,7 @@ class WorkspaceManager:
         if (
             request.require_clean_validation is True
             and baseline_summary is not None
-            and baseline_summary.status
-            in (ValidationStatus.FAILED, ValidationStatus.ERROR)
+            and baseline_summary.status in (ValidationStatus.FAILED, ValidationStatus.ERROR)
         ):
             raise BaselineValidationError(
                 "baseline validation did not pass and require_clean_validation "
@@ -458,6 +474,34 @@ class WorkspaceManager:
         squash_message = self._commit_message(request)
         squashed = self._git.squash_commits(ws, request.base_branch, squash_message)
 
+        # Pre-PR custodian gate. Run AFTER the squash but BEFORE the push so a
+        # custodian-failing run produces a clean failure with NO orphan branch
+        # pushed and NO PR opened (its required `audit` CI check would just go
+        # red on arrival). Fail-safe: only a real findings exit blocks; a missing
+        # binary / crash / timeout degrades to the prior behavior (push + PR).
+        findings = self._run_pre_pr_custodian_gate(request)
+        if findings is not None:
+            logger.warning(
+                "WorkspaceManager.finalize: pre-PR custodian gate BLOCKED %s — "
+                "not pushing, not opening PR. %s",
+                request.task_branch,
+                findings.splitlines()[0] if findings else "custodian findings",
+            )
+            return result.model_copy(
+                update={
+                    "status": ExecutionStatus.FAILED,
+                    "success": False,
+                    "branch_pushed": False,
+                    "failure_category": FailureReasonCategory.POLICY_BLOCKED,
+                    "failure_reason": (
+                        "pre-PR custodian gate: the task branch has custodian "
+                        "findings; refusing to push or open a PR that would fail "
+                        "the required `audit` CI check. Resolve the findings and "
+                        f"re-run.\n{findings}"
+                    ),
+                }
+            )
+
         try:
             if squashed:
                 self._git.push_branch_force(ws, request.task_branch)
@@ -482,6 +526,116 @@ class WorkspaceManager:
                 "pull_request_url": pr_url,
             }
         )
+
+    # ── pre-PR custodian gate ──────────────────────────────
+
+    def _resolve_custodian_bin(self, request: ExecutionRequest) -> str | None:
+        """Resolve the ``custodian-multi`` binary, or None if not found.
+
+        Mirrors ``_phase0_ci_fix``\'s ruff resolution (pr_review_watcher): prefer
+        the repo\'s own venv bin, then a system ``custodian-multi`` on PATH, then
+        OC\'s own ``.venv/bin``. Unlike the ruff fallback we do NOT fall through to
+        a bare ``custodian-multi`` name — a missing binary must be a clean
+        "not found" so the gate fail-safes (degrade → proceed) cleanly.
+        """
+        # 1) repo venv bin (the repo being built may ship custodian itself)
+        repo_cfg = self._repo_lookup(request.repo_key)
+        venv_dir = (getattr(repo_cfg, "venv_dir", None) or ".venv") if repo_cfg else ".venv"
+        local_path = getattr(repo_cfg, "local_path", None) if repo_cfg else None
+        if local_path:
+            cand = Path(local_path) / venv_dir / "bin" / "custodian-multi"
+            if cand.exists():
+                return str(cand)
+        # 2) system custodian-multi on PATH
+        which = shutil.which("custodian-multi")
+        if which:
+            return which
+        # 3) OC\'s own venv bin (the fleet runs OC/.venv)
+        oc_bin = self._oc_root / ".venv" / "bin" / "custodian-multi"
+        if oc_bin.exists():
+            return str(oc_bin)
+        return None
+
+    def _run_pre_pr_custodian_gate(self, request: ExecutionRequest) -> str | None:
+        """Run custodian on the workspace; return findings text iff it BLOCKS.
+
+        Returns:
+            - ``None`` to PROCEED (gate disabled, custodian clean, OR any
+              fail-safe condition: binary missing, crash, timeout, or a non
+              findings error exit). When unsure -> proceed.
+            - a non-empty findings summary string to BLOCK (push + PR skipped).
+              Only returned when custodian actually RAN and reported findings
+              (the ``--fail-on-findings`` contract: exit code 1 with a findings
+              table on stdout).
+        """
+        # Gate behind the Settings flag. Read defensively so callers / tests
+        # that construct WorkspaceManager without a Settings object default to
+        # gate-ON (the safe default), and a config with the field absent (older
+        # config) also defaults ON.
+        if not getattr(self._settings, "pre_pr_custodian_gate", True):
+            logger.debug("WorkspaceManager: pre-PR custodian gate disabled via settings — skipping")
+            return None
+
+        bin_path = self._resolve_custodian_bin(request)
+        if bin_path is None:
+            # FAIL-SAFE: no custodian binary anywhere -> degrade to prior behavior.
+            logger.warning(
+                "WorkspaceManager: pre-PR custodian gate could not find a "
+                "custodian-multi binary — proceeding without the gate (fail-safe)"
+            )
+            return None
+
+        ws = str(request.workspace_path)
+        env = dict(os.environ)
+        # Some detectors (boundary checks) need the disclosure artifact; pass it
+        # through when present. Absence must NOT hard-fail — the fail-safe below
+        # treats a non-findings error exit as "proceed", and findings exits are
+        # the only thing that blocks.
+        artifact = os.environ.get("REPOGRAPH_BOUNDARY_ARTIFACT_FILE")
+        if artifact:
+            env["REPOGRAPH_BOUNDARY_ARTIFACT_FILE"] = artifact
+
+        try:
+            proc = subprocess.run(
+                [bin_path, "--repos", ws, "--fail-on-findings", "--no-color"],
+                capture_output=True,
+                text=True,
+                timeout=180,
+                env=env,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            # FAIL-SAFE: timeout or spawn failure -> proceed.
+            logger.warning(
+                "WorkspaceManager: pre-PR custodian gate did not complete (%s) — "
+                "proceeding without the gate (fail-safe)",
+                exc,
+            )
+            return None
+
+        # custodian-multi --fail-on-findings contract:
+        #   0  -> clean (no findings)        -> PROCEED
+        #   1  -> findings present           -> BLOCK
+        #   other (>=2 / negative signal)    -> tool/env error -> PROCEED (fail-safe)
+        if proc.returncode == 0:
+            return None
+        if proc.returncode != 1:
+            logger.warning(
+                "WorkspaceManager: pre-PR custodian gate exited %s (not a clean "
+                "findings exit) — proceeding without the gate (fail-safe). stderr: %s",
+                proc.returncode,
+                (proc.stderr or "").strip()[:300],
+            )
+            return None
+
+        # Exit 1 = real findings. Surface the findings table (stdout) trimmed.
+        summary = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+        if not summary:
+            # Defensive: exit 1 but no output at all is ambiguous; treat the bare
+            # signal as findings (block) since --fail-on-findings only returns 1
+            # when it found something.
+            summary = "custodian reported findings (no detail captured)"
+        # Keep the message bounded — the full table can be large.
+        return summary[:4000]
 
     def _validate_patch_before_commit(
         self, ws: Path, request: ExecutionRequest
@@ -765,12 +919,8 @@ class WorkspaceManager:
 
             cfg_for_validation = SimpleNamespace(
                 validation_commands=list(request.validation_commands),
-                validation_timeout_seconds=getattr(
-                    repo_cfg, "validation_timeout_seconds", 300
-                ),
-                skip_baseline_validation=getattr(
-                    repo_cfg, "skip_baseline_validation", False
-                ),
+                validation_timeout_seconds=getattr(repo_cfg, "validation_timeout_seconds", 300),
+                skip_baseline_validation=getattr(repo_cfg, "skip_baseline_validation", False),
             )
 
         try:

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -9,7 +9,11 @@ from unittest import mock
 
 import pytest
 
-from operations_center.contracts.enums import ExecutionStatus, ValidationStatus
+from operations_center.contracts.enums import (
+    ExecutionStatus,
+    FailureReasonCategory,
+    ValidationStatus,
+)
 from operations_center.contracts.execution import ExecutionRequest, ExecutionResult
 from operations_center.execution import workspace as ws_mod
 from operations_center.execution.workspace import WorkspaceManager
@@ -1061,3 +1065,298 @@ def test_finalize_full_chain_with_validation_summary(tmp_path):
         out = mgr.finalize(req, result)
     assert out.pull_request_url == "http://pr/7"
     assert out.validation.status == ValidationStatus.PASSED
+
+
+# ── pre-PR custodian gate ─────────────────────────────────────────────────────
+#
+# The autouse _no_real_custodian fixture stubs _run_pre_pr_custodian_gate to
+# return None. The finalize-wiring tests below re-patch it explicitly per case.
+# The gate-logic tests capture the REAL unbound implementation so they exercise
+# the actual subprocess / exit-code / settings logic.
+
+_REAL_GATE = WorkspaceManager.__dict__["_run_pre_pr_custodian_gate"]
+_REAL_RESOLVE = WorkspaceManager.__dict__["_resolve_custodian_bin"]
+
+
+# (a) custodian clean → branch pushed + PR opened (existing behavior preserved)
+def test_finalize_custodian_clean_pushes_and_opens_pr(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = True
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/9"),
+        # gate explicitly clean → None
+        mock.patch.object(mgr, "_run_pre_pr_custodian_gate", return_value=None),
+    ):
+        out = mgr.finalize(req, result)
+    git.push_branch_force.assert_called_once_with(ws, "goal/fix-widget")
+    assert out.success is True
+    assert out.branch_pushed is True
+    assert out.pull_request_url == "http://pr/9"
+
+
+# (b) custodian findings → no push, no PR, failed/retryable result with findings
+def test_finalize_custodian_findings_blocks_push_and_pr(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = True
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    findings = "T2 no-assert test: tests/test_x.py:5\nB1 boundary violation: src/y.py"
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact") as warn,
+        mock.patch.object(mgr, "_maybe_create_pr") as pr,
+        mock.patch.object(mgr, "_run_pre_pr_custodian_gate", return_value=findings),
+    ):
+        out = mgr.finalize(req, result)
+    # neither push variant fired; no PR; no cross-repo warn (we returned before)
+    git.push_branch.assert_not_called()
+    git.push_branch_force.assert_not_called()
+    pr.assert_not_called()
+    warn.assert_not_called()
+    # retryable FAILURE convention (mirrors coordinator prep-failure results)
+    assert out.success is False
+    assert out.status == ExecutionStatus.FAILED
+    assert out.branch_pushed is False
+    assert out.failure_category == FailureReasonCategory.POLICY_BLOCKED
+    assert "custodian" in out.failure_reason.lower()
+    assert "T2 no-assert" in out.failure_reason
+
+
+# (c) binary missing / subprocess error → proceeds (fail-safe), PR opens
+def test_finalize_custodian_binary_missing_proceeds(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = False
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    # Bind the REAL gate to this manager (the autouse fixture stubbed the class
+    # method). The gate runs, finds no binary -> returns None -> finalize proceeds.
+    mgr._run_pre_pr_custodian_gate = _REAL_GATE.__get__(mgr)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/ok"),
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value=None),
+    ):
+        out = mgr.finalize(req, result)
+    git.push_branch.assert_called_once_with(ws, "goal/fix-widget")
+    assert out.success is True
+    assert out.branch_pushed is True
+    assert out.pull_request_url == "http://pr/ok"
+
+
+def test_finalize_custodian_subprocess_error_proceeds(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = False
+    mgr = WorkspaceManager(git_client=git)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    # The custodian subprocess raises OSError; only the custodian invocation is
+    # affected (the pre-gate patch-validation git calls run normally). Fail-safe
+    # -> the gate returns None -> finalize proceeds to push + PR.
+    mgr._run_pre_pr_custodian_gate = _REAL_GATE.__get__(mgr)
+
+    def fake_run(cmd, **kw):
+        if cmd and "custodian-multi" in str(cmd[0]):
+            raise OSError("exec format error")
+        return _fake_completed(0)
+
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_validate_patch_before_commit", return_value=(True, None)),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/ok2"),
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/usr/bin/custodian-multi"),
+        mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run),
+    ):
+        out = mgr.finalize(req, result)
+    git.push_branch.assert_called_once_with(ws, "goal/fix-widget")
+    assert out.success is True
+    assert out.branch_pushed is True
+
+
+# (d) pre_pr_custodian_gate=False → gate skipped entirely (binary never resolved)
+def test_finalize_gate_disabled_skips_entirely(tmp_path):
+    ws = _git_repo(tmp_path)
+    git = _finalize_git_ok()
+    git.squash_commits.return_value = False
+    settings = SimpleNamespace(pre_pr_custodian_gate=False)
+    mgr = WorkspaceManager(git_client=git, settings=settings)
+    req = _make_request(ws)
+    result = _make_result(success=True)
+    with (
+        mock.patch.object(mgr, "_diff_oversized", return_value=None),
+        mock.patch.object(mgr, "_has_new_commits", return_value=True),
+        mock.patch.object(mgr, "_warn_cross_repo_impact"),
+        mock.patch.object(mgr, "_maybe_create_pr", return_value="http://pr/dis"),
+        mock.patch.object(mgr, "_resolve_custodian_bin") as resolve,
+    ):
+        mgr._run_pre_pr_custodian_gate = _REAL_GATE.__get__(mgr)
+        out = mgr.finalize(req, result)
+    resolve.assert_not_called()  # disabled → never even resolves the binary
+    git.push_branch.assert_called_once_with(ws, "goal/fix-widget")
+    assert out.success is True
+    assert out.branch_pushed is True
+
+
+# ── _run_pre_pr_custodian_gate unit logic ─────────────────────────────────────
+
+
+def _gate_mgr(**kw):
+    mgr = WorkspaceManager(**kw)
+    mgr._run_pre_pr_custodian_gate = _REAL_GATE.__get__(mgr)
+    mgr._resolve_custodian_bin = _REAL_RESOLVE.__get__(mgr)
+    return mgr
+
+
+def test_gate_disabled_via_settings_returns_none(tmp_path):
+    mgr = _gate_mgr(settings=SimpleNamespace(pre_pr_custodian_gate=False))
+    req = _make_request(tmp_path)
+    # subprocess must never be called when disabled
+    with mock.patch.object(ws_mod.subprocess, "run") as run:
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+    run.assert_not_called()
+
+
+def test_gate_default_on_when_no_settings(tmp_path):
+    # No settings object → getattr default True → gate runs (resolves binary).
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value=None) as resolve,
+    ):
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+    resolve.assert_called_once()
+
+
+def test_gate_clean_exit_zero_returns_none(tmp_path):
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/x/custodian-multi"),
+        mock.patch.object(
+            ws_mod.subprocess, "run", return_value=_fake_completed(0, stdout="clean")
+        ),
+    ):
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+
+
+def test_gate_findings_exit_one_blocks_with_summary(tmp_path):
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    table = "FINDINGS\nT2: tests/test_a.py:3 no assert"
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/x/custodian-multi"),
+        mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(1, stdout=table)),
+    ):
+        out = mgr._run_pre_pr_custodian_gate(req)
+    assert out is not None
+    assert "T2" in out and "no assert" in out
+
+
+def test_gate_error_exit_two_proceeds(tmp_path):
+    # exit 2 = tool/env error (not a clean findings exit) → fail-safe proceed
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/x/custodian-multi"),
+        mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(2, stderr="boom")),
+    ):
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+
+
+def test_gate_timeout_proceeds(tmp_path):
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/x/custodian-multi"),
+        mock.patch.object(
+            ws_mod.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="custodian-multi", timeout=180),
+        ),
+    ):
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+
+
+def test_gate_passes_boundary_artifact_env(tmp_path, monkeypatch):
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    monkeypatch.setenv("REPOGRAPH_BOUNDARY_ARTIFACT_FILE", "/path/to/artifact.json")
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["env"] = kw.get("env")
+        captured["timeout"] = kw.get("timeout")
+        return _fake_completed(0)
+
+    with (
+        mock.patch.object(mgr, "_resolve_custodian_bin", return_value="/x/custodian-multi"),
+        mock.patch.object(ws_mod.subprocess, "run", side_effect=fake_run),
+    ):
+        assert mgr._run_pre_pr_custodian_gate(req) is None
+    assert captured["cmd"][1:] == [
+        "--repos",
+        str(req.workspace_path),
+        "--fail-on-findings",
+        "--no-color",
+    ]
+    assert captured["env"]["REPOGRAPH_BOUNDARY_ARTIFACT_FILE"] == "/path/to/artifact.json"
+    assert captured["timeout"] == 180
+
+
+# ── _resolve_custodian_bin fallback order ─────────────────────────────────────
+
+
+def test_resolve_custodian_prefers_repo_venv(tmp_path):
+    repo = tmp_path / "repo"
+    venv_bin = repo / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    cand = venv_bin / "custodian-multi"
+    cand.write_text("#!/bin/sh\n")
+    cfg = SimpleNamespace(local_path=str(repo), venv_dir=".venv")
+    mgr = _gate_mgr(repo_settings_lookup=lambda _k: cfg)
+    req = _make_request(tmp_path)
+    assert mgr._resolve_custodian_bin(req) == str(cand)
+
+
+def test_resolve_custodian_falls_back_to_path(tmp_path):
+    mgr = _gate_mgr()
+    req = _make_request(tmp_path)
+    with mock.patch.object(ws_mod.shutil, "which", return_value="/usr/local/bin/custodian-multi"):
+        assert mgr._resolve_custodian_bin(req) == "/usr/local/bin/custodian-multi"
+
+
+def test_resolve_custodian_falls_back_to_oc_venv(tmp_path):
+    oc_root = tmp_path / "oc"
+    oc_bin = oc_root / ".venv" / "bin"
+    oc_bin.mkdir(parents=True)
+    (oc_bin / "custodian-multi").write_text("#!/bin/sh\n")
+    mgr = _gate_mgr(oc_root=oc_root)
+    req = _make_request(tmp_path)
+    with mock.patch.object(ws_mod.shutil, "which", return_value=None):
+        assert mgr._resolve_custodian_bin(req) == str(oc_bin / "custodian-multi")
+
+
+def test_resolve_custodian_returns_none_when_absent(tmp_path):
+    oc_root = tmp_path / "oc-empty"
+    oc_root.mkdir()
+    mgr = _gate_mgr(oc_root=oc_root)
+    req = _make_request(tmp_path)
+    with mock.patch.object(ws_mod.shutil, "which", return_value=None):
+        assert mgr._resolve_custodian_bin(req) is None


### PR DESCRIPTION
**Prevent at source** (layer 3 of the autonomy hardening). The board_worker could produce code with custodian findings (e.g. T2 no-assert tests), open the PR anyway, and the required `audit` CI check went red on arrival — the #387 class (a 2.5-day stuck PR this session).

## Change
A fail-safe pre-PR gate in `WorkspaceManager.finalize`: **after the squash, before the push**, run `custodian-multi --repos <workspace> --fail-on-findings`. On a real findings exit (code 1), return a **FAILED** result (`success=False`, `failure_category=POLICY_BLOCKED`, findings in `failure_reason`) and skip the push + PR — so **no orphan branch** is pushed, and the board_worker routes it to `handle_failure` (BLOCKED/retryable; `POLICY_BLOCKED` is deliberately *not* a transient-retry category).

## Fail-safe by construction
Missing `custodian-multi` binary / crash / 180s timeout / any non-findings exit (≥2) → **degrade to prior behavior** (warn + push + PR). Only a clean findings exit blocks. Gated by `settings.pre_pr_custodian_gate` (default `True`, read via `getattr`; `False` = prior behavior).

`WorkspaceManager` gains an optional `settings` ctor arg, wired via `entrypoints/execute/main.py`.

## Tests
16 new (clean→push+PR; findings→FAILED+no-push; binary-missing/crash/timeout→proceed; disabled→skip; artifact-env passthrough). Full `tests/unit/execution` green (751).

🤖 Generated with Claude Code