### PR TITLE
fix(containment): bwrap/netns/egress default-on + fail-closed per task

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-07-06 — Track A3: containment default-on + fail-closed per task
+
+Audit defect: bwrap/netns/egress were opt-in AND fail-open — a missing binary
+or dead proxy silently ran the token-holding backend un-contained. Now:
+OC_BWRAP_SANDBOX + OC_EGRESS_NETNS default ON (set =0 to disable);
+OC_SANDBOX_REQUIRED + OC_EGRESS_REQUIRED default ON (a degrade raises, and
+board_worker/reviewer catch it as a failed TASK + fault — the fleet keeps
+serving, so §0.1 degrade-never-halt holds at fleet level). New single gate
+sandbox_enabled() consumed by dispatch, reviewer, wheelhouse (no drift); new
+verify_containment() startup self-check logs containment_selfcheck_failed at
+boot instead of discovering the gap at task N. Unit-test conftest pins
+containment OFF for orchestration tests; containment tests opt in explicitly.
+Posture layer extracted to containment.py (sandbox.py was over C29's limit).
+DEPLOY NOTE: live .env already sets sandbox/netns/proxy; required-flags were
+unset and now default to required — if bwrap/pasta/proxy break, tasks fail
+visibly instead of running un-contained.
+
 ## 2026-07-06 — Track A1: trusted-source label provenance gate (forgeable-label bypass)
 
 Audit defect: `source: autonomy`/`spec-campaign`/`board_worker` labels set

--- a/.env.operations-center.example
+++ b/.env.operations-center.example
@@ -83,12 +83,14 @@ export OPERATIONS_CENTER_PLANE_OPEN_BROWSER='0'
 # ---------------------------------------------------------------------------
 # Executor sandbox + egress confinement (SBX)
 # ---------------------------------------------------------------------------
-# All fail-open (§0.1 degrade-never-halt): unavailable/unset => runs as before,
-# never a halt. When ENABLED-but-degraded the harness now logs an observable
-# `sandbox_degraded` / `netns_degraded` warning (the audit's "absent isolation
-# must be visible" requirement) so the log sweep can alert on it.
+# Containment is DEFAULT-ON and REQUIRED (audit Track A3): unset flags mean
+# enabled + fail-closed PER TASK — a degrade (missing bwrap/pasta/proxy) fails
+# that task with a visible fault; the fleet keeps serving (§0.1 holds at fleet
+# level). Explicitly set a flag to 0 to opt out. A startup self-check logs
+# `containment_selfcheck_failed` for any enabled-but-unavailable component.
 
 # bwrap process containment for the executor subprocess (Phase 2).
+# Default-on; set to 0 to disable.
 export OC_BWRAP_SANDBOX=1
 # Route the sandbox's HTTPS egress through the L7/SNI allowlist proxy
 # (oc-egress-proxy.service). Honor-system on its own — see OC_EGRESS_NETNS.
@@ -98,16 +100,18 @@ export OC_EGRESS_SNI_STRICT=1
 # STRUCTURAL egress confinement (B1): run the executor in a rootless pasta netns
 # with an in-netns iptables OUTPUT DROP, so a raw socket bypassing the proxy is
 # kernel-blocked. Requires the `passt` package (provides `pasta`).
+# Default-on; set to 0 to disable. Requires the `passt` package (pasta) AND
+# OC_EGRESS_PROXY — enabled-with-no-proxy fails tasks closed (a locked netns
+# with no proxy has no egress at all).
 export OC_EGRESS_NETNS=1
 
-# FAIL-CLOSED containment opt-in (B4, determinism surface 8). By default the
-# sandbox + egress confinement are fail-open (§0.1 degrade-never-halt): if bwrap
-# or pasta is missing, the backend runs un-contained. Set these to refuse to run
-# a token-holding backend without containment — a degrade then fails the cycle
-# (observably, via the heartbeat) instead of silently dropping isolation. Leave
-# UNSET to preserve degrade-never-halt.
-# export OC_SANDBOX_REQUIRED=1
-# export OC_EGRESS_REQUIRED=1
+# FAIL-CLOSED containment (B4, determinism surface 8) is now the DEFAULT
+# (audit Track A3): a degrade (missing bwrap/pasta/proxy) refuses to run the
+# token-holding backend and fails that task observably instead of silently
+# dropping isolation. Set to 0 to restore the old fail-open degrade — the task
+# then runs UN-CONTAINED when containment is unavailable (the audit finding).
+# export OC_SANDBOX_REQUIRED=0
+# export OC_EGRESS_REQUIRED=0
 
 # ---------------------------------------------------------------------------
 # Defaults

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -13,13 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from .netns import maybe_netns, netns_enabled
-from .sandbox import _resolve_egress_proxy, maybe_sandbox
-
-# SBX Phase 2: the bwrap sandbox is OFF by default and enabled by setting this
-# env var to "1" in the fleet environment. Off-by-default + fail-open means
-# merging the sandbox changes nothing in production until it is deliberately
-# turned on and observed (the staged rollout the trust-hardening §0.1 requires).
-_SANDBOX_ENV_FLAG = "OC_BWRAP_SANDBOX"
+from .sandbox import _resolve_egress_proxy, maybe_sandbox, sandbox_enabled
 
 # SBX Layer 3 (resource limits): gated on this flag. Wraps the executor in a
 # transient systemd-user cgroup scope with memory/pids/cpu caps + a wall-timeout
@@ -300,12 +294,13 @@ def run_executor(
     """Spawn the executor subprocess, optionally inside the bwrap sandbox and a
     resource-limited cgroup scope.
 
-    Centralizes the SBX wraps so dispatch's spawn sites stay one-liners. Both are
-    gated + fail-open: the bwrap sandbox on ``OC_BWRAP_SANDBOX=1`` (off/unavailable
-    => runs as before); the Layer-3 cgroup caps on ``OC_SANDBOX_RLIMITS=1``. The
-    outer ``env`` is still passed (harmless: bwrap ``--clearenv`` + ``--setenv``
-    re-establishes a controlled env inside; un-sandboxed it is the real env)."""
-    enabled = os.environ.get(_SANDBOX_ENV_FLAG) == "1"
+    Centralizes the SBX wraps so dispatch's spawn sites stay one-liners. The bwrap
+    sandbox is default-on + fail-closed per task (``sandbox_enabled`` /
+    ``OC_SANDBOX_REQUIRED``, audit Track A3); the Layer-3 cgroup caps stay gated on
+    ``OC_SANDBOX_RLIMITS=1``. The outer ``env`` is still passed (harmless: bwrap
+    ``--clearenv`` + ``--setenv`` re-establishes a controlled env inside;
+    un-sandboxed it is the real env)."""
+    enabled = sandbox_enabled()
     run_cmd = maybe_sandbox(
         cmd, oc_root=oc_root, rw_root=rw_root, env=env, enabled=enabled, chdir=workspace
     )

--- a/src/operations_center/entrypoints/board_worker/containment.py
+++ b/src/operations_center/entrypoints/board_worker/containment.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Containment posture for worker/executor subprocesses (audit Track A3).
+
+Single source of truth for the enable/require flags, binary availability, and
+the startup self-check shared by the bwrap sandbox (sandbox.py), the egress
+netns (netns.py), and their consumers (board_worker dispatch, the reviewer
+pipeline, wheelhouse provisioning).
+
+Posture: DEFAULT-ON + FAIL-CLOSED PER TASK. Unset flags mean enabled and
+required; a degrade raises and dispatch fails that task with a visible fault —
+the fleet keeps serving (degrade-never-halt, §0.1, holds at fleet level). An
+operator opts out explicitly with ``<FLAG>=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import socket
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# SBX Phase 3 (D-SBX-2): the egress proxy URL for the sandbox's HTTPS egress.
+_EGRESS_PROXY_ENV_FLAG = "OC_EGRESS_PROXY"
+
+class ContainmentRequiredError(RuntimeError):
+    """Raised when containment is required (the default) but unavailable.
+
+    Fail-closed by default (audit Track A3): never run a token-holding backend
+    un-contained unless the operator explicitly opts out with
+    ``OC_SANDBOX_REQUIRED=0``. Dispatch turns this into a blocked task + fault,
+    not a crash-loop — the fleet keeps serving.
+    """
+
+
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _containment_required(env: dict | None, *, var: str) -> bool:
+    """True unless the operator explicitly opted out (``var=0``).
+
+    Checks the passed worker env first (the minimized, authoritative env) then
+    the process env, so the flag works whether or not it survived minimization.
+    Unset means REQUIRED (fail-closed default, audit Track A3).
+    """
+
+    for source in (env or {}, os.environ):
+        val = source.get(var)
+        if val is not None:
+            return str(val).strip().lower() not in _FALSY
+    return True
+
+
+def sandbox_enabled() -> bool:
+    """bwrap containment is ON unless explicitly disabled (``OC_BWRAP_SANDBOX=0``).
+
+    Default-on per audit Track A3 — the single gate consumed by board_worker
+    dispatch, the reviewer pipeline, and wheelhouse provisioning, so the three
+    call sites cannot drift.
+    """
+    return str(os.environ.get("OC_BWRAP_SANDBOX", "1")).strip().lower() not in _FALSY
+
+
+def verify_containment() -> list[str]:
+    """Startup self-check (audit Track A3): the containment components that are
+    enabled but unavailable, checked BEFORE any task is accepted.
+
+    Returns human-readable problem strings; empty means the posture is
+    satisfiable. Callers log these loudly at startup — per-task enforcement
+    still raises ``ContainmentRequiredError`` / ``EgressContainmentRequiredError``,
+    but discovering a broken posture at task N is strictly worse than at boot.
+    """
+    from .netns import netns_enabled, pasta_path  # local import: netns is a sibling leaf
+
+    problems: list[str] = []
+    if sandbox_enabled() and not bwrap_available():
+        problems.append("bwrap sandbox enabled but the bwrap binary is not on PATH")
+    if netns_enabled():
+        if pasta_path() is None:
+            problems.append("egress netns enabled but the pasta binary is not on PATH")
+        url = os.environ.get(_EGRESS_PROXY_ENV_FLAG)
+        if not url:
+            problems.append(
+                "egress netns enabled but OC_EGRESS_PROXY is unset "
+                "(a locked netns with no proxy has no egress)"
+            )
+        elif not _proxy_reachable(url):
+            problems.append(f"egress proxy configured but unreachable ({url})")
+    return problems
+
+
+
+def bwrap_available() -> bool:
+    """Check if bwrap (bubblewrap) is available in the PATH."""
+    return shutil.which("bwrap") is not None
+
+
+def _proxy_reachable(url: str, *, timeout: float = 0.5) -> bool:
+    """True if the egress proxy host:port accepts a TCP connection. This is the
+    gate that keeps proxy wiring FAIL-OPEN (§0.1): if the proxy is down we inject
+    nothing and the sandbox keeps direct egress rather than losing all HTTPS."""
+    try:
+        parsed = urlparse(url if "://" in url else f"http://{url}")
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or 8889
+    except ValueError:
+        return False
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _resolve_egress_proxy(env: dict) -> str | None:
+    """The egress proxy URL to wire into the sandbox, or ``None``. Reads
+    ``OC_EGRESS_PROXY`` from the controlled env (falling back to the parent
+    process env, where the fleet actually sets it) and returns it only when the
+    proxy is reachable — so a dead/missing proxy degrades to direct egress
+    instead of breaking every HTTPS call (fail-open, §0.1)."""
+    url = env.get(_EGRESS_PROXY_ENV_FLAG) or os.environ.get(_EGRESS_PROXY_ENV_FLAG)
+    if not url or not _proxy_reachable(url):
+        return None
+    return url
+
+
+
+__all__ = [
+    "ContainmentRequiredError",
+    "bwrap_available",
+    "sandbox_enabled",
+    "verify_containment",
+]

--- a/src/operations_center/entrypoints/board_worker/main.py
+++ b/src/operations_center/entrypoints/board_worker/main.py
@@ -41,7 +41,7 @@ from .dispatch import dispatch_issue
 from .labels import ROLE_KINDS
 from .netns import EgressContainmentRequiredError
 from .outcomes import fail_task
-from .sandbox import ContainmentRequiredError
+from .sandbox import ContainmentRequiredError, verify_containment
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +153,19 @@ def main() -> int:
     )
 
     logger.info("board_worker[%s]: starting — poll_interval=%ds", role, args.poll_interval)
+
+    # Containment self-check (audit Track A3): surface a broken posture at boot,
+    # not at task N. Per-task enforcement still fails closed via
+    # ContainmentRequiredError / EgressContainmentRequiredError; this makes the
+    # gap visible the moment the worker starts.
+    for problem in verify_containment():
+        logger.error(
+            'board_worker[%s]: containment self-check FAILED — %s '
+            '{"event": "containment_selfcheck_failed", "problem": "%s"}',
+            role,
+            problem,
+            problem,
+        )
 
     _reconcile_in_flight_at_startup(args.config, role)
 

--- a/src/operations_center/entrypoints/board_worker/netns.py
+++ b/src/operations_center/entrypoints/board_worker/netns.py
@@ -25,11 +25,14 @@ This closes it structurally and rootless, validated end to end:
 Net: an agent that does ``unset HTTPS_PROXY`` + a raw socket is kernel-blocked,
 while HTTPS-through-the-proxy keeps working. The honor-system hole is closed.
 
-**Opt-in + fail-open (§0.1 degrade-never-halt).** Gated on ``OC_EGRESS_NETNS=1``.
-If pasta is missing, no proxy is configured (a locked netns with no proxy would
-have *no* egress at all), or any setup step fails, it degrades to the prior
-shared-netns behavior rather than halting the fleet. Enable-and-observe like the
-other SBX layers."""
+**Default-on + fail-closed per task (audit Track A3).** Enabled unless
+``OC_EGRESS_NETNS=0`` and required unless ``OC_EGRESS_REQUIRED=0``: when pasta is
+missing or no proxy is configured (a locked netns with no proxy would have *no*
+egress at all), the dispatch raises ``EgressContainmentRequiredError`` — the
+worker fails THAT TASK with a visible fault and keeps serving (degrade-never-halt
+holds at fleet level, §0.1; the task, not the fleet, is what fails closed). An
+operator who explicitly opts out with ``OC_EGRESS_REQUIRED=0`` restores the old
+observable fail-open degrade."""
 
 from __future__ import annotations
 
@@ -94,19 +97,27 @@ def _setup_script(*, drop_caps: bool) -> str:
     return _FIREWALL_SETUP + (_CAPDROP_EXEC if drop_caps else _PLAIN_EXEC)
 
 
+_FALSY = {"0", "false", "no", "off"}
+
+
 def netns_enabled() -> bool:
-    return os.environ.get(_NETNS_FLAG) == "1"
+    """Egress netns confinement is ON unless explicitly disabled
+    (``OC_EGRESS_NETNS=0``). Default-on per audit Track A3: containment that
+    must be remembered at deploy time is containment that silently rots."""
+    return str(os.environ.get(_NETNS_FLAG, "1")).strip().lower() not in _FALSY
 
 
 class EgressContainmentRequiredError(RuntimeError):
-    """Raised when egress confinement is REQUIRED (OC_EGRESS_REQUIRED=1) but
-    cannot be established. Default posture is fail-open (§0.1); this is the
-    operator opt-in to never run a token-holding backend with unconfined egress.
+    """Raised when egress confinement cannot be established and the operator has
+    not explicitly opted out (``OC_EGRESS_REQUIRED=0``). Dispatch turns it into
+    a failed task + fault — the fleet keeps serving (§0.1 holds at fleet level).
     """
 
 
 def egress_required() -> bool:
-    return str(os.environ.get(_REQUIRED_FLAG, "")).strip().lower() in {"1", "true", "yes", "on"}
+    """Fail-closed by default (audit Track A3): a degrade raises unless the
+    operator explicitly opts out with ``OC_EGRESS_REQUIRED=0``."""
+    return str(os.environ.get(_REQUIRED_FLAG, "1")).strip().lower() not in _FALSY
 
 
 def pasta_path() -> str | None:
@@ -164,7 +175,8 @@ def maybe_netns(
         )
         if egress_required():
             raise EgressContainmentRequiredError(
-                f"OC_EGRESS_REQUIRED set but egress confinement unavailable ({reason})"
+                f"egress confinement required (default; opt out with "
+                f"OC_EGRESS_REQUIRED=0) but unavailable ({reason})"
             )
         return list(cmd)
     forwards: list[str] = []

--- a/src/operations_center/entrypoints/board_worker/sandbox.py
+++ b/src/operations_center/entrypoints/board_worker/sandbox.py
@@ -27,11 +27,15 @@ listening, no proxy env is injected and the sandbox keeps direct egress (losing
 all HTTPS to a dead proxy would be a §0.1 violation). localhost (ollama floor +
 key-proxy) always bypasses the proxy via ``NO_PROXY``.
 
-SELF-HEALING INVARIANT (§0.1): this is **fail-open**. If bwrap is missing, the
-config flag is off, or any bind path is absent, ``maybe_sandbox`` returns the
-command UNCHANGED — the fleet runs un-sandboxed rather than halting. A wrong
-sandbox must never deadlock the fleet (the bootstrap-deadlock lesson from the
-PATH/CL_ANCHOR regressions). Turning it on is an explicit, observed step.
+CONTAINMENT POSTURE (audit Track A3): **default-on, fail-closed per task.**
+The sandbox is enabled unless ``OC_BWRAP_SANDBOX=0`` and required unless
+``OC_SANDBOX_REQUIRED=0``: a degrade (missing bwrap, absent workspace,
+construction error) raises ``ContainmentRequiredError``, which dispatch turns
+into a failed task + fault — the FLEET keeps serving (§0.1 degrade-never-halt
+holds at fleet level; it is the task, not the fleet, that fails closed). An
+operator who explicitly opts out with ``OC_SANDBOX_REQUIRED=0`` restores the
+old observable fail-open degrade (the pre-audit posture, where a missing bwrap
+silently ran the token-holding backend un-sandboxed — the exact finding).
 """
 
 from __future__ import annotations
@@ -41,10 +45,18 @@ import json
 import logging
 import os
 import shutil
-import socket
 from collections.abc import Sequence
 from pathlib import Path
-from urllib.parse import urlparse
+
+from .containment import (  # noqa: F401 — re-exported for existing importers
+    ContainmentRequiredError,
+    _containment_required,
+    _proxy_reachable,
+    _resolve_egress_proxy,
+    bwrap_available,
+    sandbox_enabled,
+    verify_containment,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,31 +72,6 @@ def _warn_degraded(reason: str) -> None:
         reason,
         reason,
     )
-
-
-class ContainmentRequiredError(RuntimeError):
-    """Raised when containment is REQUIRED (operator opt-in) but unavailable.
-
-    The default posture is fail-open (§0.1: degrade-never-halt). An operator who
-    wants the stronger guarantee — never run a token-holding backend
-    un-contained — sets ``OC_SANDBOX_REQUIRED=1``; then a degrade raises this
-    instead of silently dropping the sandbox. Dispatch turns it into a blocked
-    task + fault, not a crash-loop.
-    """
-
-
-def _containment_required(env: dict | None, *, var: str) -> bool:
-    """True if the operator has opted into fail-closed containment for ``var``.
-
-    Checks the passed worker env first (the minimized, authoritative env) then
-    the process env, so the flag works whether or not it survived minimization.
-    """
-
-    for source in (env or {}, os.environ):
-        val = source.get(var)
-        if val is not None:
-            return str(val).strip().lower() in {"1", "true", "yes", "on"}
-    return False
 
 
 # HOME subdirectories that hold host credentials — NEVER bound into the sandbox.
@@ -112,40 +99,6 @@ _EGRESS_PROXY_ENV_FLAG = "OC_EGRESS_PROXY"
 # and the localhost cloud-key proxy (D-OP-1) live on loopback and are not
 # "egress" — routing them through the CONNECT proxy would break the local floor.
 _PROXY_BYPASS = "127.0.0.1,localhost,::1"
-
-
-def bwrap_available() -> bool:
-    """Check if bwrap (bubblewrap) is available in the PATH."""
-    return shutil.which("bwrap") is not None
-
-
-def _proxy_reachable(url: str, *, timeout: float = 0.5) -> bool:
-    """True if the egress proxy host:port accepts a TCP connection. This is the
-    gate that keeps proxy wiring FAIL-OPEN (§0.1): if the proxy is down we inject
-    nothing and the sandbox keeps direct egress rather than losing all HTTPS."""
-    try:
-        parsed = urlparse(url if "://" in url else f"http://{url}")
-        host = parsed.hostname or "127.0.0.1"
-        port = parsed.port or 8889
-    except ValueError:
-        return False
-    try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
-        return False
-
-
-def _resolve_egress_proxy(env: dict) -> str | None:
-    """The egress proxy URL to wire into the sandbox, or ``None``. Reads
-    ``OC_EGRESS_PROXY`` from the controlled env (falling back to the parent
-    process env, where the fleet actually sets it) and returns it only when the
-    proxy is reachable — so a dead/missing proxy degrades to direct egress
-    instead of breaking every HTTPS call (fail-open, §0.1)."""
-    url = env.get(_EGRESS_PROXY_ENV_FLAG) or os.environ.get(_EGRESS_PROXY_ENV_FLAG)
-    if not url or not _proxy_reachable(url):
-        return None
-    return url
 
 
 def _proxy_env(url: str, *, existing_no_proxy: str = "") -> dict[str, str]:
@@ -436,7 +389,8 @@ def maybe_sandbox(
         _warn_degraded(reason)
         if required:
             raise ContainmentRequiredError(
-                f"OC_SANDBOX_REQUIRED set but sandbox unavailable ({reason})"
+                f"sandbox containment required (default; opt out with "
+                f"OC_SANDBOX_REQUIRED=0) but unavailable ({reason})"
             )
         return list(inner_cmd)
 
@@ -472,4 +426,6 @@ __all__ = [
     "build_sandbox_argv",
     "bwrap_available",
     "maybe_sandbox",
+    "sandbox_enabled",
+    "verify_containment",
 ]

--- a/src/operations_center/entrypoints/board_worker/wheelhouse.py
+++ b/src/operations_center/entrypoints/board_worker/wheelhouse.py
@@ -177,7 +177,9 @@ def provision_env(
     of truth: whatever python builds the wheelhouse also creates the venv that
     installs from it, so the two can never drift.
     """
-    if os.environ.get("OC_BWRAP_SANDBOX") != "1":
+    from .sandbox import sandbox_enabled
+
+    if not sandbox_enabled():
         return {}
     out: dict[str, str] = {}
     wh = ensure_wheelhouse(repo_key, repo_local_path, python_bin=python_bin)

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -70,6 +70,8 @@ from operations_center.entrypoints.board_worker.sandbox import (
     ContainmentRequiredError,
     _resolve_egress_proxy,
     maybe_sandbox,
+    sandbox_enabled,
+    verify_containment,
 )
 from operations_center.entrypoints.heartbeat import write_heartbeat
 from operations_center.reviewer.instrumentation import (
@@ -399,10 +401,10 @@ def _build_env(oc_root: Path) -> dict:
 
 
 def _sandbox_enabled() -> bool:
-    """True when the bwrap sandbox is enabled for worker subprocesses. Mirrors
-    board_worker._subprocess's gate (OC_BWRAP_SANDBOX=1) so the reviewer's
+    """True when the bwrap sandbox is enabled for worker subprocesses. Delegates
+    to board_worker's single gate (default-on, audit Track A3) so the reviewer's
     executor is contained on exactly the same switch as board_worker dispatch."""
-    return os.environ.get("OC_BWRAP_SANDBOX") == "1"
+    return sandbox_enabled()
 
 
 class OCSourceTreeUncleanError(RuntimeError):
@@ -3854,6 +3856,15 @@ def main() -> int:
         return 0
 
     logger.info("pr_review_watcher: starting — poll_interval=%ds", args.poll_interval)
+
+    # Containment self-check (audit Track A3): surface a broken posture at boot.
+    for problem in verify_containment():
+        logger.error(
+            'pr_review_watcher: containment self-check FAILED — %s '
+            '{"event": "containment_selfcheck_failed", "problem": "%s"}',
+            problem,
+            problem,
+        )
     while True:
         try:
             settings = _load_settings(args.config)

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -3259,8 +3259,9 @@ def test_sandbox_enabled_reads_flag(monkeypatch) -> None:
     assert watcher._sandbox_enabled() is True
     monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
     assert watcher._sandbox_enabled() is False
+    # Track A3: default-on — an unset flag means enabled.
     monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
-    assert watcher._sandbox_enabled() is False
+    assert watcher._sandbox_enabled() is True
 
 
 def _pipeline_settings() -> MagicMock:
@@ -3291,6 +3292,9 @@ def _patched_pipeline_run(monkeypatch, tmp_path: Path):
 
 def test_run_pipeline_sandboxes_exec_when_enabled(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    # keep the test about the SANDBOX wrap: netns default-on would raise on a
+    # host with no egress proxy configured
+    monkeypatch.setenv("OC_EGRESS_NETNS", "0")
     popen = _patched_pipeline_run(monkeypatch, tmp_path)
     sentinel = ["bwrap", "WRAPPED", "execute.main"]
     with patch.object(watcher, "maybe_sandbox", return_value=sentinel) as msbx:
@@ -3311,7 +3315,8 @@ def test_run_pipeline_sandboxes_exec_when_enabled(tmp_path: Path, monkeypatch) -
 
 
 def test_run_pipeline_no_sandbox_when_disabled(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+    # Track A3: default-on — disabling now takes an explicit opt-out.
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
     popen = _patched_pipeline_run(monkeypatch, tmp_path)
     with patch.object(watcher, "maybe_sandbox") as msbx:
         watcher._run_pipeline(

--- a/tests/unit/entrypoints/board_worker/conftest.py
+++ b/tests/unit/entrypoints/board_worker/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""board_worker unit-test defaults.
+
+Containment is default-on + required (audit Track A3), so any test that
+exercises dispatch/spec-author/run_executor paths would otherwise raise
+ContainmentRequiredError / EgressContainmentRequiredError on a host without
+bwrap/pasta/proxy. Unit tests exercise the orchestration logic, not the
+containment posture — so containment is pinned OFF here, and the containment
+tests (test_sandbox.py / test_netns.py) re-enable it explicitly per test.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _containment_off(monkeypatch):
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
+    monkeypatch.setenv("OC_EGRESS_NETNS", "0")
+    monkeypatch.setenv("OC_SANDBOX_REQUIRED", "0")
+    monkeypatch.setenv("OC_EGRESS_REQUIRED", "0")

--- a/tests/unit/entrypoints/board_worker/test_netns.py
+++ b/tests/unit/entrypoints/board_worker/test_netns.py
@@ -21,36 +21,38 @@ def test_disabled_returns_cmd_unchanged():
     assert netns.maybe_netns(cmd, proxy_url="http://127.0.0.1:8889", enabled=False) == cmd
 
 
-def test_no_proxy_fails_open(monkeypatch):
+def test_no_proxy_fails_open_when_opted_out(monkeypatch):
     monkeypatch.setattr(netns, "pasta_path", lambda: "/usr/bin/pasta")
+    monkeypatch.setenv("OC_EGRESS_REQUIRED", "0")
     cmd = ["bwrap", "x"]
     assert netns.maybe_netns(cmd, proxy_url=None, enabled=True) == cmd
 
 
-def test_missing_pasta_fails_open(monkeypatch):
+def test_missing_pasta_fails_open_when_opted_out(monkeypatch):
     monkeypatch.setattr(netns, "pasta_path", lambda: None)
+    monkeypatch.setenv("OC_EGRESS_REQUIRED", "0")
     cmd = ["bwrap", "x"]
     assert netns.maybe_netns(cmd, proxy_url="http://127.0.0.1:8889", enabled=True) == cmd
 
 
-def test_required_raises_when_pasta_missing(monkeypatch):
-    # B4: OC_EGRESS_REQUIRED flips fail-open into fail-closed.
+def test_required_by_default_raises_when_pasta_missing(monkeypatch):
+    # Track A3: fail-closed is the DEFAULT — an unset flag means required.
     monkeypatch.setattr(netns, "pasta_path", lambda: None)
-    monkeypatch.setenv("OC_EGRESS_REQUIRED", "1")
+    monkeypatch.delenv("OC_EGRESS_REQUIRED", raising=False)
     with pytest.raises(netns.EgressContainmentRequiredError):
         netns.maybe_netns(["bwrap", "x"], proxy_url="http://127.0.0.1:8889", enabled=True)
 
 
-def test_required_raises_when_no_proxy(monkeypatch):
+def test_required_by_default_raises_when_no_proxy(monkeypatch):
     monkeypatch.setattr(netns, "pasta_path", lambda: "/usr/bin/pasta")
-    monkeypatch.setenv("OC_EGRESS_REQUIRED", "1")
+    monkeypatch.delenv("OC_EGRESS_REQUIRED", raising=False)
     with pytest.raises(netns.EgressContainmentRequiredError):
         netns.maybe_netns(["bwrap", "x"], proxy_url=None, enabled=True)
 
 
-def test_not_required_still_fails_open(monkeypatch):
+def test_explicit_opt_out_fails_open(monkeypatch):
     monkeypatch.setattr(netns, "pasta_path", lambda: None)
-    monkeypatch.delenv("OC_EGRESS_REQUIRED", raising=False)
+    monkeypatch.setenv("OC_EGRESS_REQUIRED", "0")
     cmd = ["bwrap", "x"]
     assert netns.maybe_netns(cmd, proxy_url="http://127.0.0.1:8889", enabled=True) == cmd
 
@@ -108,7 +110,10 @@ def test_extra_ports_forwarded(monkeypatch):
 def test_enabled_flag(monkeypatch):
     monkeypatch.setenv("OC_EGRESS_NETNS", "1")
     assert netns.netns_enabled() is True
+    # Track A3: default-on — an unset flag means enabled.
     monkeypatch.delenv("OC_EGRESS_NETNS")
+    assert netns.netns_enabled() is True
+    monkeypatch.setenv("OC_EGRESS_NETNS", "0")
     assert netns.netns_enabled() is False
 
 

--- a/tests/unit/entrypoints/board_worker/test_sandbox.py
+++ b/tests/unit/entrypoints/board_worker/test_sandbox.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from operations_center.entrypoints.board_worker import containment
 from operations_center.entrypoints.board_worker import sandbox as sbx
 from operations_center.entrypoints.board_worker.sandbox import (
     build_sandbox_argv,
@@ -222,31 +223,66 @@ class TestFailOpen:
             == cmd
         )
 
-    def test_missing_workspace_returns_unchanged(self, tmp_path: Path):
+    def test_missing_workspace_raises_by_default(self, tmp_path: Path, monkeypatch):
+        # Track A3: containment is required unless explicitly opted out — a
+        # degrade fails the task, it does not silently run un-sandboxed.
+        monkeypatch.delenv("OC_SANDBOX_REQUIRED", raising=False)
+        with pytest.raises(sbx.ContainmentRequiredError):
+            maybe_sandbox(
+                ["python"], oc_root=tmp_path, rw_root=tmp_path / "nope", env={}, enabled=True
+            )
+
+    def test_missing_workspace_fail_open_when_opted_out(self, tmp_path: Path):
         cmd = ["python"]
-        out = maybe_sandbox(cmd, oc_root=tmp_path, rw_root=tmp_path / "nope", env={}, enabled=True)
+        out = maybe_sandbox(
+            cmd,
+            oc_root=tmp_path,
+            rw_root=tmp_path / "nope",
+            env={"OC_SANDBOX_REQUIRED": "0"},
+            enabled=True,
+        )
         assert out == cmd
 
-    def test_no_bwrap_returns_unchanged(self, tmp_path: Path, monkeypatch):
+    def test_no_bwrap_raises_by_default(self, tmp_path: Path, monkeypatch):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        monkeypatch.setattr(
+            "operations_center.entrypoints.board_worker.sandbox.bwrap_available", lambda: False
+        )
+        monkeypatch.delenv("OC_SANDBOX_REQUIRED", raising=False)
+        with pytest.raises(sbx.ContainmentRequiredError):
+            maybe_sandbox(["python"], oc_root=tmp_path, rw_root=ws, env={}, enabled=True)
+
+    def test_no_bwrap_fail_open_when_opted_out(self, tmp_path: Path, monkeypatch):
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(
             "operations_center.entrypoints.board_worker.sandbox.bwrap_available", lambda: False
         )
         cmd = ["python"]
-        assert maybe_sandbox(cmd, oc_root=tmp_path, rw_root=ws, env={}, enabled=True) == cmd
+        out = maybe_sandbox(
+            cmd, oc_root=tmp_path, rw_root=ws, env={"OC_SANDBOX_REQUIRED": "0"}, enabled=True
+        )
+        assert out == cmd
 
     def test_enabled_but_degraded_logs_observable_warning(
         self, tmp_path: Path, monkeypatch, caplog
     ):
-        # Audit fix: enabled-but-degraded fail-open must be OBSERVABLE, not silent.
+        # Audit fix: enabled-but-degraded must be OBSERVABLE, not silent —
+        # the warning fires on the opted-out fail-open path too.
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(
             "operations_center.entrypoints.board_worker.sandbox.bwrap_available", lambda: False
         )
         with caplog.at_level("WARNING"):
-            maybe_sandbox(["python"], oc_root=tmp_path, rw_root=ws, env={}, enabled=True)
+            maybe_sandbox(
+                ["python"],
+                oc_root=tmp_path,
+                rw_root=ws,
+                env={"OC_SANDBOX_REQUIRED": "0"},
+                enabled=True,
+            )
         assert any("sandbox_degraded" in r.message for r in caplog.records)
 
     def test_disabled_does_not_warn(self, tmp_path: Path, monkeypatch, caplog):
@@ -285,16 +321,57 @@ class TestFailOpen:
         with pytest.raises(sbx.ContainmentRequiredError):
             maybe_sandbox(["python"], oc_root=tmp_path, rw_root=ws, env={}, enabled=True)
 
-    def test_not_required_still_fail_open(self, tmp_path: Path, monkeypatch):
+    def test_explicit_opt_out_fail_open(self, tmp_path: Path, monkeypatch):
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(
             "operations_center.entrypoints.board_worker.sandbox.bwrap_available", lambda: False
         )
-        # default (flag unset) preserves degrade-never-halt
+        # explicit opt-out restores the observable fail-open degrade
+        monkeypatch.setenv("OC_SANDBOX_REQUIRED", "0")
         assert maybe_sandbox(
             ["python"], oc_root=tmp_path, rw_root=ws, env={}, enabled=True
         ) == ["python"]
+
+    def test_required_by_default_when_flag_unset(self, tmp_path: Path, monkeypatch):
+        # Track A3 pin: an UNSET flag means required — this is the posture the
+        # audit flipped; a regression back to opt-in must fail here.
+        monkeypatch.delenv("OC_SANDBOX_REQUIRED", raising=False)
+        assert sbx._containment_required({}, var="OC_SANDBOX_REQUIRED") is True
+        assert sbx._containment_required({"OC_SANDBOX_REQUIRED": "0"}, var="OC_SANDBOX_REQUIRED") is False
+
+
+class TestDefaultsAndSelfCheck:
+    def test_sandbox_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+        assert sbx.sandbox_enabled() is True
+        monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
+        assert sbx.sandbox_enabled() is False
+        monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+        assert sbx.sandbox_enabled() is True
+
+    def test_verify_containment_reports_missing_bwrap(self, monkeypatch):
+        monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+        monkeypatch.setenv("OC_EGRESS_NETNS", "0")
+        monkeypatch.setattr(containment, "bwrap_available", lambda: False)
+        problems = sbx.verify_containment()
+        assert any("bwrap" in p for p in problems)
+
+    def test_verify_containment_reports_netns_gaps(self, monkeypatch):
+        monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
+        monkeypatch.delenv("OC_EGRESS_NETNS", raising=False)  # default on
+        monkeypatch.delenv("OC_EGRESS_PROXY", raising=False)
+        monkeypatch.setattr(
+            "operations_center.entrypoints.board_worker.netns.pasta_path", lambda: None
+        )
+        problems = sbx.verify_containment()
+        assert any("pasta" in p for p in problems)
+        assert any("OC_EGRESS_PROXY" in p for p in problems)
+
+    def test_verify_containment_clean_when_all_disabled(self, monkeypatch):
+        monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
+        monkeypatch.setenv("OC_EGRESS_NETNS", "0")
+        assert sbx.verify_containment() == []
 
 
 @pytest.mark.skipif(not _HAS_BWRAP, reason="bwrap not installed")
@@ -361,11 +438,11 @@ class TestEgressProxyWiring:
 
     def test_resolve_returns_none_when_unreachable(self, monkeypatch):
         # Set the flag but make the reachability probe fail -> fail-open (None).
-        monkeypatch.setattr(sbx, "_proxy_reachable", lambda url, **kw: False)
+        monkeypatch.setattr(containment, "_proxy_reachable", lambda url, **kw: False)
         assert sbx._resolve_egress_proxy({"OC_EGRESS_PROXY": "http://127.0.0.1:8889"}) is None
 
     def test_resolve_returns_url_when_reachable(self, monkeypatch):
-        monkeypatch.setattr(sbx, "_proxy_reachable", lambda url, **kw: True)
+        monkeypatch.setattr(containment, "_proxy_reachable", lambda url, **kw: True)
         assert (
             sbx._resolve_egress_proxy({"OC_EGRESS_PROXY": "http://127.0.0.1:8889"})
             == "http://127.0.0.1:8889"
@@ -373,14 +450,14 @@ class TestEgressProxyWiring:
 
     def test_resolve_falls_back_to_parent_env(self, monkeypatch):
         monkeypatch.setenv("OC_EGRESS_PROXY", "http://127.0.0.1:9999")
-        monkeypatch.setattr(sbx, "_proxy_reachable", lambda url, **kw: True)
+        monkeypatch.setattr(containment, "_proxy_reachable", lambda url, **kw: True)
         assert sbx._resolve_egress_proxy({}) == "http://127.0.0.1:9999"
 
     def test_maybe_sandbox_injects_proxy_when_reachable(self, tmp_path: Path, monkeypatch):
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(sbx, "bwrap_available", lambda: True)
-        monkeypatch.setattr(sbx, "_proxy_reachable", lambda url, **kw: True)
+        monkeypatch.setattr(containment, "_proxy_reachable", lambda url, **kw: True)
         env = {"HOME": str(tmp_path / "home"), "OC_EGRESS_PROXY": "http://127.0.0.1:8889"}
         argv = maybe_sandbox(["x"], oc_root=tmp_path, rw_root=ws, env=env, enabled=True)
         joined = " ".join(argv)
@@ -391,7 +468,7 @@ class TestEgressProxyWiring:
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(sbx, "bwrap_available", lambda: True)
-        monkeypatch.setattr(sbx, "_proxy_reachable", lambda url, **kw: False)
+        monkeypatch.setattr(containment, "_proxy_reachable", lambda url, **kw: False)
         env = {"HOME": str(tmp_path / "home"), "OC_EGRESS_PROXY": "http://127.0.0.1:8889"}
         argv = maybe_sandbox(["x"], oc_root=tmp_path, rw_root=ws, env=env, enabled=True)
         # dead proxy => no proxy env injected => still sandboxed, direct egress

--- a/tests/unit/entrypoints/board_worker/test_wheelhouse.py
+++ b/tests/unit/entrypoints/board_worker/test_wheelhouse.py
@@ -121,7 +121,9 @@ def test_tiktoken_cache_fail_open(tmp_path, monkeypatch):
 
 
 def test_provision_env_empty_when_sandbox_off(monkeypatch):
-    monkeypatch.delenv("OC_BWRAP_SANDBOX", raising=False)
+    # Track A3: the sandbox is default-ON — an explicit opt-out is what skips
+    # provisioning now.
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "0")
     assert wh.provision_env("Repo", "/x", python_bin="python3") == {}
 
 


### PR DESCRIPTION
**Track A3 of the grounded audit** (PlatformManifest docs/architecture/oc-audit-and-pseudooperator-spec.md §2).

The three containment layers were opt-in AND fail-open — a missing bwrap binary, absent pasta, or dead egress proxy silently ran the token-holding backend un-contained.

- `OC_BWRAP_SANDBOX` and `OC_EGRESS_NETNS` default **ON** (explicit `=0` disables)
- `OC_SANDBOX_REQUIRED` and `OC_EGRESS_REQUIRED` default **ON**: a degrade raises, and board_worker/reviewer already convert that into a failed **task** + fault — the fleet keeps serving (§0.1 degrade-never-halt holds at fleet level)
- new single gate `sandbox_enabled()` consumed by dispatch, reviewer, and wheelhouse (three call sites, one truth)
- new `verify_containment()` startup self-check logs `containment_selfcheck_failed` at boot instead of discovering the gap at task N
- posture layer extracted to `containment.py` (sandbox.py was over C29's 500-line limit)
- board_worker test conftest pins containment OFF for orchestration tests; containment tests opt in/out explicitly

**Deploy note:** live `.env` already enables sandbox/netns/proxy; the required-flags were unset and now default to required — breakage fails tasks visibly instead of running un-contained.

Suite green (8515 incl. reviewer root tests); ruff + custodian clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)