### PR TITLE
fix(sandbox): bwrap-in-netns composed fail-closed — skip cap-drop for bwrap payload

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,22 @@
+## 2026-06-25 — FIX: SBX layers composed fail-CLOSED — bwrap-in-netns cap-drop broke the executor
+
+The goal lane churned claim→"execute produced no result" every ~30s: the executor subprocess never
+launched. Root cause is a fail-CLOSED *composition* of two individually-fail-open SBX layers. With
+both `OC_BWRAP_SANDBOX=1` and `OC_EGRESS_NETNS=1`, `run_executor` wraps the bwrap argv inside the
+pasta netns, whose in-netns setup script runs `setpriv --inh-caps=-all --bounding-set=-all
+--ambient-caps=-all` *before* exec'ing bwrap. That emptied bounding set PERSISTS into bwrap's child
+user namespace and masks the CAP_SYS_ADMIN bwrap needs to create its pid/uts/ipc namespaces, so
+bwrap aborts `Creating new namespace failed: Operation not permitted` (rc 1) → no result → churn.
+Isolated with a 4-config bisect under the live env: bwrap alone ✓, pasta+bwrap (no setpriv) ✓,
+pasta+setpriv+bwrap ✗ — the cap-drop is the culprit. It is also *redundant* in this mode: the agent
+runs in bwrap's child userns and (per netns.py §3) cannot reach the parent-owned netns firewall
+regardless of caps. Fix: `maybe_netns` takes `drop_caps` (default True); `run_executor` passes
+`drop_caps=False` when the resolved payload is actually bwrap (basename check, so the sandbox
+fail-open path that returns the bare executor STILL gets the cap-drop). The firewall (`OUTPUT DROP`)
+stays unconditional. Verified end to end under the real live env: bwrap+netns now rc 0, raw external
+egress still BLOCKED, loopback proxy still CONNECTED. 4 new tests incl. a decisive bwrap-in-netns
+e2e regression. Unblocks goal-task autonomy; continues [[oc-autonomy-hardening-deadlock]].
+
 ## 2026-06-25 — FIX: reviewer self-merged RED PRs — add a CI-green precondition to _merge_and_done
 
 The reviewer auto-merged #405 and #406 with FAILING CI. Root cause: `_merge_and_done` (the single

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -313,8 +313,18 @@ def run_executor(
     # whose only egress is the proxy. Opt-in (OC_EGRESS_NETNS=1) + fail-open. Wraps
     # bwrap but stays INSIDE the systemd-run scope (so systemd-run keeps the host
     # user bus). See netns.py.
+    #
+    # Skip the netns cap-drop when the payload is ACTUALLY bwrap (basename check, not
+    # the flag — `maybe_sandbox` fail-opens to the bare command when bwrap is
+    # unavailable, and that bare executor DOES need the cap-drop). bwrap is its own
+    # containment, and `setpriv --bounding-set=-all` would mask the CAP_SYS_ADMIN it
+    # needs to build its namespaces (fail-CLOSED composition). See maybe_netns.
+    sandboxed = bool(run_cmd) and os.path.basename(run_cmd[0]) == "bwrap"
     run_cmd = maybe_netns(
-        run_cmd, proxy_url=_resolve_egress_proxy(env), enabled=netns_enabled()
+        run_cmd,
+        proxy_url=_resolve_egress_proxy(env),
+        enabled=netns_enabled(),
+        drop_caps=not sandboxed,
     )
     rlimits = os.environ.get(_RLIMIT_ENV_FLAG) == "1"
     run_cmd = resource_limit_argv(run_cmd, enabled=rlimits)

--- a/src/operations_center/entrypoints/board_worker/netns.py
+++ b/src/operations_center/entrypoints/board_worker/netns.py
@@ -48,10 +48,22 @@ _EXTRA_PORTS_ENV = "OC_EGRESS_NETNS_PORTS"  # comma-sep extra host-loopback port
 _OLLAMA_PORT = 11434
 
 # In-netns setup: lock egress to loopback (the proxy lives on the host loopback that
-# pasta maps in), drop CAP_NET_ADMIN so the agent can't undo it, then exec the cmd.
-# Fail-open at every step: a missing/failing iptables or setpriv degrades to running
-# the command without that protection rather than halting (§0.1).
-_SETUP_SCRIPT = r"""
+# pasta maps in), then exec the cmd. Fail-open at every step: a missing/failing
+# iptables or setpriv degrades to running the command without that protection rather
+# than halting (§0.1).
+#
+# The cap-drop (`setpriv --bounding-set=-all`) is applied ONLY when the payload runs
+# DIRECTLY in this netns (sandbox off). When the payload is the bwrap sandbox the
+# cap-drop is both redundant AND fatal, so it is omitted (see ``maybe_netns``'s
+# ``drop_caps``):
+#   - redundant: the agent runs inside bwrap's CHILD user namespace and cannot reach
+#     this parent-owned netns firewall regardless of its caps (docstring §3);
+#   - fatal: `--bounding-set=-all` empties the bounding set, which PERSISTS into
+#     bwrap's child userns and masks CAP_SYS_ADMIN there, so bwrap can no longer
+#     create its pid/uts/ipc namespaces — bwrap aborts with "Creating new namespace
+#     failed: Operation not permitted" and the two SBX layers compose fail-CLOSED
+#     (the executor never starts; the lane churns claim→no-result forever).
+_FIREWALL_SETUP = r"""
 set -u
 if command -v iptables >/dev/null 2>&1; then
   iptables -A OUTPUT -o lo -j ACCEPT 2>/dev/null \
@@ -59,11 +71,27 @@ if command -v iptables >/dev/null 2>&1; then
     && iptables -P OUTPUT DROP 2>/dev/null \
     || echo "oc-netns: egress filter not applied (fail-open)" >&2
 fi
+"""
+
+# Drop all caps before exec so a payload running DIRECTLY in the netns can't flush the
+# firewall. Fail-open: a missing setpriv degrades to exec'ing without the drop.
+_CAPDROP_EXEC = r"""
 if command -v setpriv >/dev/null 2>&1; then
   exec setpriv --inh-caps=-all --bounding-set=-all --ambient-caps=-all "$@"
 fi
 exec "$@"
 """
+
+# Sandboxed payload: bwrap is the containment, so exec it WITH caps intact (it needs
+# CAP_SYS_ADMIN in its own child userns to build its namespaces).
+_PLAIN_EXEC = r"""
+exec "$@"
+"""
+
+
+def _setup_script(*, drop_caps: bool) -> str:
+    """In-netns setup script: firewall always; the cap-drop only when ``drop_caps``."""
+    return _FIREWALL_SETUP + (_CAPDROP_EXEC if drop_caps else _PLAIN_EXEC)
 
 
 def netns_enabled() -> bool:
@@ -103,13 +131,19 @@ def _forward_ports(proxy_url: str) -> list[int]:
 
 
 def maybe_netns(
-    cmd: Sequence[str], *, proxy_url: str | None, enabled: bool
+    cmd: Sequence[str], *, proxy_url: str | None, enabled: bool, drop_caps: bool = True
 ) -> list[str]:
     """Wrap ``cmd`` to run inside a pasta netns whose only egress is the proxy.
 
     pasta ``-T <port>`` forwards each host-loopback service (proxy, ollama) to the
     netns ``127.0.0.1:<port>`` so the executor's existing env (``HTTPS_PROXY=
     127.0.0.1:8889``) works unchanged; the in-netns iptables drops everything else.
