### PR TITLE
fix(reviewer): require CI green before self-merge (stop merging red PRs)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-06-25 — FIX: reviewer self-merged RED PRs — add a CI-green precondition to _merge_and_done
+
+The reviewer auto-merged #405 and #406 with FAILING CI. Root cause: `_merge_and_done` (the single
+self-merge path) gated only on `get_mergeable()` (conflicts) + opt-in branch-protection/sensitive-
+path gates, then published its own `reviewer-verdict=success` and called `merge_pr` (REST). Because
+the fleet satisfies branch protection with that self-issued verdict, GitHub does NOT enforce the
+other required checks on the fleet's own merge — so the reviewer had to verify CI itself, and
+didn't. Fix: before publishing the verdict + merging, require CI GREEN — refuse if
+`get_failed_checks` is non-empty OR `get_incomplete_checks` is non-empty (a queued/in_progress run
+has no conclusion yet, so a "nothing failed?" check would merge a still-running head; the helper's
+own docstring says a green gate MUST treat incomplete as not-green). Centralized in
+`_merge_and_done` so it covers every merge path (self_review LGTM, ci_validated_after_retraction,
+auto_merge_on_ci_green). On not-green → leave the state file, re-checked next poll (the ci_fix /
+audit-autofix loop drives it to green or escalates). `_make_gh` test mock now defaults
+`get_failed_checks=[]` (green). 2 new tests (red → no merge, pending → no merge); reviewer suites
+green (246). Closes the [[oc-autonomy-hardening-deadlock]] critical follow-up.
+
 ## 2026-06-25 — HARDEN: reviewer auto-fixes failing `audit` (custodian) checks (self-heal)
 
 The reviewer's Phase-0 ci_fix only knew how to fix ruff (`ruff --fix` codemod); a failing

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1224,6 +1224,39 @@ def _merge_and_done(
             pr_number,
         )
         return  # leave state file — operator must inspect/ack
+    # CI-GREEN PRECONDITION. The fleet self-merges via the REST merge API plus the
+    # self-issued reviewer-verdict published just below, which together clear branch
+    # protection WITHOUT GitHub enforcing the OTHER required checks — so the reviewer
+    # must verify CI itself. A PR is green only when nothing has FAILED *and* nothing
+    # is still PENDING: a queued/in_progress run has no conclusion yet, so
+    # get_failed_checks alone cannot see it. Refusing here is what stops the fleet
+    # from self-merging red (the hole that landed #405 and #406 with red pytest/perf).
+    _repo_cfg_ci = (
+        settings.repos.get(state["repo_key"]) if getattr(settings, "repos", None) else None
+    )
+    _ci_ignored = list(getattr(_repo_cfg_ci, "ci_ignored_checks", []) or [])
+    _ci_failed = (
+        gh_client.get_failed_checks(
+            owner, repo, pr_number, pr_data=_pr_data, ignored_checks=_ci_ignored
+        )
+        or []
+    )
+    _ci_pending = (
+        gh_client.get_incomplete_checks(
+            owner, repo, pr_number, pr_data=_pr_data, ignored_checks=_ci_ignored
+        )
+        or []
+    )
+    if _ci_failed or _ci_pending:
+        logger.warning(
+            "pr_review_watcher: PR #%d NOT merged — CI not green (failed=%s pending=%s); "
+            "re-evaluated next poll (reason=%s)",
+            pr_number,
+            _ci_failed,
+            _ci_pending,
+            reason,
+        )
+        return  # leave state file — re-checked next poll once CI settles
     # Bless this head with reviewer-verdict=success BEFORE merging, so the
     # required status check is satisfied for the fleet's own merge — and so the
     # non-LGTM merge paths (e.g. ci_validated_after_retraction) also clear the

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -70,8 +70,10 @@ def _make_gh(*, comment_id: int = 0) -> MagicMock:
     gh.post_comment.return_value = {"id": comment_id} if comment_id else {}
     gh.merge_pr.return_value = {}
     gh.update_comment.return_value = {}
-    # Default: CI has settled (no checks still running). The premature-green gate
-    # treats a non-empty result as "not green yet"; tests override as needed.
+    # Default: CI is green — nothing failed and nothing still running. The merge
+    # gate (_merge_and_done) treats a non-empty failed OR incomplete result as
+    # "not green yet" and refuses to merge; tests override as needed.
+    gh.get_failed_checks.return_value = []
     gh.get_incomplete_checks.return_value = []
     # Default: CI has reported on the current head (Guard C requires ≥1 completed
     # check before declaring green); the "no CI on this head yet" path overrides [].
@@ -137,6 +139,49 @@ def test_phase1_lgtm_merges_and_removes_state(tmp_path: Path) -> None:
 
     gh.merge_pr.assert_called_once_with("owner", "repo", PR_NUMBER, merge_method="squash")
     assert not sp.exists()
+
+
+def test_phase1_lgtm_does_not_merge_when_ci_failing(tmp_path: Path) -> None:
+    """LGTM must NOT self-merge a PR with failing CI — the #405/#406 hole."""
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _make_gh()
+    gh.get_failed_checks.return_value = ["Test (pytest): assertion error"]
+
+    with (
+        patch.object(
+            watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+        ),
+        patch.object(watcher, "_plane_client") as mock_pc,
+    ):
+        mock_pc.return_value = MagicMock()
+        mock_pc.return_value.close = MagicMock()
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    gh.merge_pr.assert_not_called()
+
+
+def test_phase1_lgtm_does_not_merge_when_ci_pending(tmp_path: Path) -> None:
+    """LGTM must NOT self-merge before CI settles (a still-running check has no
+    conclusion yet, so a 'nothing failed?' check would merge a green-so-far head)."""
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _make_gh()
+    gh.get_incomplete_checks.return_value = ["Test (pytest)"]
+
+    with (
+        patch.object(
+            watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+        ),
+        patch.object(watcher, "_plane_client") as mock_pc,
+    ):
+        mock_pc.return_value = MagicMock()
+        mock_pc.return_value.close = MagicMock()
+        watcher._phase1(
+            state, sp, _pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    gh.merge_pr.assert_not_called()
 
 
 def test_phase1_lgtm_increments_loop_count(tmp_path: Path) -> None:


### PR DESCRIPTION
**Fixes the reviewer self-merging RED PRs** — it auto-merged #405 and #406 with failing CI during the hardening work.

## Root cause
`_merge_and_done` (the single self-merge path) gated only on `get_mergeable()` (conflicts) + opt-in branch-protection / sensitive-path gates, then **published its own `reviewer-verdict=success`** and called `merge_pr` (REST). Because that self-issued verdict satisfies branch protection, GitHub does **not** enforce the *other* required checks on the fleet's own merge — so the reviewer had to verify CI itself, and didn't.

## Fix
Add a **CI-green precondition** to `_merge_and_done` (before the verdict + merge, so it covers every merge path — self_review LGTM, `ci_validated_after_retraction`, `auto_merge_on_ci_green`): refuse to merge if `get_failed_checks` is non-empty **OR** `get_incomplete_checks` is non-empty.

The *pending* half matters: a queued/in_progress run has no conclusion yet, so a "nothing failed?" check would merge a still-running head (the helper's own docstring says a green gate MUST treat incomplete as not-green). On not-green → leave the state file; re-checked next poll once CI settles (the ci_fix / audit-autofix loop drives it green or escalates).

- `_make_gh` mock now defaults `get_failed_checks=[]` (green).
- 2 new tests: LGTM + CI-failing → no merge; LGTM + CI-pending → no merge. Reviewer suites green (**246**).

🤖 Generated with Claude Code