### PR TITLE
[DO NOT MERGE] e2e probe: red PR to verify CI-green merge gate

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,9 @@
+## 2026-06-25 — PROBE (throwaway, never merged): red-PR to verify the CI-green merge gate e2e
+
+A deliberately-failing test on a throwaway branch (`test/ci-green-gate-e2e-probe`) to confirm,
+against real GitHub CI, that the deployed `_merge_and_done` refuses to self-merge a red PR.
+Branch is closed + deleted after the check; this entry never reaches main.
+
 ## 2026-06-25 — FIX: reviewer self-merged RED PRs — add a CI-green precondition to _merge_and_done
 
 The reviewer auto-merged #405 and #406 with FAILING CI. Root cause: `_merge_and_done` (the single

--- a/tests/unit/test_ci_green_gate_e2e_probe.py
+++ b/tests/unit/test_ci_green_gate_e2e_probe.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""E2E probe — a deliberately-failing test used ONLY on a throwaway branch to
+verify the reviewer's CI-green merge gate refuses to self-merge a red PR.
+
+This is never merged to main; the branch is deleted after the verification.
+"""
+
+
+def test_ci_green_gate_e2e_probe() -> None:
+    # Intentional failure to make the "Test (pytest)" check RED so we can confirm
+    # _merge_and_done refuses to merge a PR whose CI is not green.
+    assert False, "intentional e2e probe failure (CI-green merge-gate verification)"


### PR DESCRIPTION
Throwaway probe: a deliberately pytest-failing test to verify the deployed _merge_and_done refuses to self-merge a red PR. Closed + deleted after the check. 🤖 Generated with Claude Code