### PR TITLE
fix(policy): trusted-source labels require creator provenance — close the forgeable-label bypass

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-07-06 — Track A1: trusted-source label provenance gate (forgeable-label bypass)
+
+Audit defect: `source: autonomy`/`spec-campaign`/`board_worker` labels set
+trusted=True in the policy engine and skip the risk/task-type review gates —
+but a Plane label is a plain string ANY board author can attach, and the API
+records no per-label applier. Fix at the dispatch boundary (the only place
+labels enter planning): trusted source labels are forwarded only when the
+issue CREATOR matches new `task_admission.trusted_label_authors` (the issue
+creator is the only provenance Plane exposes). Empty allowlist = fail closed.
+DEPLOY PREREQUISITE: before fleet restart, add the fleet's own Plane service
+account to trusted_label_authors in operations_center.local.yaml, or the
+autonomy lane loses its review-gate bypass (degrades safe, not broken —
+tasks route through normal review). TRUSTED_SOURCE_LABELS made public in
+policy/engine.py so dispatch and the gate can't drift. Label helpers moved
+to labels.py (dispatch.py was over the C29 500-line limit).
+
 ## 2026-07-06 — Sonnet tier rename: claude-sonnet-4-6 -> claude-sonnet-5
 
 Operator directive: move all live pinned Sonnet references to Sonnet 5.

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -531,6 +531,18 @@ class TaskAdmissionSettings(BaseModel):
     author_allowlist: list[str] = Field(default_factory=list)
     # Label applied to a task rejected for an un-allowlisted author.
     reject_label: str = "unauthorized-author"
+    # Trusted-source label provenance gate. `source: autonomy` /
+    # `source: spec-campaign` / `source: board_worker` labels bypass the policy
+    # engine's risk/task-type review gates (TRUSTED_SOURCE_LABELS in
+    # policy/engine.py) — but a Plane label is a plain string any board author
+    # can attach, and the API records no per-label applier. The only provenance
+    # available is the issue CREATOR, so dispatch forwards a trusted source
+    # label to planning only when the issue creator matches this allowlist
+    # (same identity matching as author_allowlist: id, email, or display name,
+    # case-insensitive). Empty (the default) FAILS CLOSED: no issue may carry a
+    # trusted source label through dispatch. To re-enable the autonomy-lane
+    # bypass, allowlist the fleet's own Plane service account here.
+    trusted_label_authors: list[str] = Field(default_factory=list)
 
     def enforced(self) -> bool:
         return bool(self.author_allowlist)
@@ -541,6 +553,21 @@ class TaskAdmissionSettings(BaseModel):
         if not self.enforced():
             return True
         allow = {a.strip().lower() for a in self.author_allowlist if a and a.strip()}
+        for ident in identities:
+            if ident and ident.strip().lower() in allow:
+                return True
+        return False
+
+    def label_trust_allows(self, *identities: str | None) -> bool:
+        """True only if a provided identity matches ``trusted_label_authors``.
+
+        Unlike ``allows``, an empty allowlist means NO ONE — the review-gate
+        bypass fails closed rather than open when unconfigured.
+        """
+
+        allow = {a.strip().lower() for a in self.trusted_label_authors if a and a.strip()}
+        if not allow:
+            return False
         for ident in identities:
             if ident and ident.strip().lower() in allow:
                 return True

