### PR TITLE
fix(board_worker): wall timeout on the executor subprocess (default 4500s)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-07-06 — Track A4: board-path executor wall timeout
+
+Audit defect: the reviewer path caps its executor at 1800s but the board path
+had NO timeout — a wedged agent pinned a worker slot forever. run_executor now
+enforces a wall timeout (default 4500s = inner team-executor cap 3600s + 15min
+grace, so the outer wall never races the inner; OC_EXECUTOR_TIMEOUT_SEC
+overrides, <=0 opts out). On expiry the child is killed and a synthesized
+CompletedProcess(returncode=124) flows through the existing failure paths —
+no caller changes needed. Structured executor_timeout log event.
+
 ## 2026-07-06 — Track A3: containment default-on + fail-closed per task
 
 Audit defect: bwrap/netns/egress were opt-in AND fail-open — a missing binary

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -15,6 +15,30 @@ from typing import Any
 from .netns import maybe_netns, netns_enabled
 from .sandbox import _resolve_egress_proxy, maybe_sandbox, sandbox_enabled
 
+# Hard wall-clock cap on the executor subprocess (audit Track A4). The reviewer
+# path caps its executor at 1800s; the board path had NO timeout, so a wedged
+# agent pinned a worker slot forever. Default = the inner team-executor cap
+# (3600s) + 15min grace so the outer wall never races the inner one; override
+# with OC_EXECUTOR_TIMEOUT_SEC. Values <= 0 disable (explicit opt-out).
+_EXECUTOR_TIMEOUT_ENV = "OC_EXECUTOR_TIMEOUT_SEC"
+_EXECUTOR_TIMEOUT_DEFAULT = 4500
+
+
+def executor_timeout_seconds() -> float | None:
+    raw = os.environ.get(_EXECUTOR_TIMEOUT_ENV, "")
+    try:
+        val = float(raw) if raw.strip() else float(_EXECUTOR_TIMEOUT_DEFAULT)
+    except ValueError:
+        logger.warning(
+            "board_worker: invalid %s=%r — using default %ds",
+            _EXECUTOR_TIMEOUT_ENV,
+            raw,
+            _EXECUTOR_TIMEOUT_DEFAULT,
+        )
+        val = float(_EXECUTOR_TIMEOUT_DEFAULT)
+    return val if val > 0 else None
+
+
 # SBX Layer 3 (resource limits): gated on this flag. Wraps the executor in a
 # transient systemd-user cgroup scope with memory/pids/cpu caps + a wall-timeout
 # backstop, so a runaway/stuck sandboxed run can't exhaust the host. Defaults are
@@ -329,4 +353,29 @@ def run_executor(
         # re-add ONLY those for the outer hop. bwrap --clearenv keeps them out of
         # the sandbox; un-sandboxed they are harmless (not secrets).
         run_env = {**env, **{k: os.environ[k] for k in _USER_BUS_ENV if k in os.environ}}
-    return subprocess.run(run_cmd, cwd=oc_root, env=run_env, capture_output=True, text=True)
+    timeout = executor_timeout_seconds()
+    try:
+        return subprocess.run(
+            run_cmd, cwd=oc_root, env=run_env, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired as exc:
+        # subprocess.run has already killed the child. Synthesize a completed
+        # process so every caller's existing failure path handles it uniformly
+        # (returncode 124 = the conventional timeout exit code).
+        def _text(stream: bytes | str | None) -> str:
+            if stream is None:
+                return ""
+            return stream.decode(errors="replace") if isinstance(stream, bytes) else stream
+
+        logger.error(
+            "board_worker: executor subprocess exceeded %ss wall timeout — killed "
+            '{"event": "executor_timeout", "timeout_s": %s}',
+            timeout,
+            timeout,
+        )
+        return subprocess.CompletedProcess(
+            args=list(run_cmd),
+            returncode=124,
+            stdout=_text(exc.stdout),
+            stderr=(_text(exc.stderr) + f"\n[board_worker] executor timed out after {timeout}s").strip(),
+        )

--- a/tests/unit/entrypoints/board_worker/test_netns.py
+++ b/tests/unit/entrypoints/board_worker/test_netns.py
@@ -253,3 +253,35 @@ def test_bwrap_inside_netns_runs_when_caps_kept():
     assert wrapped[0].endswith("pasta")
     r = subprocess.run(wrapped, capture_output=True, text=True, timeout=60)
     assert r.returncode == 0 and "NS-OK" in r.stdout, (r.returncode, r.stderr)
+
+
+# ── run_executor wall timeout (audit Track A4) ───────────────────────────────
+
+
+def test_run_executor_timeout_returns_completed_process_124(monkeypatch, tmp_path):
+    from operations_center.entrypoints.board_worker import _subprocess
+
+    def fake_run(cmd, **kw):
+        assert kw.get("timeout") == 4500.0  # default: inner cap 3600 + grace
+        raise _subprocess.subprocess.TimeoutExpired(cmd, kw["timeout"], output="partial", stderr="err")
+
+    monkeypatch.setattr(_subprocess.subprocess, "run", fake_run)
+    monkeypatch.delenv("OC_EXECUTOR_TIMEOUT_SEC", raising=False)
+    monkeypatch.delenv("OC_SANDBOX_RLIMITS", raising=False)
+    proc = _subprocess.run_executor(
+        ["echo", "hi"], oc_root=tmp_path, rw_root=tmp_path, workspace=tmp_path, env={}
+    )
+    assert proc.returncode == 124
+    assert "timed out after" in proc.stderr
+    assert proc.stdout == "partial"
+
+
+def test_executor_timeout_env_override_and_opt_out(monkeypatch):
+    from operations_center.entrypoints.board_worker import _subprocess
+
+    monkeypatch.setenv("OC_EXECUTOR_TIMEOUT_SEC", "120")
+    assert _subprocess.executor_timeout_seconds() == 120.0
+    monkeypatch.setenv("OC_EXECUTOR_TIMEOUT_SEC", "0")
+    assert _subprocess.executor_timeout_seconds() is None
+    monkeypatch.setenv("OC_EXECUTOR_TIMEOUT_SEC", "junk")
+    assert _subprocess.executor_timeout_seconds() == 4500.0


### PR DESCRIPTION
**Track A4 of the grounded audit.**

The reviewer path caps its executor at 1800s; the board path had **no timeout** — a wedged agent pinned a worker slot forever.

- `run_executor` enforces a wall timeout: default **4500s** (inner team-executor cap 3600s + 15min grace, so the outer wall never races the inner)
- `OC_EXECUTOR_TIMEOUT_SEC` overrides; `<=0` opts out explicitly
- on expiry the child is killed and a synthesized `CompletedProcess(returncode=124)` flows through the existing failure paths — no caller changes
- structured `executor_timeout` log event; tests pin default, override, opt-out, and the 124 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)