### PR TITLE
fix(reviewer): require_branch_protection defaults True — prove the self-merge is constrained

### DIFF
--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -308,9 +308,12 @@ class ReviewerSettings(BaseModel):
     # and main is the repo's branch protection — an out-of-repo setting the fleet
     # can't see. When True, the fleet verifies (from code) that protection
     # actually requires the reviewer-verdict check AND enforces admins before
-    # self-merging; if not, it refuses and leaves the PR for an operator. False
-    # preserves prior behavior (trust GitHub protection blindly).
-    require_branch_protection: bool = False
+    # self-merging; if not, it refuses and leaves the PR for an operator.
+    # Default True (audit Track A2): the fleet must PROVE its self-merge is
+    # constrained before performing it. Set False only to restore the old
+    # trust-GitHub-blindly behavior on a repo where protection is managed
+    # out-of-band and the API check is unavailable.
+    require_branch_protection: bool = True
     # Sensitive-path ack gate (opt-in). When True, a PR whose diff touches a
     # blast-radius path (CI workflows, migrations, secrets, infra config) is NOT
     # self-merged unless the operator acked it ONCE with a 'risk-reviewed' label —

--- a/tests/unit/config/test_reviewer_defaults.py
+++ b/tests/unit/config/test_reviewer_defaults.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Pin the reviewer's fail-closed defaults (audit Track A2).
+
+The self-merge gate default is a security posture, not a tuning knob: the
+fleet self-issues its own reviewer-verdict then merges via REST, so branch
+protection is the only external constraint. A regression back to False would
+silently restore blind-trust self-merge.
+"""
+
+from operations_center.config.settings import ReviewerSettings
+
+
+def test_require_branch_protection_defaults_on():
+    assert ReviewerSettings().require_branch_protection is True


### PR DESCRIPTION
**Track A2 of the grounded audit** (PlatformManifest docs/architecture/oc-audit-and-pseudooperator-spec.md §2).

The reviewer self-issues its own `reviewer-verdict` status and merges via REST — the only external constraint is GitHub branch protection, which the code trusted blindly (`require_branch_protection` defaulted `False`).

The fail-closed verification gate (`_branch_protection_ok`) already existed behind an opt-in. This PR:
- flips the default to `True`: the fleet must verify (reviewer-verdict is a **required check** AND **enforce_admins** on) before any self-merge, refusing on API errors
- pins the default with a test so it can't silently regress

**Deploy note:** managed repos without that protection now leave LGTM PRs for the operator (safe degrade). OC main already satisfies the gate (verified live via API). No `reviewer:` override exists in `operations_center.local.yaml`, so the new default takes effect on restart.

Suite green (8503 passed incl. pr_review_watcher root tests, which CI doesn't run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)