### PR TITLE
feat(reviewer): auto-fix failing audit (custodian) checks via agent self-heal

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,21 @@
+## 2026-06-25 — HARDEN: reviewer auto-fixes failing `audit` (custodian) checks (self-heal)
+
+The reviewer's Phase-0 ci_fix only knew how to fix ruff (`ruff --fix` codemod); a failing
+`audit` (custodian) check was "non-auto-fixable" → it advanced to self_review and the PR sat red
+forever (goal-lane #387: 2.5 days on 3 T2 no-assert findings until a human added the asserts).
+Now, when `audit` is among the failing checks, the reviewer enumerates the custodian findings
+(`custodian-multi --json`, the deterministic `findings[].sample` lines) and routes them as
+concerns into the SAME agent fix pass (`_run_fix_pass`) it already uses for self_review — the
+agent clones the PR branch into a throwaway executor workspace (never touches the live checkout),
+edits the code (adds the missing assert, etc.), and re-pushes. Bounded by the existing
+`ci_fix_attempts` cap (3, charged up-front so a crash mid-pass still counts → can never loop);
+on exhaustion it advances to self_review AND posts a PR comment listing the unresolved findings
+(escalation). Fail-safe: custodian unavailable / no findings / dispatch error → advance to
+self_review (never worse than today). Gated by `settings.reviewer_autofix_audit` (default True).
+8 new tests; reviewer suites green (256). Combined with the pre-PR gate (#77/#406) and the
+OPEN_PR_GATE staleness escape (#75), the #387 deadlock class is now prevented, self-healed, AND
+unable to halt the lane.
+
 ## 2026-06-25 — FIX: de-flake observer perf test (was reliably red on CI, blocked every PR)
 
 `test_list_snapshots_scales_linearly` asserted `time_for_50 < time_for_10 * 10`, but the

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -576,6 +576,17 @@ class Settings(BaseModel):
     self_repo_key: str | None = None
     escalation: EscalationSettings = Field(default_factory=EscalationSettings)
     scheduled_tasks: list[ScheduledTask] = Field(default_factory=list)
+    # Reviewer Phase-0 ci_fix: when a PR's `audit` (custodian) CI check fails,
+    # route the custodian findings into the SAME agent-based fix pass the reviewer
+    # uses for self_review concerns (the agent edits the code — e.g. adds a missing
+    # assert for a T2 finding — and re-pushes the PR branch), bounded by the
+    # existing ci_fix attempt cap. Custodian T2-class findings are NOT codemod-
+    # fixable (`custodian fix` can't invent an assertion), so before this the PR
+    # sat red forever (goal-lane #387: 2.5 days on 3 T2 findings until a human
+    # added the asserts). When False, audit failures fall through to self_review
+    # (the prior behavior — the PR stays red but is never auto-fixed). Read
+    # defensively (getattr) so older config files default to the prior behavior.
+    reviewer_autofix_audit: bool = True
     # Number of days a PR can remain open without activity before stale-PR scan
     # closes it and requeues the task.
     stale_pr_days: int = 7

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1866,8 +1866,83 @@ def _custodian_findings(oc_root: Path, repo_key: str, settings) -> str:
 _MAX_CI_FIX_ATTEMPTS = 3
 _CI_FIX_WAIT_SECONDS = 120  # wait after pushing before re-checking CI
 
-# Checks whose failure we know how to auto-fix locally.
+# Checks whose failure we fix with a local ruff codemod (deterministic, no agent).
 _AUTOFIX_CHECK_NAMES = {"lint (ruff)", "ruff", "lint"}
+
+# The `audit` CI check runs `custodian-multi --fail-on-findings`. Its failures are
+# NOT codemod-fixable (a custodian T2 finding — a test with no assert — can't be
+# fixed by `custodian fix`; it needs an agent to add a real assertion). So `audit`
+# is routed to the agent-based fix pass (the SAME machinery as self_review
+# concerns), kept DISTINCT from the ruff codemod path above. Match by check-name
+# prefix the way GitHub reports it (e.g. "audit", "audit (custodian): failure").
+_AUDIT_CHECK_NAMES = {"audit"}
+
+
+def _is_audit_check(check_name: str) -> bool:
+    cn = str(check_name).lower().split(":")[0].strip()
+    return cn in _AUDIT_CHECK_NAMES or any(cn.startswith(k) for k in _AUDIT_CHECK_NAMES)
+
+
+def _custodian_audit_findings(repo_cfg, oc_root: Path) -> list[str]:
+    """Per-finding custodian detail for the repo's local clone, as a list of
+    ``"<code>: <path:line: message>"`` strings — the exact lines the `audit` CI
+    check (``custodian-multi --fail-on-findings``) would report.
+
+    These are DETERMINISTIC tool output (the structured ``findings[].sample``
+    field of ``custodian-multi --json``), not free-form model text, so they are
+    safe to hand to the fix pass as concrete fix instructions. Returns ``[]``
+    (NOT an error) when custodian is unavailable, the repo has no local clone, or
+    anything fails — the caller treats an empty list as "can't enumerate" and
+    falls back to self_review, so this never makes the reviewer worse than today.
+    """
+    local_path = getattr(repo_cfg, "local_path", None) if repo_cfg else None
+    if not local_path or not Path(local_path).exists():
+        return []
+    custodian_bin = oc_root / ".venv" / "bin" / "custodian-multi"
+    if not custodian_bin.exists():
+        return []
+    try:
+        proc = subprocess.run(
+            [str(custodian_bin), "--repos", str(local_path), "--json", "--fail-on-findings"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        output = (proc.stdout or "").strip()
+        if not output:
+            return []
+        results = json.loads(output)
+        findings: list[str] = []
+        for repo_result in results:
+            for finding in repo_result.get("findings") or []:
+                code = str(finding.get("code", "?"))
+                sample = str(finding.get("sample", "")).strip()
+                findings.append(f"{code}: {sample}" if sample else code)
+        return findings
+    except Exception as exc:  # noqa: BLE001 — enumeration must never raise into the loop
+        logger.warning("pr_review_watcher: custodian audit enumeration failed — %s", exc)
+        return []
+
+
+def _format_audit_concerns(findings: list[str]) -> str:
+    """Render custodian findings as an enumerated concern list for the fix pass.
+
+    The leading directive frames them as the `audit` (custodian) CI gate so the
+    agent resolves the ROOT cause (e.g. adds a real assertion for a T2 finding,
+    not a `# noqa`). Output flows through ``_build_fix_goal`` →
+    ``_structure_concerns`` which splits this bulleted list back into one
+    addressable concern per finding.
+    """
+    bullets = "\n".join(f"- {f}" for f in findings)
+    return (
+        "The `audit` CI check (custodian-multi --fail-on-findings) is failing on "
+        "this PR's branch with the following findings. Resolve the ROOT CAUSE of "
+        "each in the code (for example, a `T2` finding means a test function has "
+        "no assert — add a real, meaningful assertion that exercises the behavior "
+        "under test; do NOT silence the detector with a noqa/ignore). After "
+        "fixing, re-run `custodian-multi --repos . --fail-on-findings` and confirm "
+        "it is clean:\n\n" + bullets
+    )
 
 
 def _ci_checks_failing(
@@ -1880,6 +1955,141 @@ def _ci_checks_failing(
         return []
 
 
+def _phase0_audit_autofix(
+    state: dict,
+    state_path: Path,
+    pr_data: dict,
+    gh_client,
+    owner: str,
+    repo: str,
+    oc_root: Path,
+    config_path: Path,
+    settings,
+    *,
+    failed: list[str],
+    attempts: int,
+) -> None:
+    """Fix a PR failing the `audit` (custodian) CI check via the agent-based fix
+    pass — the SAME machinery (`_run_fix_pass`) the reviewer uses for self_review
+    concerns, which clones the PR branch into a throwaway executor workspace (it
+    never touches the live ``local_path`` checkout), has the agent edit the code,
+    and re-pushes the PR branch.
+
+    Bounds (this can NEVER loop forever):
+      - Shares the ``ci_fix_attempts`` budget capped at ``_MAX_CI_FIX_ATTEMPTS``.
+        On exhaustion → advance to self_review (today's fall-through) AND post a
+        PR comment listing the unresolved custodian findings (escalation /
+        visibility), so a stuck custodian PR is never silently abandoned.
+      - The post-push ``_CI_FIX_WAIT_SECONDS`` gate (enforced by the caller)
+        spaces attempts out so CI can re-run between them.
+
+    Fail-safe: on ANY error (custodian can't enumerate, dispatch raises, no head
+    ref) → log a WARNING and advance to self_review. Never worse than today.
+    """
+    pr_number = int(state["pr_number"])
+    repo_key = state["repo_key"]
+    repo_cfg = settings.repos.get(repo_key)
+    head_ref = ((pr_data.get("head") or {}).get("ref") or "").strip()
+
+    # Enumerate the actual findings up front — both the dispatch (fix instructions)
+    # and the exhaustion comment (escalation) need them. Empty means we couldn't
+    # enumerate (custodian unavailable / errored): there is nothing concrete to
+    # hand the agent, so fall back rather than dispatch a blind pass.
+    findings = _custodian_audit_findings(repo_cfg, oc_root)
+
+    if attempts >= _MAX_CI_FIX_ATTEMPTS:
+        # Exhausted: advance to self_review (today's behavior) + post escalation.
+        logger.info(
+            "pr_review_watcher: PR #%d exhausted %d audit fix attempts — advancing to "
+            "self_review and posting unresolved-findings comment",
+            pr_number,
+            attempts,
+        )
+        if findings:
+            try:
+                marker = getattr(settings.reviewer, "bot_comment_marker", "")
+                # findings are deterministic custodian tool output, but defang
+                # belt-and-suspenders before reflecting to GitHub (a `sample` line
+                # echoes a repo path/symbol name that is ultimately repo content).
+                body = (
+                    f"{marker}\n"
+                    f"**Audit auto-fix exhausted** — the `audit` (custodian) check is still "
+                    f"failing after {attempts} automated fix attempt(s). These findings "
+                    f"remain unresolved and need a human:\n\n"
+                    + sanitize_for_comment("\n".join(f"- {f}" for f in findings))
+                )
+                gh_client.post_comment(owner, repo, pr_number, body)
+            except Exception as exc:  # noqa: BLE001 — comment is best-effort visibility
+                logger.warning(
+                    "pr_review_watcher: PR #%d failed to post audit-exhausted comment — %s",
+                    pr_number,
+                    exc,
+                )
+        state["phase"] = "self_review"
+        _save_state(state_path, state)
+        return
+
+    if not head_ref or not findings:
+        # No head ref (can't push a fix) or nothing enumerable → fall back safely.
+        logger.warning(
+            "pr_review_watcher: PR #%d audit auto-fix unavailable (head_ref=%r, "
+            "%d findings) — advancing to self_review",
+            pr_number,
+            head_ref,
+            len(findings),
+        )
+        state["phase"] = "self_review"
+        _save_state(state_path, state)
+        return
+
+    # Pre-save the attempt counter BEFORE the (potentially long) agent pass so the
+    # budget survives a restart mid-dispatch — exactly like the ruff path records
+    # its attempt only on a successful push, but here we charge the attempt up
+    # front because the agent pass is expensive and a crash mid-pass must still
+    # count toward the cap (otherwise a repeatedly-crashing pass loops forever).
+    state["ci_fix_attempts"] = attempts + 1
+    state["ci_fix_last_push_at"] = datetime.now(UTC).isoformat()
+    _save_state(state_path, state)
+
+    concerns = _format_audit_concerns(findings)
+    logger.info(
+        "pr_review_watcher: PR #%d audit failing (%s) — dispatching agent fix pass "
+        "%d/%d on branch %s (%d findings)",
+        pr_number,
+        [c for c in failed if _is_audit_check(c)],
+        attempts + 1,
+        _MAX_CI_FIX_ATTEMPTS,
+        head_ref,
+        len(findings),
+    )
+    try:
+        pushed = _run_fix_pass(
+            oc_root,
+            config_path,
+            repo_key,
+            head_ref,
+            concerns,
+            settings,
+            state_key=state["state_key"],
+        )
+    except Exception as exc:  # noqa: BLE001 — dispatch failure must never wedge the loop
+        logger.warning("pr_review_watcher: PR #%d audit fix dispatch error — %s", pr_number, exc)
+        state["phase"] = "self_review"
+        _save_state(state_path, state)
+        return
+
+    if not pushed:
+        logger.warning(
+            "pr_review_watcher: PR #%d audit fix pass pushed no changes (attempt %d/%d)",
+            pr_number,
+            attempts + 1,
+            _MAX_CI_FIX_ATTEMPTS,
+        )
+    # Stay in ci_fix: the caller's _CI_FIX_WAIT_SECONDS gate defers the next sweep
+    # so CI re-runs on the pushed commit; the next pass re-enumerates findings and
+    # either sees green (→ self_review) or charges the next bounded attempt.
+
+
 def _phase0_ci_fix(
     state: dict,
     state_path: Path,
@@ -1889,10 +2099,19 @@ def _phase0_ci_fix(
     repo: str,
     oc_root: Path,
     settings,
+    config_path: Path | None = None,
 ) -> None:
     """Phase 0: if CI is failing on an autonomy PR, push an auto-fix and wait.
 
+    Two fix paths, both bounded by ``ci_fix_attempts``/``_MAX_CI_FIX_ATTEMPTS``:
+      - ruff lint failures → a deterministic local ``ruff --fix`` codemod.
+      - ``audit`` (custodian) failures → the agent-based fix pass (same machinery
+        as self_review concerns), since custodian findings aren't codemod-fixable.
+
     Transitions to self_review when CI is green or when attempts are exhausted.
+    ``config_path`` is required for the audit agent-fix path (it dispatches the
+    executor pipeline); when None that path degrades to the prior behavior
+    (audit failures fall through to self_review).
     """
     pr_number = int(state["pr_number"])
     repo_key = state["repo_key"]
@@ -1925,6 +2144,36 @@ def _phase0_ci_fix(
             return
 
     attempts = state.get("ci_fix_attempts", 0)
+
+    # --- audit (custodian) failures → agent-based fix pass ---------------------
+    # Routed BEFORE the generic attempt-cap and the ruff codemod path: custodian
+    # findings (e.g. a T2 "test with no assert") are not codemod-fixable, so they
+    # go to the SAME agent-fix machinery the reviewer uses for self_review
+    # concerns. The branch owns its own exhaustion handling (escalation comment),
+    # so it must run before the shared cap check below. Gated on the opt-out
+    # setting and on having a config_path to dispatch the pipeline; either absent
+    # degrades to the prior fall-through-to-self_review behavior.
+    audit_failing = [c for c in failed if _is_audit_check(c)]
+    if (
+        audit_failing
+        and getattr(settings, "reviewer_autofix_audit", False)
+        and config_path is not None
+    ):
+        _phase0_audit_autofix(
+            state,
+            state_path,
+            pr_data,
+            gh_client,
+            owner,
+            repo,
+            oc_root,
+            config_path,
+            settings,
+            failed=failed,
+            attempts=attempts,
+        )
+        return
+
     if attempts >= _MAX_CI_FIX_ATTEMPTS:
         logger.info(
             "pr_review_watcher: PR #%d exhausted %d CI fix attempts (%s still failing) "
@@ -3516,7 +3765,9 @@ def _poll_once(oc_root: Path, config_path: Path, settings) -> None:
 
             try:
                 if phase == "ci_fix":
-                    _phase0_ci_fix(state, sp, pr_data, gh_client, owner, repo, oc_root, settings)
+                    _phase0_ci_fix(
+                        state, sp, pr_data, gh_client, owner, repo, oc_root, settings, config_path
+                    )
                 elif phase == "self_review":
                     _phase1(
                         state, sp, pr_data, gh_client, owner, repo, oc_root, config_path, settings

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -1251,6 +1251,242 @@ def test_run_fix_pass_noop_returns_false(tmp_path: Path) -> None:
     assert pushed is False
 
 
+# ── Phase 0 audit (custodian) auto-fix → agent fix pass ───────────────────────
+
+
+def _audit_settings(*, autofix_audit: bool = True) -> MagicMock:
+    """Settings for the audit auto-fix path: a repo with a local clone + venv,
+    a git token, and the reviewer_autofix_audit toggle."""
+    repo_cfg = MagicMock(
+        local_path="/tmp/does-not-matter",  # _run_fix_pass is mocked; never read
+        venv_dir=".venv",
+        default_branch="main",
+        ci_ignored_checks=[],
+        clone_url=f"git@github.com:owner/{REPO_KEY}.git",
+    )
+    settings = MagicMock(
+        reviewer=REVIEWER_CFG,
+        repos={REPO_KEY: repo_cfg},
+        plane=MagicMock(base_url="http://plane.local", project_id="proj", workspace_slug="ws"),
+        git=MagicMock(author_name="Bot", author_email="bot@x"),
+        reviewer_autofix_audit=autofix_audit,
+    )
+    settings.git_token.return_value = "tok"
+    return settings
+
+
+# Two custodian findings as the enumeration helper yields them.
+_AUDIT_FINDINGS = [
+    "T2: tests/unit/test_x.py:1: test_x() — no assert",
+    "T2: tests/unit/test_y.py:9: test_y() — no assert",
+]
+
+
+def test_audit_failure_dispatches_agent_fix_pass(tmp_path: Path) -> None:
+    """(a) An `audit`-failing PR routes the custodian findings into the SAME
+    agent fix pass the reviewer uses for self_review concerns, and stays in
+    ci_fix (does NOT prematurely advance to self_review)."""
+    settings = _audit_settings()
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit (custodian): failure"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    with (
+        patch.object(watcher, "_custodian_audit_findings", return_value=list(_AUDIT_FINDINGS)),
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    # The agent fix pass was dispatched on the PR head branch with the findings
+    # carried as concerns (NOT the ruff codemod).
+    fix.assert_called_once()
+    args, kwargs = fix.call_args
+    # positional: (oc_root, config_path, repo_key, head_ref, concerns, settings)
+    assert args[3] == f"goal/{PR_NUMBER}"  # head_ref
+    concerns = args[4]
+    assert "audit" in concerns.lower() and "custodian" in concerns.lower()
+    assert "test_x.py" in concerns and "test_y.py" in concerns
+    # Bounded counter charged; still in ci_fix so CI can re-run on the push.
+    assert state["ci_fix_attempts"] == 1
+    assert state["phase"] == "ci_fix"
+    assert state.get("ci_fix_last_push_at")
+
+
+def test_audit_autofix_bounded_then_escalates(tmp_path: Path) -> None:
+    """(b) When attempts are exhausted, advance to self_review (today's behavior)
+    AND post an escalation comment listing the unresolved findings — never an
+    infinite loop, and the dispatch is NOT re-run."""
+    settings = _audit_settings()
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+    state["ci_fix_attempts"] = watcher._MAX_CI_FIX_ATTEMPTS  # already exhausted
+    # Past the post-push wait window so the cap check is reached this sweep.
+    state["ci_fix_last_push_at"] = None
+
+    with (
+        patch.object(watcher, "_custodian_audit_findings", return_value=list(_AUDIT_FINDINGS)),
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    fix.assert_not_called()  # no further dispatch once exhausted
+    assert state["phase"] == "self_review"  # advances like today
+    # Escalation comment posted, listing the unresolved findings for a human.
+    gh.post_comment.assert_called_once()
+    body = gh.post_comment.call_args.args[3]
+    assert "test_x.py" in body and "test_y.py" in body
+    assert "exhausted" in body.lower()
+
+
+def test_audit_autofix_dispatch_error_falls_back(tmp_path: Path) -> None:
+    """(c) Any error in the fix path → fall back to self_review (fail-safe);
+    never worse than today."""
+    settings = _audit_settings()
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    with (
+        patch.object(watcher, "_custodian_audit_findings", return_value=list(_AUDIT_FINDINGS)),
+        patch.object(watcher, "_run_fix_pass", side_effect=RuntimeError("dispatch boom")),
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    assert state["phase"] == "self_review"  # safe fall-back, no crash propagated
+
+
+def test_audit_autofix_no_findings_falls_back(tmp_path: Path) -> None:
+    """Custodian unavailable / can't enumerate (empty findings) → fall back to
+    self_review without dispatching a blind agent pass (fail-safe)."""
+    settings = _audit_settings()
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    with (
+        patch.object(watcher, "_custodian_audit_findings", return_value=[]),
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    fix.assert_not_called()
+    assert state["phase"] == "self_review"
+
+
+def test_audit_autofix_disabled_falls_back(tmp_path: Path) -> None:
+    """(e) reviewer_autofix_audit=False → prior behavior: audit failure falls
+    through to self_review, no custodian enumeration, no agent dispatch."""
+    settings = _audit_settings(autofix_audit=False)
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    with (
+        patch.object(
+            watcher, "_custodian_audit_findings", return_value=list(_AUDIT_FINDINGS)
+        ) as enum,
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    enum.assert_not_called()
+    fix.assert_not_called()
+    assert state["phase"] == "self_review"
+
+
+def test_audit_autofix_no_config_path_falls_back(tmp_path: Path) -> None:
+    """No config_path (can't dispatch the pipeline) → prior behavior, fail-safe."""
+    settings = _audit_settings()
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["audit"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    with (
+        patch.object(
+            watcher, "_custodian_audit_findings", return_value=list(_AUDIT_FINDINGS)
+        ) as enum,
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+    ):
+        # config_path omitted (defaults to None).
+        watcher._phase0_ci_fix(state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings)
+
+    enum.assert_not_called()
+    fix.assert_not_called()
+    assert state["phase"] == "self_review"
+
+
+def test_ruff_path_unchanged_when_only_ruff_fails(tmp_path: Path) -> None:
+    """(d) The ruff codemod path is unchanged: a ruff-only failure runs the local
+    ruff --fix in an isolated worktree and never touches the agent fix pass, even
+    with reviewer_autofix_audit on."""
+    local_path = tmp_path / "live_checkout"
+    (local_path / ".venv" / "bin").mkdir(parents=True)
+    ruff = local_path / ".venv" / "bin" / "ruff"
+    ruff.write_text("#!/bin/sh\nexit 0\n")
+    ruff.chmod(0o755)
+
+    repo_cfg = MagicMock(
+        local_path=str(local_path),
+        venv_dir=".venv",
+        default_branch="main",
+        ci_ignored_checks=[],
+        clone_url=f"git@github.com:owner/{REPO_KEY}.git",
+    )
+    settings = MagicMock(
+        reviewer=REVIEWER_CFG,
+        repos={REPO_KEY: repo_cfg},
+        git=MagicMock(author_name="Bot", author_email="bot@x"),
+        reviewer_autofix_audit=True,
+    )
+    settings.git_token.return_value = "tok"
+
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["Lint (ruff): failure"]
+
+    state, sp = _make_state(tmp_path)
+    state["phase"] = "ci_fix"
+
+    calls: list[dict] = []
+    with (
+        patch.object(watcher.subprocess, "run", side_effect=_record_git_runs(calls)),
+        patch.object(watcher, "_run_fix_pass", return_value=True) as fix,
+        patch.object(watcher, "_custodian_audit_findings", return_value=[]) as enum,
+    ):
+        watcher._phase0_ci_fix(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, settings, tmp_path / "cfg.yaml"
+        )
+
+    # Ruff path: isolated worktree + push, and NO audit machinery touched.
+    fix.assert_not_called()
+    enum.assert_not_called()
+    push_calls = [c for c in calls if c["argv"][:1] == ["git"] and "push" in c["argv"]]
+    assert push_calls, "expected the ruff codemod to push from the isolated worktree"
+    assert state["ci_fix_attempts"] == 1
+
+
 # ── Self-Heal Ladder Phase 1: structured concerns + anti-no-op acceptance bar ──
 
 


### PR DESCRIPTION
**Self-heal layer** of the autonomy hardening. The reviewer's Phase-0 `ci_fix` only fixed ruff (`ruff --fix` codemod); a failing **`audit`** (custodian) check was treated as "non-auto-fixable" → it advanced to self_review and the PR sat red forever (goal-lane #387: 2.5 days on 3 T2 no-assert findings until a human added the asserts).

## Change
When `audit` is among the failing checks, the reviewer enumerates the custodian findings (`custodian-multi --json`, the deterministic `findings[].sample` lines) and routes them as concerns into the **same agent fix pass (`_run_fix_pass`)** it already uses for self_review concerns — which clones the PR branch into a throwaway executor workspace (never touches the live checkout), has the agent edit the code (add the missing assert, etc.), and re-pushes.

## Bounded + fail-safe
- Bounded by the existing `ci_fix_attempts` cap (3), **charged up-front** so a crash mid-pass still counts → can never loop.
- On exhaustion → advance to self_review **and** post a PR comment listing the unresolved findings (escalation).
- Any error (custodian unavailable / no findings / dispatch raises) → advance to self_review (never worse than today).
- Gated by `settings.reviewer_autofix_audit` (default `True`).

8 new tests; reviewer suites green (256). Reuses `_run_fix_pass` (already isolated via clone, per #399) — not `_isolated_repo_checkout` (which is for in-process git-verb passes).

Together with the pre-PR gate (#77/#406) and the OPEN_PR_GATE staleness escape (#75), the #387 deadlock class is **prevented, self-healed, and unable to halt the lane**.

🤖 Generated with Claude Code