### PR TITLE
fix(sandbox): set IS_SANDBOX=1 so the agent can run as root in the sandbox

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — FIX: agent refused to run as root in the sandbox — set IS_SANDBOX=1 (egress confirmed live)
+
+With the workspace env fixed, a goal task ran the FULL workspace prep + backend and reached the agent
+launch (~3 min of real work), then failed: `claude … --dangerously-skip-permissions cannot be used with
+root/sudo privileges for security reasons` → `claude exited 1` → task failed. Inside the sandbox the
+executor runs as **uid 0** (the pasta egress netns maps the process to root — confirmed `id -u` = 0),
+and the agent CLI refuses the skip flag under root. The agent's own escape hatch is `IS_SANDBOX=1`,
+which attests that an outer sandbox already provides the isolation. Fix: `build_sandbox_argv` adds
+`--setenv IS_SANDBOX 1` — correct by construction (it only runs when the bwrap sandbox is active, which
+IS the isolation it attests). Verified through `run_executor` (real bwrap+netns, no manual env): without
+it → root-blocked; with it → the agent runs AND reaches the model — `claude -p` returned `PING_OK`,
+which also proves egress works end to end (subscription auth through the netns + L7 proxy). This was a
+newly-exposed layer: pre-#411 the agent never ran inside the netns (bwrap-in-netns failed outright), so
+the root path was only reached once the cap-drop composition was fixed. 44 sandbox tests.
+[[oc-autonomy-hardening-deadlock]]
+
 ## 2026-06-25 — HARDEN: executor workspace env — wheelhouse/venv python match + self-healing backends
 
 With the sandbox launch fixed, a goal task ran real work (~20s) but FAILED at two env layers; both

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -401,6 +401,14 @@ def build_sandbox_argv(
             continue
         argv += ["--setenv", k, str(v)]
     argv += ["--setenv", "HOME", home]
+    # The executor runs as uid 0 inside the sandbox (the pasta egress netns maps the
+    # process to root), and the agent CLI REFUSES `--dangerously-skip-permissions`
+    # under root "for security reasons" → `claude exited 1` and every goal task fails
+    # at the agent launch. `IS_SANDBOX=1` is the agent's explicit signal that an outer
+    # sandbox already provides the isolation, so the skip is allowed as root. Setting
+    # it here is correct by construction: build_sandbox_argv only runs when the bwrap
+    # sandbox is active, which IS the isolation it attests to.
+    argv += ["--setenv", "IS_SANDBOX", "1"]
     argv += ["--chdir", str(chdir if chdir is not None else rw_root)]
     return [*argv, *inner_cmd]
 

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -118,6 +118,16 @@ class TestArgvContract:
         )
         assert argv[-3:] == ["python", "-m", "x"]
 
+    def test_is_sandbox_env_set(self, tmp_path: Path):
+        # The agent runs as uid 0 in the sandbox (the pasta egress netns maps the
+        # process to root) and refuses --dangerously-skip-permissions under root unless
+        # IS_SANDBOX=1 attests the outer sandbox provides isolation. Must be set
+        # whenever we wrap in bwrap.
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        argv = build_sandbox_argv(["x"], oc_root=tmp_path, rw_root=ws, env=_env(tmp_path))
+        assert "--setenv IS_SANDBOX 1" in " ".join(argv)
+
     def test_workspace_venv_bin_prepended_to_path(self, tmp_path: Path):
         # The agent must run bare `pytest`/`ruff`; the workspace .venv/bin is
         # prepended to PATH (resolved at exec time, after the bootstrap makes it).


### PR DESCRIPTION
## Problem

With the workspace env fixed (#415), a goal task ran the **full** workspace prep + backend and reached the agent launch (~3 min of real work), then failed:
```
claude … --dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
→ claude exited 1 → task failed
```
Inside the sandbox the executor runs as **uid 0** (the pasta egress netns maps the process to root — confirmed `id -u` = 0), and the agent CLI refuses the skip flag under root.

## Fix

`build_sandbox_argv` adds `--setenv IS_SANDBOX 1` — the agent's escape hatch attesting an outer sandbox already provides the isolation. Correct by construction: it only runs when the bwrap sandbox is active, which *is* the isolation it attests.

## Verification (real bwrap+netns via run_executor)

- Without it → root-blocked (`claude exited 1`).
- With it → the agent **runs and reaches the model**: `claude -p` returned `PING_OK` — which also proves egress works end to end (subscription auth through the netns + L7 proxy).
- 44 sandbox tests.

Newly-exposed layer: pre-#411 the agent never ran inside the netns (bwrap-in-netns failed outright), so the root path was only reached once the cap-drop composition was fixed.

🤖 Generated with Claude Code