### PR TITLE
fix(sandbox): bind uv's version-alias interpreter dir too (complete #412)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-06-25 — FIX: complete the venv-interpreter bind — uv's version-alias symlink was still dangling
+
+The first interpreter-bind fix (#412) was INCOMPLETE: it bound only the realpath'd patch dir
+(`…/uv/python/cpython-3.12.13-…`), but `.venv/bin/python` targets a **version-alias** path
+(`…/uv/python/cpython-3.12-…/bin/python3.12`) whose dir is itself a symlink to the patch dir. The
+alias path was never bound, so inside the sandbox it still dangled → `bwrap: execvp …/.venv/bin/python:
+No such file or directory` → still no result. Two compounding reasons it slipped through #412: (1) the
+#412 "rc 0" verification ran execute.main via a PLAIN subprocess (un-sandboxed), so it never exercised
+the bwrap execvp at all — fixed by verifying through `run_executor` (bwrap+netns) this time; (2)
+`add()` realpaths every bind, which collapses the alias back onto the patch dir, so even returning the
+alias from the resolver lost it. Fix: `_venv_interpreter_roots(.venv/bin/python)` returns the install
+root of BOTH the realpath target AND the immediate `readlink` target (the alias dir), and the loop
+appends them VERBATIM (bypassing `add()`'s realpath). Verified end to end via the real sandboxed path:
+`run_executor` of the venv python → rc 0; a full plan→execute through `run_executor` → rc 0 with
+result.json written. 43 sandbox tests (added a uv version-alias case). Completes #412; both bwrap-namespace
+and venv-interpreter blockers are now closed. [[oc-autonomy-hardening-deadlock]]
+
 ## 2026-06-25 — FIX: sandbox didn't bind the venv's uv interpreter — bwrap execvp failed → no result
 
 Second, distinct cause of the goal-lane "execute produced no result" churn (the first was the

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -235,6 +235,40 @@ def _editable_install_dirs(oc_root: Path) -> list[str]:
     return dirs
 
 
+def _venv_interpreter_roots(venv_python: Path) -> list[str]:
+    """Install root(s) to ro-bind so ``venv_python`` resolves inside the sandbox.
+
+    Returns the install root (the dir holding ``bin/``) of both the realpath'd
+    interpreter AND the immediate symlink target, deduped. A uv-managed venv points
+    ``.venv/bin/python`` at a version-alias dir (``cpython-3.12-…``) that is itself a
+    symlink to the patch dir (``cpython-3.12.13-…``); binding only the realpath'd
+    patch dir leaves that alias path dangling, so both are needed. Existing/real
+    paths only (a copied — non-symlink — venv python yields just its own root)."""
+    roots: list[str] = []
+
+    def _push(root: str) -> None:
+        if root and os.path.exists(root) and root not in roots:
+            roots.append(root)
+
+    vp = str(venv_python)
+    rp = _real(vp)  # realpath target's install root (has bin + lib)
+    if rp:
+        _push(os.path.dirname(os.path.dirname(rp)))
+    # The immediate symlink target's install root — the version-alias dir the symlink
+    # traverses. Do NOT realpath it: realpath would collapse the very alias we must
+    # bind (its dir is itself a symlink to the patch dir already added above).
+    try:
+        if os.path.islink(vp):
+            link = os.readlink(vp)
+            link_abs = (
+                link if os.path.isabs(link) else os.path.normpath(os.path.join(os.path.dirname(vp), link))
+            )
+            _push(os.path.dirname(os.path.dirname(link_abs)))
+    except OSError:
+        pass
+    return roots
+
+
 def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     """Read-only host paths the executor toolchain needs. Derived from the
     resolved binaries + env so it tracks where things actually live."""
@@ -249,20 +283,25 @@ def _toolchain_ro_binds(oc_root: Path, env: dict) -> list[str]:
     add(str(oc_root / "src"))
     add(str(oc_root / ".venv"))
     # A uv-managed venv symlinks `.venv/bin/python` to an interpreter OUTSIDE the
-    # bound system dirs (under ~/.local/share/uv/python/cpython-*/). Binding only
-    # .venv leaves that symlink dangling inside the sandbox, so bwrap aborts
-    # `execvp .../.venv/bin/python: No such file or directory` and the executor
-    # never starts (→ "execute produced no result", the lane churns). Bind the
-    # interpreter's install root (parent of its bin/) so the symlink resolves.
-    # Skipped when the interpreter already lives under a bound system dir (a system
-    # python needs no extra bind).
-    real_py = _real(str(oc_root / ".venv" / "bin" / "python"))
-    if real_py:
-        interp_root = os.path.dirname(os.path.dirname(real_py))
-        if not any(
+    # bound system dirs, AND through a version-alias symlink:
+    #   .venv/bin/python -> <store>/cpython-3.12-<plat>/bin/python3.12
+    #   <store>/cpython-3.12-<plat>        (a symlink) -> <store>/cpython-3.12.13-<plat>
+    # Binding only the *realpath'd* patch dir (cpython-3.12.13-…) leaves the ALIAS
+    # path (cpython-3.12-…) the symlink actually traverses dangling inside the
+    # sandbox, so bwrap aborts `execvp .../.venv/bin/python: No such file or
+    # directory` and the executor never starts (→ "execute produced no result", the
+    # lane churns). Bind the install root of BOTH the realpath target and the
+    # immediate symlink target so the whole chain resolves. Each is skipped when it
+    # already lives under a bound system dir (a system python needs no extra bind).
+    # Append VERBATIM, not via add(): add() realpaths, which would collapse the
+    # version-alias dir back onto the patch dir and lose the alias path the venv
+    # symlink actually traverses. _venv_interpreter_roots already returns existing,
+    # correct paths.
+    for interp_root in _venv_interpreter_roots(oc_root / ".venv" / "bin" / "python"):
+        if interp_root not in binds and not any(
             interp_root == d or interp_root.startswith(d + os.sep) for d in _RO_SYSTEM_DIRS
         ):
-            add(interp_root)
+            binds.append(interp_root)
     # Editable-installed sibling-repo deps (team_executor, dag_executor, …).
     for d in _editable_install_dirs(oc_root):
         add(d)

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -150,6 +150,33 @@ class TestArgvContract:
         ]
         assert str(interp_root) in ro_srcs, ro_srcs
 
+    def test_venv_python_version_alias_binds_both_roots(self, tmp_path: Path):
+        # uv layout: .venv/bin/python -> <store>/cpython-3.12-/bin/python3.12, and
+        # <store>/cpython-3.12- is itself a symlink to the patch dir <store>/
+        # cpython-3.12.13-. Binding only the realpath'd patch dir leaves the ALIAS
+        # path dangling in the sandbox (bwrap execvp fails). BOTH install roots must
+        # be bound. Regression for the incomplete first interpreter-bind fix.
+        oc = tmp_path / "oc"
+        (oc / ".venv" / "bin").mkdir(parents=True)
+        store = tmp_path / "store"
+        store.mkdir()
+        real_dir = store / "cpython-3.12.13"
+        (real_dir / "bin").mkdir(parents=True)
+        real_py = real_dir / "bin" / "python3.12"
+        real_py.write_text("#!/bin/true\n")
+        real_py.chmod(0o755)
+        alias_dir = store / "cpython-3.12"  # version-alias DIR symlink -> patch dir
+        alias_dir.symlink_to(real_dir)
+        (oc / ".venv" / "bin" / "python").symlink_to(alias_dir / "bin" / "python3.12")
+        ws = oc / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["python"], oc_root=oc, rw_root=ws, env=_env(tmp_path))
+        ro_srcs = [
+            argv[i + 1] for i, a in enumerate(argv) if a == "--ro-bind" and i + 1 < len(argv)
+        ]
+        assert str(real_dir) in ro_srcs, ro_srcs  # realpath target's root (bin + lib)
+        assert str(alias_dir) in ro_srcs, ro_srcs  # the alias path the symlink traverses
+
     def test_interpreter_under_system_dir_not_double_bound(
         self, tmp_path: Path, monkeypatch
     ):


### PR DESCRIPTION
## Problem

#412 was **incomplete**. It bound only the realpath'd patch dir (`…/uv/python/cpython-3.12.13-…`), but `.venv/bin/python` targets a **version-alias** path:

```
.venv/bin/python -> …/uv/python/cpython-3.12-…/bin/python3.12
…/uv/python/cpython-3.12-…   (a symlink) -> …/uv/python/cpython-3.12.13-…
```

The alias path was never bound, so it still dangled inside the sandbox → `bwrap: execvp …/.venv/bin/python: No such file or directory` → still "execute produced no result".

Two reasons it slipped past #412:
1. The #412 "rc 0" verification ran `execute.main` via a **plain subprocess (un-sandboxed)**, so it never exercised the bwrap execvp. This PR verifies through `run_executor` (bwrap+netns), the real dispatch path.
2. `add()` realpaths every bind, which **collapses the alias** back onto the patch dir — so even returning the alias from the resolver lost it.

## Fix

`_venv_interpreter_roots(.venv/bin/python)` returns the install root of **both** the realpath target and the immediate `readlink` target (the alias dir); the loop appends them **verbatim** (bypassing `add()`'s realpath).

## Verification (real sandboxed path)

- `run_executor` of the venv python → **rc 0** (`SANDBOXED_EXECVP_OK`).
- Full plan→execute through `run_executor` → **rc 0 with result.json written**.
- 43 sandbox tests (added a uv version-alias case).

Completes #412; both the bwrap-namespace (#411) and venv-interpreter blockers are now closed.

🤖 Generated with Claude Code