### PR TITLE
fix(execution): pre-PR custodian gate requires settings (fixes #405 red main)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-06-25 — FIX: pre-PR custodian gate broke pytest (#405 merged red) — gate requires settings
+
+#405 (the pre-PR custodian gate) merged with FAILING pytest: 4 finalize tests in
+test_workspace_cov.py blocked because the gate ran a real `custodian-multi` on their fake
+workspaces. Root cause was MINE: rebasing the implementation worktree dropped the agent's
+autouse `_no_real_custodian` fixture, so nothing neutralized the gate — and the gate defaulted
+ON even with no Settings object, so it shelled out to custodian in unit tests. Fix (more robust
+than the fragile fixture): the gate now requires a real Settings object —
+`_run_pre_pr_custodian_gate` returns early when `self._settings is None`. Production always wires
+settings (entrypoints/execute/main.py, default True); the many tests that build WorkspaceManager
+without settings now skip the gate DETERMINISTICALLY (no monkeypatch to lose or pollute).
+Gate-logic tests get settings via `_gate_mgr` (defaults gate-ON); `test_gate_inactive_when_no_
+settings` replaces the old default-on test. tests/unit/execution green (751). NOTE: #405 should
+not have merged red — the reviewer/verdict path let a red PR through (separate follow-up).
+
 ## 2026-06-25 — HARDEN: pre-PR custodian gate in the executor (prevent bad PRs at source)
 
 The board_worker could produce code with custodian findings (e.g. T2 no-assert tests), open the

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -568,12 +568,17 @@ class WorkspaceManager:
               (the ``--fail-on-findings`` contract: exit code 1 with a findings
               table on stdout).
         """
-        # Gate behind the Settings flag. Read defensively so callers / tests
-        # that construct WorkspaceManager without a Settings object default to
-        # gate-ON (the safe default), and a config with the field absent (older
-        # config) also defaults ON.
-        if not getattr(self._settings, "pre_pr_custodian_gate", True):
-            logger.debug("WorkspaceManager: pre-PR custodian gate disabled via settings — skipping")
+        # Gate requires a real Settings object. Production wires one through
+        # (entrypoints/execute/main.py, default True); the many callers / tests
+        # that construct WorkspaceManager WITHOUT settings skip the gate, so unit
+        # tests never shell out to a real custodian-multi against a fake workspace
+        # — that no-settings-default-ON behavior was the #405 test-pollution
+        # regression. With a Settings object the field defaults True (older config
+        # missing the field still enables it).
+        if self._settings is None or not getattr(
+            self._settings, "pre_pr_custodian_gate", True
+        ):
+            logger.debug("WorkspaceManager: pre-PR custodian gate inactive — skipping")
             return None
 
         bin_path = self._resolve_custodian_bin(request)

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -1069,10 +1069,12 @@ def test_finalize_full_chain_with_validation_summary(tmp_path):
 
 # ── pre-PR custodian gate ─────────────────────────────────────────────────────
 #
-# The autouse _no_real_custodian fixture stubs _run_pre_pr_custodian_gate to
-# return None. The finalize-wiring tests below re-patch it explicitly per case.
-# The gate-logic tests capture the REAL unbound implementation so they exercise
-# the actual subprocess / exit-code / settings logic.
+# The gate is inactive unless WorkspaceManager is built with a Settings object
+# (production wires one; default ON), so finalize tests that construct the manager
+# without settings never run it. The finalize-wiring tests below re-patch the gate
+# method explicitly per case; the gate-logic tests capture the REAL unbound
+# implementation (and supply settings via _gate_mgr) to exercise the actual
+# subprocess / exit-code / settings logic.
 
 _REAL_GATE = WorkspaceManager.__dict__["_run_pre_pr_custodian_gate"]
 _REAL_RESOLVE = WorkspaceManager.__dict__["_resolve_custodian_bin"]
@@ -1217,6 +1219,10 @@ def test_finalize_gate_disabled_skips_entirely(tmp_path):
 
 
 def _gate_mgr(**kw):
+    # The gate now requires a real Settings object (production always wires one);
+    # default these gate-logic tests to gate-ON unless the test passes its own
+    # settings (e.g. settings=None to exercise the inactive path).
+    kw.setdefault("settings", SimpleNamespace(pre_pr_custodian_gate=True))
     mgr = WorkspaceManager(**kw)
     mgr._run_pre_pr_custodian_gate = _REAL_GATE.__get__(mgr)
     mgr._resolve_custodian_bin = _REAL_RESOLVE.__get__(mgr)
@@ -1232,15 +1238,16 @@ def test_gate_disabled_via_settings_returns_none(tmp_path):
     run.assert_not_called()
 
 
-def test_gate_default_on_when_no_settings(tmp_path):
-    # No settings object → getattr default True → gate runs (resolves binary).
-    mgr = _gate_mgr()
+def test_gate_inactive_when_no_settings(tmp_path):
+    # No Settings object → gate inactive (production always wires one), so it
+    # never even resolves the binary. Deterministic replacement for the dropped
+    # autouse stub: unit tests that build WorkspaceManager without settings never
+    # shell out to a real custodian-multi (the #405 regression).
+    mgr = _gate_mgr(settings=None)
     req = _make_request(tmp_path)
-    with (
-        mock.patch.object(mgr, "_resolve_custodian_bin", return_value=None) as resolve,
-    ):
+    with mock.patch.object(mgr, "_resolve_custodian_bin") as resolve:
         assert mgr._run_pre_pr_custodian_gate(req) is None
-    resolve.assert_called_once()
+    resolve.assert_not_called()
 
 
 def test_gate_clean_exit_zero_returns_none(tmp_path):


### PR DESCRIPTION
**Fixes main's red CI from #405.** #405 (the pre-PR custodian gate) merged with **failing pytest**: 4 finalize tests in `test_workspace_cov.py` blocked because the gate ran a real `custodian-multi` on their fake workspaces.

## Root cause (mine)
Rebasing #77's implementation worktree **dropped the agent's autouse `_no_real_custodian` fixture** (the comment survived; the fixture didn't), so nothing neutralized the gate — and the gate **defaulted ON even with no `Settings` object**, so it shelled out to custodian in unit tests. (The agent only ran `tests/unit/execution`, where local custodian happened to return clean; CI's custodian found findings → block → fail.)

## Fix (more robust than the fixture)
The gate now **requires a real `Settings` object**: `_run_pre_pr_custodian_gate` returns early when `self._settings is None`. Production always wires settings (`entrypoints/execute/main.py`, default `True`); the many tests that build `WorkspaceManager` without settings now **skip the gate deterministically** — no monkeypatch to lose or pollute. Gate-logic tests get settings via `_gate_mgr` (defaults gate-ON); `test_gate_inactive_when_no_settings` replaces the old default-on test.

`tests/unit/execution` green (751), incl. the 4 previously-failing finalize tests, with `custodian-multi` available locally (reproduces CI's condition).

> Note: #405 should not have merged with red CI — the verdict/auto-merge path let it through. Flagged as a separate follow-up.

🤖 Generated with Claude Code