### PR TITLE
fix(board_worker): goal-task DoD 'zero NEW failures' not 'zero total'

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-06-26 — FIX: goal-task DoD demanded "zero TOTAL test failures" — relaxed to "zero NEW failures"
+
+A goal task (89fdd864) did clean work + opened a mergeable PR but then FAILED its own self-verification:
+the team_executor verifier's acceptance criterion was "Zero test failures or skipped tests" against the
+FULL suite, which has 5 pre-existing failures + 21 skips (tests/ root + sandbox-gated tests CI doesn't
+run). The agent correctly noted "zero NEW failures, branch is clean, ready for PR" but rejected itself
+on the strict criterion — an autonomy stall caused by mis-specified done-ness, not bad work. Root cause:
+`_append_definition_of_done` (dispatch.py) said "run the test suite and make them pass / verified green",
+which the team_executor `stage_planner` (it LLM-derives acceptance_criteria from the goal text — not
+hardcoded) turned into "zero failures". Fix: reword DoD criteria 3+4 to "your change must introduce ZERO
+NEW failures; pre-existing/unrelated failures+skips are OUT OF SCOPE, do not block on them or fix them;
+the merge gate is the repo's REQUIRED CI checks, not a fully-green pre-existing local suite." So the
+planner now generates a no-regression criterion the verifier can actually satisfy. Test asserts the new
+intent. NOTE: the 5 pre-existing full-suite failures are a separate repo-health item (CI runs only
+tests/unit, which is green — see [[oc-reviewer-tests-not-in-ci]]). [[oc-autonomy-hardening-deadlock]]
+
 ## 2026-06-26 — Stage 5: complete verification of extraction fidelity metric implementation
 
 Full test-suite and linter verification confirmed the branch is mergeable as-is:

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -371,11 +371,12 @@ def _append_definition_of_done(goal_text: str) -> str:
         "   not leave TODOs, stubs, or 'follow-up' gaps; a partial change is rejected\n"
         "   in review.\n"
         "2. Add or update tests/checks that prove the work is correct.\n"
-        "3. Run the repository's test suite and linters/formatters and make them\n"
-        "   pass locally. If anything fails, fix it before finishing — do not hand\n"
-        "   off a red build.\n"
-        "4. Only consider the task done when the full change is in place AND verified\n"
-        "   green. The PR you open should be mergeable as-is.\n"
+        "3. Run the tests/linters relevant to your change and make them pass: your\n"
+        "   change must introduce ZERO NEW failures. Pre-existing or unrelated\n"
+        "   failures/skips are OUT OF SCOPE — do not block on or fix them; the repo's\n"
+        "   REQUIRED CI checks are the merge gate, not a fully-green pre-existing suite.\n"
+        "4. Done = full change in place, self-verified, no NEW failures; PR mergeable\n"
+        "   as-is (green on the required CI checks).\n"
     )
 
 

--- a/tests/unit/entrypoints/test_board_worker_definition_of_done.py
+++ b/tests/unit/entrypoints/test_board_worker_definition_of_done.py
@@ -20,3 +20,9 @@ def test_definition_of_done_preserves_goal_and_demands_completeness() -> None:
     assert "lint" in lowered or "linter" in lowered
     # No partial / stub hand-offs.
     assert "todo" in lowered and "stub" in lowered
+    # The verification bar is "no NEW failures", NOT a fully-green pre-existing suite:
+    # a repo with pre-existing/unrelated test failures must not block a clean change
+    # (the over-strict "zero total failures" reading stalled goal-task autonomy).
+    assert "zero new failures" in lowered
+    assert "out of scope" in lowered
+    assert "required ci checks" in lowered


### PR DESCRIPTION
## Problem

A goal task (89fdd864) did clean, mergeable work but **failed its own self-verification**: team_executor's verifier checked the LLM-derived acceptance criterion *'Zero test failures or skipped tests'* against the **full** suite, which has **5 pre-existing failures + 21 skips** (tests/ root + sandbox-gated tests CI doesn't run). The agent correctly noted *'zero NEW failures, branch is clean, ready for PR'* but then rejected itself on the over-strict bar — an autonomy stall from mis-specified done-ness, not bad work.

Root cause: `_append_definition_of_done` said *'run the test suite and make them pass / verified green'*; team_executor's `stage_planner` (it **LLM-derives** acceptance_criteria from the goal text — not hardcoded) turned that into *'zero failures'*.

## Fix

Reword DoD criteria 3+4: your change must introduce **ZERO NEW failures**; pre-existing/unrelated failures+skips are **OUT OF SCOPE** (don't block on or fix them); the merge gate is the repo's **REQUIRED CI checks**, not a fully-green pre-existing local suite. The planner now generates a no-regression criterion the verifier can actually satisfy. Test asserts the new intent.

Note: the 5 pre-existing full-suite failures are a separate repo-health item (CI runs only `tests/unit`, which is green).

🤖 Generated with Claude Code