### PR TITLE
fix(executor): match workspace venv python to the wheelhouse + self-heal backends

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-06-25 — HARDEN: executor workspace env — wheelhouse/venv python match + self-healing backends
+
+With the sandbox launch fixed, a goal task ran real work (~20s) but FAILED at two env layers; both
+fixed here so this CLASS can't block autonomy. (1) **Wheelhouse/venv python drift.** The workspace
+venv was created with `repo_cfg.python_binary` = `python3` (host system **3.14**), but the offline
+wheelhouse is built with OC's venv (**3.12**) → cp312 wheels. The `pip --no-index --find-links` install
+then failed `PyYAML>=6.0 … from versions: none`, `.venv/bin/pytest` exit 127, task failed. Single
+source of truth: `provision_env` now exports `OC_WHEELHOUSE_PYTHON` (the interpreter that BUILT the
+wheelhouse) and `WorkspaceManager._maybe_bootstrap` creates the venv with it (falls back to
+`python_binary` when no wheelhouse) — so the venv and the wheels are tag-locked to the same python and
+can't drift. Verified in-sandbox: 3.14 → "No matching distribution"; `$OC_WHEELHOUSE_PYTHON` (3.12) →
+"Successfully installed PyYAML-6.0.3 … pytest-9.1.1". (2) **Execute backend missing.** `team_executor`/
+`dag_executor` are sibling CHECKOUTS, not declared OC deps — `uv pip install -e .[dev]` never installs
+them and the Jun-22 re-sync DROPPED them, so `backends/team_executor/adapter.py` hit
+`from team_executor.executor import …` → ImportError → "team_executor not installed" → every goal task
+failed at execute. They import on neither host NOR sandbox. Fix: repaired OC's venv now
+(`uv pip install -e ../TeamExecutor -e ../DAGExecutor`; repograph plane override intact;
+`_editable_install_dirs` now binds both into the sandbox; SANDBOX_BACKEND_IMPORT_OK), and made it
+durable — `scripts/operations-center.sh` gains `ensure_executor_backends`, a SELF-HEALING check that
+(re)installs the siblings whenever they aren't importable, every launch (import probe is ~free), so a
+future drop recovers on the next fleet start instead of silently stalling the lane. All 4 recent goal
+failures were this same env pair (the `EffectiveRepoGraph … videofoundry … manifest not found` line is
+non-fatal — PrivateManifest isn't bound in the sandbox; "continuing without graph context"). 4 tests.
+Both env blockers now clear; [[oc-autonomy-hardening-deadlock]].
+
 ## 2026-06-25 — FIX: complete the venv-interpreter bind — uv's version-alias symlink was still dangling
 
 The first interpreter-bind fix (#412) was INCOMPLETE: it bound only the realpath'd patch dir

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -66,6 +66,32 @@ ensure_venv() {
     uv pip install --python "${VENV_DIR}/bin/python" -e '.[dev]'
     touch "${BOOTSTRAP_STAMP}"
   fi
+  ensure_executor_backends
+}
+
+# The execute backends (team_executor, dag_executor) are sibling CHECKOUTS, not
+# declared OC dependencies — `uv pip install -e .[dev]` never installs them and a
+# `uv sync` / venv-recreate actively DROPS them. When that happens the executor
+# can't load its backend ("team_executor not installed: No module named
+# 'team_executor'") and EVERY goal task fails at execute → the whole lane stalls
+# with no obvious cause. Self-heal: whenever the backends aren't importable, (re)install
+# them editable. Runs every launch but the import check is ~free and the install only
+# fires when actually missing, so a mid-life drop recovers on the next fleet start
+# rather than blocking autonomy until a human notices.
+ensure_executor_backends() {
+  if "${VENV_DIR}/bin/python" -c "import team_executor, dag_executor" 2>/dev/null; then
+    return 0
+  fi
+  echo "operations-center.sh: executor backends missing — (re)installing siblings" >&2
+  local _sib
+  for _sib in TeamExecutor DAGExecutor; do
+    if [[ -f "${ROOT_DIR}/../${_sib}/pyproject.toml" ]]; then
+      uv pip install --python "${VENV_DIR}/bin/python" -e "${ROOT_DIR}/../${_sib}" \
+        || echo "operations-center.sh: WARNING failed to install ${_sib} — execute backend unavailable" >&2
+    else
+      echo "operations-center.sh: WARNING sibling checkout ${_sib} not found at ${ROOT_DIR}/../${_sib}" >&2
+    fi
+  done
 }
 
 # Ensure the user-level pip config requires a virtualenv for all pip installs.

--- a/src/operations_center/entrypoints/board_worker/wheelhouse.py
+++ b/src/operations_center/entrypoints/board_worker/wheelhouse.py
@@ -167,6 +167,15 @@ def provision_env(
     bwrap sandbox is on (else ``{}``, fail-open). Wires the offline wheelhouse
     (``OC_WHEELHOUSE``) and the tiktoken encoding cache (``TIKTOKEN_CACHE_DIR``) —
     both bound into the sandbox — so the executor needs no pypi / CDN egress.
+
+    Also exports ``OC_WHEELHOUSE_PYTHON`` = the interpreter that BUILT the
+    wheelhouse. The offline install is by definition tag-locked to that interpreter
+    (``pip --no-index --find-links`` over cp-tagged wheels), so the consumer — the
+    workspace venv (``WorkspaceManager._maybe_bootstrap``) — must be created with the
+    SAME interpreter or the wheels won't match (the host ``python3`` may be a
+    different version than OC's venv; e.g. 3.14 vs a cp312 wheelhouse). Single source
+    of truth: whatever python builds the wheelhouse also creates the venv that
+    installs from it, so the two can never drift.
     """
     if os.environ.get("OC_BWRAP_SANDBOX") != "1":
         return {}
@@ -174,6 +183,7 @@ def provision_env(
     wh = ensure_wheelhouse(repo_key, repo_local_path, python_bin=python_bin)
     if wh is not None:
         out["OC_WHEELHOUSE"] = str(wh)
+        out["OC_WHEELHOUSE_PYTHON"] = python_bin
     tk = ensure_tiktoken_cache(python_bin)
     if tk is not None:
         out["TIKTOKEN_CACHE_DIR"] = str(tk)

--- a/src/operations_center/execution/workspace.py
+++ b/src/operations_center/execution/workspace.py
@@ -1000,7 +1000,19 @@ class WorkspaceManager:
 
         # Standard path: create venv, run install_dev_command.
         venv_dir = getattr(repo_cfg, "venv_dir", None) or ".venv"
-        python_bin = getattr(repo_cfg, "python_binary", None) or "python3"
+        # When an offline wheelhouse is in play, its wheels are tag-locked to the
+        # interpreter that built it (OC_WHEELHOUSE_PYTHON, set by provision_env). The
+        # venv that installs from it MUST be that same interpreter or the cp-tagged
+        # wheels won't match (e.g. host python3=3.14 vs a cp312 wheelhouse → the
+        # `--no-index --find-links` install fails "from versions: none" and the task
+        # is blocked). Prefer it; fall back to the repo's configured python_binary
+        # (and finally `python3`) when no wheelhouse is active. Single source of truth
+        # with the wheelhouse builder, so the two can never drift.
+        python_bin = (
+            os.environ.get("OC_WHEELHOUSE_PYTHON")
+            or getattr(repo_cfg, "python_binary", None)
+            or "python3"
+        )
         try:
             subprocess.run(
                 [python_bin, "-m", "venv", venv_dir],

--- a/tests/unit/entrypoints/board_worker/test_wheelhouse.py
+++ b/tests/unit/entrypoints/board_worker/test_wheelhouse.py
@@ -129,6 +129,20 @@ def test_provision_env_merges_wheelhouse_and_tiktoken(monkeypatch, tmp_path):
     monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
     monkeypatch.setattr(wh, "ensure_wheelhouse", lambda *a, **k: tmp_path / "wh")
     monkeypatch.setattr(wh, "ensure_tiktoken_cache", lambda *a, **k: tmp_path / "tk")
-    out = wh.provision_env("Repo", "/x", python_bin="python3")
+    out = wh.provision_env("Repo", "/x", python_bin="/oc/.venv/bin/python")
     assert out["OC_WHEELHOUSE"] == str(tmp_path / "wh")
     assert out["TIKTOKEN_CACHE_DIR"] == str(tmp_path / "tk")
+    # The wheels are tag-locked to the builder python — export it so the workspace
+    # venv is created with the SAME interpreter (else cp-tag mismatch breaks install).
+    assert out["OC_WHEELHOUSE_PYTHON"] == "/oc/.venv/bin/python"
+
+
+def test_provision_env_no_wheelhouse_python_when_build_fails(monkeypatch, tmp_path):
+    # Wheelhouse build fail-opens to None → no OC_WHEELHOUSE and no OC_WHEELHOUSE_PYTHON
+    # (nothing to tag-match against); tiktoken can still wire independently.
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    monkeypatch.setattr(wh, "ensure_wheelhouse", lambda *a, **k: None)
+    monkeypatch.setattr(wh, "ensure_tiktoken_cache", lambda *a, **k: tmp_path / "tk")
+    out = wh.provision_env("Repo", "/x", python_bin="/oc/.venv/bin/python")
+    assert "OC_WHEELHOUSE" not in out
+    assert "OC_WHEELHOUSE_PYTHON" not in out

--- a/tests/unit/execution/test_workspace_cov.py
+++ b/tests/unit/execution/test_workspace_cov.py
@@ -860,7 +860,8 @@ def test_bootstrap_custom_command_failure_aborts(tmp_path):
     assert run.call_count == 1
 
 
-def test_bootstrap_standard_install_success(tmp_path):
+def test_bootstrap_standard_install_success(tmp_path, monkeypatch):
+    monkeypatch.delenv("OC_WHEELHOUSE_PYTHON", raising=False)
     ws = tmp_path / "ws"
     cfg = SimpleNamespace(
         bootstrap_commands=None,
@@ -879,7 +880,45 @@ def test_bootstrap_standard_install_success(tmp_path):
     assert install_call.args[0] == "pip install -e ."
 
 
-def test_bootstrap_defaults_venv_and_python(tmp_path):
+def test_bootstrap_uses_wheelhouse_python_over_config(tmp_path, monkeypatch):
+    # When an offline wheelhouse is active, the venv MUST be created with the
+    # interpreter that BUILT it (OC_WHEELHOUSE_PYTHON), not the repo's python_binary,
+    # or the cp-tagged wheels won't match and the `--no-index` install fails (the
+    # host python3 may be a different version than a cp312 wheelhouse).
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=".venv",
+        python_binary="python3",
+    )
+    monkeypatch.setenv("OC_WHEELHOUSE_PYTHON", "/oc/.venv/bin/python")
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    venv_call = run.call_args_list[0]
+    assert venv_call.args[0] == ["/oc/.venv/bin/python", "-m", "venv", ".venv"]
+
+
+def test_bootstrap_falls_back_to_config_python_without_wheelhouse(tmp_path, monkeypatch):
+    # No wheelhouse → use the repo's configured python_binary (existing behavior).
+    monkeypatch.delenv("OC_WHEELHOUSE_PYTHON", raising=False)
+    ws = tmp_path / "ws"
+    cfg = SimpleNamespace(
+        bootstrap_commands=None,
+        install_dev_command="pip install -e .",
+        venv_dir=".venv",
+        python_binary="python3.12",
+    )
+    mgr = WorkspaceManager(repo_settings_lookup=lambda k: cfg)
+    with mock.patch.object(ws_mod.subprocess, "run", return_value=_fake_completed(0)) as run:
+        mgr._maybe_bootstrap(ws, _make_request(ws))
+    venv_call = run.call_args_list[0]
+    assert venv_call.args[0] == ["python3.12", "-m", "venv", ".venv"]
+
+
+def test_bootstrap_defaults_venv_and_python(tmp_path, monkeypatch):
+    monkeypatch.delenv("OC_WHEELHOUSE_PYTHON", raising=False)
     ws = tmp_path / "ws"
     cfg = SimpleNamespace(
         bootstrap_commands=None,


### PR DESCRIPTION
## Problem

After the sandbox launch was fixed (#411/#412/#414), a goal task ran real work (~20s) but failed at **two** environment layers. Both fixed here so this *class* can't block autonomy.

### 1. Wheelhouse/venv python drift
The workspace venv is created with `repo_cfg.python_binary` = `python3` (host system **3.14** on this Manjaro box), but the offline wheelhouse is built with OC's venv (**3.12**) → **cp312** wheels. So:
```
pip install --no-index --find-links $OC_WHEELHOUSE -e .[dev]
  → Could not find a version that satisfies PyYAML>=6.0 (from versions: none)
  → .venv/bin/pytest exit 127 → task failed
```
**Fix (single source of truth):** `provision_env` exports `OC_WHEELHOUSE_PYTHON` (the interpreter that *built* the wheelhouse), and `WorkspaceManager._maybe_bootstrap` creates the venv with it (falls back to `python_binary` when no wheelhouse). The venv and the wheels are now tag-locked to the same python and can't drift.

### 2. Execute backend missing
`team_executor`/`dag_executor` are sibling **checkouts**, not declared OC deps — `uv pip install -e .[dev]` never installs them and a `uv sync` (the Jun-22 re-sync) *drops* them. So `backends/team_executor/adapter.py` hit `from team_executor.executor import …` → ImportError → **"team_executor not installed"** → every goal task failed at execute. They imported on neither host nor sandbox.
**Fix:** repaired OC's venv now (editable-installed both; repograph plane override intact; `_editable_install_dirs` now binds them into the sandbox), and made it **durable + self-healing** — `operations-center.sh` gains `ensure_executor_backends`, which (re)installs the siblings whenever they aren't importable (every launch; the import probe is ~free), so a future drop recovers on the next fleet start instead of silently stalling the lane.

## Verification
- In-sandbox: `python3` (3.14) → "No matching distribution"; `$OC_WHEELHOUSE_PYTHON` (3.12) → "Successfully installed PyYAML-6.0.3 … pytest-9.1.1".
- `SANDBOX_BACKEND_IMPORT_OK` (team_executor + dag_executor import inside the sandbox).
- 4 new tests; `test_wheelhouse.py` + `test_workspace_cov.py`: 96 passed.

All 4 recent goal failures were this same env pair. The `EffectiveRepoGraph … manifest not found` line is non-fatal (PrivateManifest isn't bound in the sandbox; "continuing without graph context").

🤖 Generated with Claude Code