### PR TITLE
fix(sandbox): bind the venv's uv interpreter so bwrap can execvp it

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-06-25 — FIX: sandbox didn't bind the venv's uv interpreter — bwrap execvp failed → no result
+
+Second, distinct cause of the goal-lane "execute produced no result" churn (the first was the
+bwrap-in-netns cap-drop). With that fixed, the executor STILL fast-failed — dispatch discards the
+execute subprocess's stderr, so the real error was masked. Reproduced the plan→execute path under the
+live env and captured it: `bwrap: execvp /…/OperationsCenter/.venv/bin/python: No such file or
+directory`. Root cause: `.venv/bin/python` is a symlink to a **uv-managed** interpreter
+(`~/.local/share/uv/python/cpython-3.12.13-…/bin/python3.12`) that lives OUTSIDE the bound system
+dirs. The sandbox bound `.venv` but not the symlink target, so it dangled inside bwrap and execvp
+failed before execute.main even started (→ no result.json → churn). The venv was re-synced to that
+uv interpreter on Jun 22, AFTER the Jun 21 end-to-end success — the next layer of the documented
+sandbox-completeness cascade (`…→venv-PATH→venv-interpreter`). Fix: `_toolchain_ro_binds` resolves
+`.venv/bin/python` and ro-binds the interpreter's install root (parent of its bin/), skipped when it
+already lives under a bound system dir. Verified e2e: the plan→execute repro now returns rc 0 with
+result.json written (success path). 2 new sandbox tests. With the cap-drop fix, both together unblock
+goal-task autonomy; continues [[oc-autonomy-hardening-deadlock]].
+
 ## 2026-06-25 — FIX: pin CI custodian to pyproject's SHA — Custodian@main regression red-failed the fleet
 
 The required `audit` gate started failing fleet-wide on a phantom LOW finding. Root cause is upstream,

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -248,6 +248,21 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     # The OC source tree (PYTHONPATH) + its venv (python/pytest/ruff).
     add(str(oc_root / "src"))
     add(str(oc_root / ".venv"))
+    # A uv-managed venv symlinks `.venv/bin/python` to an interpreter OUTSIDE the
+    # bound system dirs (under ~/.local/share/uv/python/cpython-*/). Binding only
+    # .venv leaves that symlink dangling inside the sandbox, so bwrap aborts
+    # `execvp .../.venv/bin/python: No such file or directory` and the executor
+    # never starts (→ "execute produced no result", the lane churns). Bind the
+    # interpreter's install root (parent of its bin/) so the symlink resolves.
+    # Skipped when the interpreter already lives under a bound system dir (a system
+    # python needs no extra bind).
+    real_py = _real(str(oc_root / ".venv" / "bin" / "python"))
+    if real_py:
+        interp_root = os.path.dirname(os.path.dirname(real_py))
+        if not any(
+            interp_root == d or interp_root.startswith(d + os.sep) for d in _RO_SYSTEM_DIRS
+        ):
+            add(interp_root)
     # Editable-installed sibling-repo deps (team_executor, dag_executor, …).
     for d in _editable_install_dirs(oc_root):
         add(d)

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -129,6 +129,51 @@ class TestArgvContract:
         path_val = argv[argv.index("PATH") + 1]
         assert path_val.startswith(f"{ws}/.venv/bin:")
 
+    def test_venv_python_interpreter_root_is_bound(self, tmp_path: Path):
+        # A uv-managed venv symlinks .venv/bin/python to an interpreter OUTSIDE the
+        # bound system dirs; the sandbox must bind that interpreter's install root or
+        # bwrap can't execvp the venv python ("No such file or directory") and the
+        # executor never starts. Regression for the "execute produced no result" churn.
+        oc = tmp_path / "oc"
+        (oc / ".venv" / "bin").mkdir(parents=True)
+        interp_root = tmp_path / "uv" / "cpython-3.12"  # outside /usr
+        (interp_root / "bin").mkdir(parents=True)
+        real_py = interp_root / "bin" / "python3.12"
+        real_py.write_text("#!/bin/true\n")
+        real_py.chmod(0o755)
+        (oc / ".venv" / "bin" / "python").symlink_to(real_py)
+        ws = oc / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["python"], oc_root=oc, rw_root=ws, env=_env(tmp_path))
+        ro_srcs = [
+            argv[i + 1] for i, a in enumerate(argv) if a == "--ro-bind" and i + 1 < len(argv)
+        ]
+        assert str(interp_root) in ro_srcs, ro_srcs
+
+    def test_interpreter_under_system_dir_not_double_bound(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # When .venv/bin/python resolves under a bound system dir, the guard skips the
+        # extra interpreter bind (the system dir is already bound) — it appears once,
+        # not twice. Simulate by treating the fake interpreter's root as a system dir.
+        oc = tmp_path / "oc"
+        (oc / ".venv" / "bin").mkdir(parents=True)
+        interp_root = tmp_path / "syspy"
+        (interp_root / "bin").mkdir(parents=True)
+        real_py = interp_root / "bin" / "python3.12"
+        real_py.write_text("#!/bin/true\n")
+        real_py.chmod(0o755)
+        (oc / ".venv" / "bin" / "python").symlink_to(real_py)
+        monkeypatch.setattr(sbx, "_RO_SYSTEM_DIRS", (str(interp_root),))
+        ws = oc / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["python"], oc_root=oc, rw_root=ws, env=_env(tmp_path))
+        ro_srcs = [
+            argv[i + 1] for i, a in enumerate(argv) if a == "--ro-bind" and i + 1 < len(argv)
+        ]
+        # bound once (as a system dir), NOT a second time as a toolchain entry
+        assert ro_srcs.count(str(interp_root)) == 1, ro_srcs
+
 
 class TestFailOpen:
     def test_disabled_returns_unchanged(self, tmp_path: Path):


### PR DESCRIPTION
## Problem

Second, distinct cause of the goal-lane `execute produced no result` churn (the first was the bwrap-in-netns cap-drop, #411). With that fixed, the executor **still** fast-failed. Dispatch discards the execute subprocess's stderr, so the real error was masked. Reproduced the plan→execute path under the live env and captured it:

```
bwrap: execvp /…/OperationsCenter/.venv/bin/python: No such file or directory
```

`.venv/bin/python` is a symlink to a **uv-managed** interpreter (`~/.local/share/uv/python/cpython-3.12.13-…/bin/python3.12`) that lives **outside** the bound system dirs. The sandbox bound `.venv` but not the symlink target, so it dangled inside bwrap and execvp failed **before** `execute.main` even started → no `result.json` → churn.

The venv was re-synced to that uv interpreter on Jun 22, **after** the Jun 21 end-to-end success — the next layer of the documented sandbox-completeness cascade (`…→venv-PATH→venv-interpreter`).

## Fix

`_toolchain_ro_binds` resolves `.venv/bin/python` and ro-binds the interpreter's **install root** (parent of its `bin/`), skipped when it already lives under a bound system dir (a system python needs no extra bind).

## Verification

- The same plan→execute repro under the live env now returns **rc 0 with `result.json` written** (success path) — the executor runs end to end.
- 2 new sandbox tests (uv-interpreter bound; system-python not double-bound). `test_sandbox.py`: 42 passed. Custodian: clean.

Together with #411 this unblocks goal-task autonomy.

🤖 Generated with Claude Code