--- a/src/operations_center/entrypoints/board_worker/claim.py
+++ b/src/operations_center/entrypoints/board_worker/claim.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 
 from ._text import desc_text, extract_goal
 from .labels import (
+    issue_author_identities as _issue_author_identities,
     ROLE_KINDS,
     STATE_BLOCKED,
     STATE_READY,
@@ -177,20 +178,6 @@ def _build_candidates(
 
         candidates.append(issue)
     return candidates
-
-
-def _issue_author_identities(issue: dict) -> tuple[str | None, ...]:
-    """Extract comparable creator identities from a Plane issue, tolerant of the
-    several shapes the API uses (bare id string, or a nested actor dict)."""
-
-    out: list[str | None] = []
-    for key in ("created_by", "created_by_id", "author", "creator"):
-        val = issue.get(key)
-        if isinstance(val, str):
-            out.append(val)
-        elif isinstance(val, dict):
-            out.extend(str(val[k]) for k in ("id", "email", "display_name", "name") if val.get(k))
-    return tuple(out)
 
 
 def _author_allowed(issue: dict, settings) -> bool:

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -18,7 +18,7 @@ from ._subprocess import build_allowlist_env, git_token_passthrough, run_executo
 from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv_python
 from .wheelhouse import provision_env
 from ._text import append_rejection_patterns, desc_text, extract_goal, task_type_from_kind
-from .labels import GITHUB_DIR, add_label, label_value
+from .labels import GITHUB_DIR, add_label, build_forwarded_labels, label_value
 from .outcomes import (
     fail_task,
     handle_failure,
@@ -106,7 +106,7 @@ def dispatch_issue(
         tmp = Path(tmpdir)
 
         # ── Step 1: Planning ──────────────────────────────────────────────────
-        forwarded_labels = _build_forwarded_labels(labels, repo_cfg)
+        forwarded_labels = build_forwarded_labels(labels, repo_cfg, issue=issue, settings=settings)
         plan_cmd = [
             python,
             "-m",
@@ -400,32 +400,6 @@ def _append_improve_output_prompt(goal_text: str) -> str:
         "(complexity:small ≈ <50 LOC, medium ≈ <200 LOC, large flagged for split). "
         "Limit to 5 suggestions; pick the highest-impact ones."
     )
-
-
-def _build_forwarded_labels(labels: list, repo_cfg) -> list[str]:
-    """Build the label list to forward to the planning subprocess.
-
-    Filters source labels based on the repo's require_explicit_approval setting.
-    """
-    explicit_required = bool(getattr(repo_cfg, "require_explicit_approval", False))
-    forwarded: list[str] = []
-    for label in labels:
-        name = (label.get("name", "") if isinstance(label, dict) else str(label)).strip()
-        low = name.lower()
-        if low == "review_required":
-            forwarded.append(name)
-            continue
-        if low.startswith("source:"):
-            if explicit_required and low in {
-                "source: autonomy",
-                "source: spec-campaign",
-                "source: board_worker",
-            }:
-                continue
-            forwarded.append(name)
-    if explicit_required:
-        forwarded.append("review_required")
-    return forwarded
 
 
 def _dispatch_spec_author(

--- a/src/operations_center/entrypoints/board_worker/labels.py
+++ b/src/operations_center/entrypoints/board_worker/labels.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
+
+from operations_center.policy.engine import TRUSTED_SOURCE_LABELS
 
 # Public API of this module — declared explicitly (consumed library; some
 # functions are tested as the boundary but not all internally wired).
@@ -15,6 +18,8 @@ __all__ = [
     "retry_count_from_labels",
     "add_label",
     "increment_retry_count",
+    "issue_author_identities",
+    "build_forwarded_labels",
 ]
 
 logger = logging.getLogger(__name__)
@@ -150,3 +155,67 @@ def increment_code_failure_count(client, issue: dict) -> None:
     code-failure loop (CODE_FAILURE_RETRY_CAP). retry-count is SIGKILL-only, so a
     clean test/lint failure would otherwise re-run forever."""
     increment_count_label(client, issue, "code-fail-count:")
+
+
+def issue_author_identities(issue: dict) -> tuple[str | None, ...]:
+    """Extract comparable creator identities from a Plane issue, tolerant of the
+    several shapes the API uses (bare id string, or a nested actor dict)."""
+
+    out: list[str | None] = []
+    for key in ("created_by", "created_by_id", "author", "creator"):
+        val = issue.get(key)
+        if isinstance(val, str):
+            out.append(val)
+        elif isinstance(val, dict):
+            out.extend(str(val[k]) for k in ("id", "email", "display_name", "name") if val.get(k))
+    return tuple(out)
+
+
+def build_forwarded_labels(
+    labels: list,
+    repo_cfg,
+    *,
+    issue: dict | None = None,
+    settings: Any = None,
+) -> list[str]:
+    """Build the label list to forward to the planning subprocess.
+
+    Filters source labels based on the repo's require_explicit_approval setting.
+
+    Trusted source labels (TRUSTED_SOURCE_LABELS) bypass the policy engine's
+    review gates, so they pass through here only when the issue creator is on
+    ``task_admission.trusted_label_authors`` — a Plane label is a plain string
+    any board author can attach, and the issue creator is the only provenance
+    the API exposes. Unconfigured (empty allowlist) fails closed: the label is
+    stripped and the task goes through the normal review gates.
+    """
+    explicit_required = bool(getattr(repo_cfg, "require_explicit_approval", False))
+    admission = getattr(settings, "task_admission", None) if settings is not None else None
+    creator_trusted = bool(
+        admission is not None
+        and issue is not None
+        and admission.label_trust_allows(*issue_author_identities(issue))
+    )
+    forwarded: list[str] = []
+    for label in labels:
+        name = (label.get("name", "") if isinstance(label, dict) else str(label)).strip()
+        low = name.lower()
+        if low == "review_required":
+            forwarded.append(name)
+            continue
+        if low.startswith("source:"):
+            if low in TRUSTED_SOURCE_LABELS:
+                if explicit_required or not creator_trusted:
+                    if not explicit_required:
+                        logger.warning(
+                            "board_worker: stripping trusted source label %r from task %s — "
+                            "issue creator not in task_admission.trusted_label_authors "
+                            "(review-gate bypass denied)",
+                            name,
+                            (issue or {}).get("id", "<unknown>"),
+                        )
+                    continue
+            forwarded.append(name)
+    if explicit_required:
+        forwarded.append("review_required")
+    return forwarded

--- a/src/operations_center/policy/engine.py
+++ b/src/operations_center/policy/engine.py
@@ -518,13 +518,21 @@ def _validation_req_applies(
     return risk_match and type_match
 
 
-_TRUSTED_SOURCE_LABELS = frozenset(
+# Labels that mark a task as coming from a pre-authorized lane. Their mere
+# presence bypasses the risk/task-type review gates below, so they are only
+# safe when their PROVENANCE is enforced upstream: board_worker dispatch strips
+# them unless the issue creator is on task_admission.trusted_label_authors
+# (Plane records no per-label applier, so the issue creator is the only
+# available provenance). Public so the dispatch boundary and this gate cannot
+# drift apart.
+TRUSTED_SOURCE_LABELS = frozenset(
     {
         "source: autonomy",
         "source: spec-campaign",
         "source: board_worker",  # follow-up tasks emitted by an already-trusted run
     }
 )
+_TRUSTED_SOURCE_LABELS = TRUSTED_SOURCE_LABELS
 
 
 def _check_review_requirements(

--- a/tests/unit/entrypoints/board_worker/test_admission.py
+++ b/tests/unit/entrypoints/board_worker/test_admission.py
@@ -86,3 +86,33 @@ def test_claim_next_allows_authorized_author():
 
     assert result is not None
     client.transition_issue.assert_called_once()  # claimed → Running
+
+
+# ── label_trust_allows (trusted-source label provenance) ────────────────────
+
+
+def test_label_trust_allows_empty_allowlist_fails_closed():
+    from operations_center.config.settings import TaskAdmissionSettings
+
+    admission = TaskAdmissionSettings()
+    assert admission.label_trust_allows("anyone") is False
+    assert admission.label_trust_allows(None) is False
+
+
+def test_label_trust_allows_matches_case_insensitively():
+    from operations_center.config.settings import TaskAdmissionSettings
+
+    admission = TaskAdmissionSettings(trusted_label_authors=["Svc-Account"])
+    assert admission.label_trust_allows("svc-account") is True
+    assert admission.label_trust_allows("other", "SVC-ACCOUNT") is True
+    assert admission.label_trust_allows("other") is False
+
+
+def test_label_trust_independent_of_author_allowlist():
+    from operations_center.config.settings import TaskAdmissionSettings
+
+    # author_allowlist unset (admission open) must NOT open the label gate.
+    admission = TaskAdmissionSettings(author_allowlist=[], trusted_label_authors=["svc"])
+    assert admission.allows("anyone") is True
+    assert admission.label_trust_allows("anyone") is False
+    assert admission.label_trust_allows("svc") is True

--- a/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from operations_center.entrypoints.board_worker import dispatch
+from operations_center.entrypoints.board_worker import labels as labels_mod
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -101,6 +102,16 @@ def test_append_improve_output_prompt():
 # ── _build_forwarded_labels ──────────────────────────────────────────────────
 
 
+def _make_admission_settings(trusted_label_authors=()):
+    from operations_center.config.settings import TaskAdmissionSettings
+
+    return SimpleNamespace(
+        task_admission=TaskAdmissionSettings(
+            trusted_label_authors=list(trusted_label_authors)
+        )
+    )
+
+
 def test_build_forwarded_labels_no_explicit_required():
     labels = [
         {"name": "review_required"},
@@ -109,13 +120,53 @@ def test_build_forwarded_labels_no_explicit_required():
         {"name": "repo: x"},
         "plain-string",
     ]
-    out = dispatch._build_forwarded_labels(labels, _make_repo_cfg(require_explicit_approval=False))
+    out = labels_mod.build_forwarded_labels(labels, _make_repo_cfg(require_explicit_approval=False))
     assert "review_required" in out
-    assert "source: autonomy" in out
-    assert "source: human" in out
+    # Trusted source labels fail closed without a provenance allowlist —
+    # any board author could have attached the string.
+    assert "source: autonomy" not in out
+    assert "source: human" in out  # untrusted source labels pass through
     # Non-source / non-review labels are dropped.
     assert "repo: x" not in out
     assert "plain-string" not in out
+
+
+def test_build_forwarded_labels_trusted_creator_keeps_trusted_labels():
+    labels = [{"name": "source: autonomy"}, {"name": "source: board_worker"}]
+    issue = {"id": "t-1", "created_by": "svc-account-id"}
+    out = labels_mod.build_forwarded_labels(
+        labels,
+        _make_repo_cfg(require_explicit_approval=False),
+        issue=issue,
+        settings=_make_admission_settings(trusted_label_authors=["svc-account-id"]),
+    )
+    assert "source: autonomy" in out
+    assert "source: board_worker" in out
+
+
+def test_build_forwarded_labels_untrusted_creator_strips_trusted_labels():
+    labels = [{"name": "source: autonomy"}, {"name": "source: human"}]
+    issue = {"id": "t-2", "created_by": "random-author"}
+    out = labels_mod.build_forwarded_labels(
+        labels,
+        _make_repo_cfg(require_explicit_approval=False),
+        issue=issue,
+        settings=_make_admission_settings(trusted_label_authors=["svc-account-id"]),
+    )
+    assert "source: autonomy" not in out
+    assert "source: human" in out
+
+
+def test_build_forwarded_labels_empty_allowlist_fails_closed():
+    labels = [{"name": "source: spec-campaign"}]
+    issue = {"id": "t-3", "created_by": "svc-account-id"}
+    out = labels_mod.build_forwarded_labels(
+        labels,
+        _make_repo_cfg(require_explicit_approval=False),
+        issue=issue,
+        settings=_make_admission_settings(trusted_label_authors=[]),
+    )
+    assert out == []
 
 
 def test_build_forwarded_labels_explicit_required_filters_and_appends():
@@ -123,14 +174,19 @@ def test_build_forwarded_labels_explicit_required_filters_and_appends():
         {"name": "source: autonomy"},
         {"name": "source: human"},
     ]
-    out = dispatch._build_forwarded_labels(labels, _make_repo_cfg(require_explicit_approval=True))
-    assert "source: autonomy" not in out  # filtered out
+    out = labels_mod.build_forwarded_labels(
+        labels,
+        _make_repo_cfg(require_explicit_approval=True),
+        issue={"id": "t-4", "created_by": "svc-account-id"},
+        settings=_make_admission_settings(trusted_label_authors=["svc-account-id"]),
+    )
+    assert "source: autonomy" not in out  # explicit approval outranks label trust
     assert "source: human" in out  # kept
     assert "review_required" in out  # appended
 
 
 def test_build_forwarded_labels_none_repo_cfg():
-    out = dispatch._build_forwarded_labels([{"name": "source: x"}], None)
+    out = labels_mod.build_forwarded_labels([{"name": "source: x"}], None)
     assert out == ["source: x"]
 
 


### PR DESCRIPTION
**Track A1 of the grounded audit** (PlatformManifest docs/architecture/oc-audit-and-pseudooperator-spec.md §2).

`source: autonomy` / `source: spec-campaign` / `source: board_worker` labels bypass the policy engine's risk/task-type review gates — but a Plane label is a plain string any board author can attach, and the API records no per-label applier.

**Fix (at the dispatch boundary, the only place labels enter planning):**
- Trusted source labels are forwarded only when the issue **creator** matches new `task_admission.trusted_label_authors` (id/email/display name, case-insensitive — the creator is the only provenance Plane exposes).
- Empty allowlist (default) **fails closed**: label stripped with a warning; task goes through normal review gates.
- `TRUSTED_SOURCE_LABELS` made public in policy/engine.py; the dispatch boundary imports it so the two ends can't drift.
- Label helpers moved to `labels.py` (dispatch.py exceeded the C29 500-line limit).

**Deploy prerequisite:** before fleet restart, allowlist the fleet's own Plane service account in `operations_center.local.yaml`, or autonomy-lane tasks route through normal review (safe degrade, not a halt).

Full unit suite green (8363 passed); ruff clean; custodian clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)