+
+    ``drop_caps`` (default True) runs ``setpriv --bounding-set=-all`` before exec so a
+    payload running directly in the netns can't flush the firewall. Pass ``False``
+    when ``cmd`` is the bwrap sandbox: the cap-drop is redundant there (bwrap's child
+    userns can't reach this netns firewall) and fatal (it masks the CAP_SYS_ADMIN
+    bwrap needs to build its namespaces). See ``_setup_script``.
 
     Fail-open: returns ``cmd`` unchanged when disabled, when pasta is unavailable,
     or when no egress proxy is configured (a locked netns with no proxy would have
@@ -136,7 +170,8 @@ def maybe_netns(
     forwards: list[str] = []
     for port in _forward_ports(proxy_url):
         forwards += ["-T", str(port)]
-    return [pasta, "--config-net", *forwards, "--", "sh", "-c", _SETUP_SCRIPT, "oc-netns", *cmd]
+    script = _setup_script(drop_caps=drop_caps)
+    return [pasta, "--config-net", *forwards, "--", "sh", "-c", script, "oc-netns", *cmd]
 
 
 __all__ = [

--- a/tests/unit/entrypoints/board_worker/test_netns.py
+++ b/tests/unit/entrypoints/board_worker/test_netns.py
@@ -71,6 +71,33 @@ def test_enabled_wraps_with_pasta(monkeypatch):
     assert "setpriv" in script and "bounding-set=-all" in script  # cap-drop
 
 
+def test_drop_caps_false_omits_capdrop_but_keeps_firewall(monkeypatch):
+    # Sandboxed payload (bwrap is the containment): the cap-drop MUST be omitted — a
+    # `setpriv --bounding-set=-all` in front of bwrap empties the bounding set, which
+    # persists into bwrap's child userns and masks the CAP_SYS_ADMIN it needs to build
+    # its namespaces (the two SBX layers would compose fail-CLOSED). The egress
+    # firewall must STILL be applied.
+    monkeypatch.setattr(netns, "pasta_path", lambda: "/usr/bin/pasta")
+    out = netns.maybe_netns(
+        ["bwrap", "exec"], proxy_url="http://127.0.0.1:8889", enabled=True, drop_caps=False
+    )
+    script = out[out.index("-c") + 1]
+    assert "setpriv" not in script  # no cap-drop in front of bwrap
+    assert "OUTPUT DROP" in script  # firewall still confines egress
+    assert out[-2:] == ["bwrap", "exec"]  # inner cmd preserved at the tail
+
+
+def test_drop_caps_true_includes_capdrop(monkeypatch):
+    # Non-sandboxed payload running DIRECTLY in the netns: the cap-drop is what stops
+    # the payload flushing the firewall, so it MUST be present (and is the default).
+    monkeypatch.setattr(netns, "pasta_path", lambda: "/usr/bin/pasta")
+    out = netns.maybe_netns(
+        ["python3", "x"], proxy_url="http://127.0.0.1:8889", enabled=True, drop_caps=True
+    )
+    script = out[out.index("-c") + 1]
+    assert "setpriv" in script and "bounding-set=-all" in script
+
+
 def test_extra_ports_forwarded(monkeypatch):
     monkeypatch.setattr(netns, "pasta_path", lambda: "/usr/bin/pasta")
     monkeypatch.setenv("OC_EGRESS_NETNS_PORTS", "9000, 9001")
@@ -83,6 +110,43 @@ def test_enabled_flag(monkeypatch):
     assert netns.netns_enabled() is True
     monkeypatch.delenv("OC_EGRESS_NETNS")
     assert netns.netns_enabled() is False
+
+
+def test_run_executor_skips_capdrop_only_for_bwrap_payload(monkeypatch, tmp_path):
+    # Integration of the fix: run_executor tells maybe_netns to KEEP caps
+    # (drop_caps=False) only when the wrapped payload is ACTUALLY bwrap, and to drop
+    # them otherwise — including the sandbox fail-open path where maybe_sandbox returns
+    # the bare executor (which DOES need the cap-drop). Keyed off the resolved argv,
+    # not the OC_BWRAP_SANDBOX flag.
+    from operations_center.entrypoints.board_worker import _subprocess
+
+    captured = {}
+
+    def fake_netns(cmd, *, proxy_url, enabled, drop_caps=True):
+        captured["drop_caps"] = drop_caps
+        return list(cmd)
+
+    monkeypatch.setattr(_subprocess, "maybe_netns", fake_netns)
+    monkeypatch.setattr(_subprocess, "netns_enabled", lambda: True)
+    monkeypatch.setattr(
+        _subprocess, "_resolve_egress_proxy", lambda env: "http://127.0.0.1:8889"
+    )
+    monkeypatch.setattr(_subprocess.subprocess, "run", lambda *a, **k: "RAN")
+    monkeypatch.delenv("OC_SANDBOX_RLIMITS", raising=False)
+
+    # payload IS bwrap -> keep caps so bwrap can build its namespaces
+    monkeypatch.setattr(_subprocess, "maybe_sandbox", lambda cmd, **kw: ["bwrap", *cmd])
+    _subprocess.run_executor(
+        ["echo", "hi"], oc_root=tmp_path, rw_root=tmp_path, workspace=tmp_path, env={}
+    )
+    assert captured["drop_caps"] is False
+
+    # sandbox fail-open returns the bare executor -> drop caps (it runs in the netns)
+    monkeypatch.setattr(_subprocess, "maybe_sandbox", lambda cmd, **kw: list(cmd))
+    _subprocess.run_executor(
+        ["python3", "x"], oc_root=tmp_path, rw_root=tmp_path, workspace=tmp_path, env={}
+    )
+    assert captured["drop_caps"] is True
 
 
 _HAVE_TOOLS = bool(
@@ -161,3 +225,26 @@ def test_kernel_enforcement_end_to_end():
     assert "FLUSH denied" in out, out
     assert f"OK 127.0.0.1 {marker} PROXY-OK" in out, out
     assert "BLOCKED 1.1.1.1 443" in out, out
+
+
+@pytest.mark.skipif(
+    not (_pasta_netns_functional() and shutil.which("bwrap")),
+    reason="pasta netns + bwrap not both functional here (CI/container)",
+)
+def test_bwrap_inside_netns_runs_when_caps_kept():
+    """Decisive regression for the fail-CLOSED SBX composition: a bwrap payload wrapped
+    by the netns with ``drop_caps=False`` can build its pid/uts/ipc namespaces and run.
+    With the cap-drop in front of it (``drop_caps=True``) bwrap instead aborts with
+    "Creating new namespace failed: Operation not permitted" — the emptied bounding set
+    persists into bwrap's child userns and masks CAP_SYS_ADMIN."""
+    bwrap_cmd = [
+        "bwrap", "--unshare-pid", "--unshare-uts", "--unshare-ipc",
+        "--ro-bind", "/", "/", "--proc", "/proc", "--dev", "/dev",
+        "--", "/bin/echo", "NS-OK",
+    ]
+    wrapped = netns.maybe_netns(
+        list(bwrap_cmd), proxy_url="http://127.0.0.1:18889", enabled=True, drop_caps=False
+    )
+    assert wrapped[0].endswith("pasta")
+    r = subprocess.run(wrapped, capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0 and "NS-OK" in r.stdout, (r.returncode, r.stderr)


### PR DESCRIPTION
## Problem

The goal lane churned `claim → "execute produced no result"` every ~30s — the executor subprocess **never launched**. This is a fail-**CLOSED** composition of two individually-fail-**open** SBX layers.

With both `OC_BWRAP_SANDBOX=1` and `OC_EGRESS_NETNS=1`, `run_executor` wraps the bwrap argv inside the pasta netns, whose in-netns setup script runs `setpriv --inh-caps=-all --bounding-set=-all --ambient-caps=-all` **before** exec'ing bwrap. That emptied bounding set **persists into bwrap's child user namespace** and masks the `CAP_SYS_ADMIN` bwrap needs to create its pid/uts/ipc namespaces, so bwrap aborts:

```
bwrap: Creating new namespace failed: Operation not permitted
```

→ no result → churn (burning retry budget on real backlog tasks).

### Bisect (under the live env)

| config | result |
|---|---|
| bwrap alone | ✅ rc 0 |
| pasta + bwrap (no setpriv) | ✅ rc 0 |
| pasta + `setpriv --bounding-set=-all` + bwrap | ❌ namespace EPERM |

The cap-drop is the culprit — and it's **redundant** in this mode: the agent runs in bwrap's child userns and (per `netns.py` §3) cannot reach the parent-owned netns firewall regardless of caps.

## Fix

- `maybe_netns` gains `drop_caps` (default `True`).
- `run_executor` passes `drop_caps=False` **only when the resolved payload is actually bwrap** (basename check — so the sandbox fail-open path that returns the bare executor STILL gets the cap-drop).
- The egress firewall (`OUTPUT DROP`) stays **unconditional**.

## Verification (real live env)

- bwrap + netns → **rc 0** (was EPERM).
- raw external egress (`1.1.1.1:443`) → still **BLOCKED**.
- loopback proxy (`127.0.0.1:8889`) → still **CONNECTED**.
- 4 new tests incl. a decisive bwrap-in-netns e2e regression; pre-existing kernel-enforcement test still green. `test_netns.py`: 14 passed.

Continues the autonomy-hardening deadlock work (#403–#409).

🤖 Generated with Claude Code