### PR TITLE
test(observer): de-flake list-snapshots perf test (absolute budget)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-06-25 — FIX: de-flake observer perf test (was reliably red on CI, blocked every PR)
+
+`test_list_snapshots_scales_linearly` asserted `time_for_50 < time_for_10 * 10`, but the
+10-snapshot baseline is sub-millisecond so CI timing noise made the ratio explode — it failed
+on CI while passing locally, and (because the reviewer red-merges) it rode in on #405 and #406
+and would fail every subsequent PR's CI. Replaced the noisy ratio with a generous absolute
+budget (`time_for_50 < 2.0s`, cf. the existing 5s store budget) that still catches pathological
+scaling. My amend carrying this fix lost a force-push race when the reviewer merged #406 at my
+pre-amend SHA, so this lands as a small standalone PR.
+
 ## 2026-06-25 — FIX: pre-PR custodian gate broke pytest (#405 merged red) — gate requires settings
 
 #405 (the pre-PR custodian gate) merged with FAILING pytest: 4 finalize tests in

--- a/tests/unit/observer/test_snapshot_performance.py
+++ b/tests/unit/observer/test_snapshot_performance.py
@@ -487,14 +487,13 @@ class TestSnapshotRepositoryPerformance:
 
             times.append((batch_size, end - start))
 
-        # Times should scale reasonably (roughly linear)
-        # Ratio between 50 snapshots and 10 snapshots should be reasonable
+        # Absolute budget instead of a ratio against the 10-snapshot baseline:
+        # that baseline is sub-millisecond, so CI timing noise makes the ratio
+        # explode (this flaked on CI while passing locally — it red-merged #405
+        # and #406). Listing the largest batch well under two seconds still proves
+        # listing does not scale pathologically (cf. the 5s store budget above).
         time_for_50 = times[2][1]
-        time_for_10 = times[0][1]
-
-        # Should be at most 5x slower for 5x more snapshots
-        # (allowing some overhead but checking it doesn't scale exponentially)
-        assert time_for_50 < time_for_10 * 10
+        assert time_for_50 < 2.0, f"listing snapshots scaled poorly: {time_for_50:.3f}s"
 
     def test_load_snapshot_sub_millisecond(self, tmp_path: Path) -> None:
         """Test that loading individual snapshots is fast."""


### PR DESCRIPTION
`test_list_snapshots_scales_linearly` asserted `time_for_50 < time_for_10 * 10`, but the 10-snapshot baseline is **sub-millisecond**, so CI timing noise makes the ratio explode. It **failed on CI while passing locally** and blocked every PR — it red-merged into #405 and #406 (the reviewer auto-merges despite failing CI — flagged separately).

Replace the noisy ratio with a generous **absolute budget** (`time_for_50 < 2.0s`, cf. the existing 5s store budget) that still catches pathological scaling.

🤖 Generated with Claude Code