### PR TITLE
fix(audit_dispatch): default 1800s dispatch timeout + refuse COMPLETED on non-terminal run_status

### DIFF
--- a/src/operations_center/audit_dispatch/api.py
+++ b/src/operations_center/audit_dispatch/api.py
@@ -35,6 +35,7 @@ from .executor import ManagedAuditExecutor
 from .lifecycle import discover_post_execution
 from .locks import acquire_audit_lock
 from .models import (
+    TERMINAL_RUN_STATUSES,
     DispatchStatus,
     FailureKind,
     ManagedAuditDispatchRequest,
@@ -228,6 +229,16 @@ def dispatch_managed_audit(
         status = DispatchStatus.FAILED
         failure_kind = FailureKind.PROCESS_NONZERO_EXIT
         error = f"process exited with code {proc_result.exit_code}"
+    elif discovery.run_status_value not in TERMINAL_RUN_STATUSES:
+        # Producer exited 0 and the contract files parse, but its OWN status is
+        # still pending/running/in_progress — the audit did not finish; reporting
+        # COMPLETED here was the audit Track A5 false-success hole.
+        status = DispatchStatus.FAILED
+        failure_kind = FailureKind.RUN_STATUS_NOT_TERMINAL
+        error = (
+            f"run_status.json reports non-terminal status "
+            f"{discovery.run_status_value!r} despite process exit 0"
+        )
     else:
         status = DispatchStatus.COMPLETED
         failure_kind = None

--- a/src/operations_center/audit_dispatch/lifecycle.py
+++ b/src/operations_center/audit_dispatch/lifecycle.py
@@ -42,10 +42,19 @@ class PostExecutionDiscovery:
     artifact_manifest_path: str | None = None
     failure_kind: FailureKind | None = None
     failure_reason: str | None = None
+    # The parsed run_status.json `status` value (None when parsing never got
+    # that far). Lets the dispatch decision refuse to report COMPLETED for a
+    # producer whose own status is still non-terminal (audit Track A5).
+    run_status_value: str | None = None
 
     @property
     def succeeded(self) -> bool:
         return self.failure_kind is None
+
+
+def _status_value(run_status) -> str | None:
+    val = getattr(run_status, "status", None)
+    return getattr(val, "value", val)
 
 
 def _find_run_status_path(
@@ -149,15 +158,18 @@ def discover_post_execution(
             run_status_path=str(run_status_path),
             failure_kind=FailureKind.MANIFEST_PATH_MISSING,
             failure_reason=str(exc),
+            run_status_value=_status_value(run_status),
         )
     except ArtifactManifestPathResolutionError as exc:
         return PostExecutionDiscovery(
             run_status_path=str(run_status_path),
             failure_kind=FailureKind.MANIFEST_PATH_UNRESOLVABLE,
             failure_reason=str(exc),
+            run_status_value=_status_value(run_status),
         )
 
     return PostExecutionDiscovery(
         run_status_path=str(run_status_path),
         artifact_manifest_path=str(manifest_path),
+        run_status_value=_status_value(run_status),
     )

--- a/src/operations_center/audit_dispatch/models.py
+++ b/src/operations_center/audit_dispatch/models.py
@@ -10,6 +10,17 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from operations_center.audit_contracts.vocabulary import RunStatus
+
+# Run-status values that mean the producer actually finished. A run_status.json
+# still saying pending/running/in_progress after the process exited 0 means the
+# producer died before finalizing (or OC matched a stale bucket) — that is a
+# FAILURE, not a completion. Shared by the dispatch decision (api.py) and the
+# watcher so the two cannot drift.
+TERMINAL_RUN_STATUSES = frozenset(
+    {RunStatus.COMPLETED.value, RunStatus.FAILED.value, RunStatus.INTERRUPTED.value}
+)
+
 
 class DispatchStatus(str, Enum):
     """Canonical status of a dispatch attempt, aligned with Phase 2 RunStatus vocabulary."""
@@ -33,6 +44,9 @@ class FailureKind(str, Enum):
     RUN_STATUS_MISSING = "run_status_missing"
     RUN_STATUS_INVALID = "run_status_invalid"
     MANIFEST_PATH_MISSING = "manifest_path_missing"
+    # Producer exited 0 and contract files parse, but run_status.json is not in
+    # a terminal state — the audit did not actually finish (audit Track A5).
+    RUN_STATUS_NOT_TERMINAL = "run_status_not_terminal"
     MANIFEST_PATH_UNRESOLVABLE = "manifest_path_unresolvable"
     UNKNOWN = "unknown"
 
@@ -55,8 +69,12 @@ class ManagedAuditDispatchRequest(BaseModel, frozen=True):
         ),
     )
     timeout_seconds: float | None = Field(
-        default=None,
-        description="Hard wall-clock timeout in seconds. None = no timeout.",
+        default=1800.0,
+        description=(
+            "Hard wall-clock timeout in seconds. Defaults to 1800 (audit Track "
+            "A5: a wedged producer must not hang the dispatcher forever). "
+            "None = no timeout (explicit opt-out)."
+        ),
     )
     requested_by: str | None = Field(
         default=None,

--- a/src/operations_center/audit_dispatch/watcher.py
+++ b/src/operations_center/audit_dispatch/watcher.py
@@ -20,13 +20,9 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
-from operations_center.audit_contracts.vocabulary import RunStatus
+from operations_center.audit_dispatch.models import TERMINAL_RUN_STATUSES
 
-_TERMINAL_STATUSES = {
-    RunStatus.COMPLETED.value,
-    RunStatus.FAILED.value,
-    RunStatus.INTERRUPTED.value,
-}
+_TERMINAL_STATUSES = TERMINAL_RUN_STATUSES
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/operations_center/audit_governance/runner.py
+++ b/src/operations_center/audit_governance/runner.py
@@ -94,7 +94,7 @@ def run_governed_audit(
     output_dir: Path | str | None = None,
     config_dir: Path | str | None = None,
     log_dir: Path | str | None = None,
-    dispatch_timeout_seconds: float | None = None,
+    dispatch_timeout_seconds: float | None = 1800.0,
 ) -> AuditGovernedRunResult:
     """Evaluate governance and optionally call Phase 6 dispatch.
 

--- a/src/operations_center/entrypoints/audit/main.py
+++ b/src/operations_center/entrypoints/audit/main.py
@@ -95,8 +95,10 @@ def cmd_run(
         "--allow-unverified",
         help="Allow audit types with command_status='not_yet_run'.",
     ),
-    timeout: float | None = typer.Option(
-        None, "--timeout", help="Hard timeout in seconds. Omit for no timeout."
+    timeout: float = typer.Option(
+        1800.0,
+        "--timeout",
+        help="Hard timeout in seconds (default 1800). Pass 0 to disable (no timeout).",
     ),
     requested_by: str | None = typer.Option(None, "--requested-by", help="Caller identity."),
     log_dir: str | None = typer.Option(None, "--log-dir", help="Override stdout/stderr log dir."),
@@ -107,7 +109,7 @@ def cmd_run(
         repo_id=repo,
         audit_type=audit_type,
         allow_unverified_command=allow_unverified,
-        timeout_seconds=timeout,
+        timeout_seconds=timeout if timeout and timeout > 0 else None,
         requested_by=requested_by,
     )
 
@@ -194,7 +196,9 @@ def cmd_dispatch(
     repo_id: str = typer.Argument(..., help="Managed repo ID."),
     audit_type: str = typer.Argument(..., help="Audit type."),
     allow_unverified: bool = typer.Option(False, "--allow-unverified"),
-    timeout: float | None = typer.Option(None, "--timeout"),
+    timeout: float = typer.Option(
+        1800.0, "--timeout", help="Hard timeout in seconds (default 1800). 0 disables."
+    ),
     requested_by: str | None = typer.Option(None, "--requested-by"),
     log_dir: str | None = typer.Option(None, "--log-dir"),
     json_output: bool = typer.Option(False, "--json"),

--- a/src/operations_center/entrypoints/governance/main.py
+++ b/src/operations_center/entrypoints/governance/main.py
@@ -201,7 +201,11 @@ def cmd_run(
     ),
     known_repos: str = typer.Option("", "--known-repos", help="Comma-separated known repo IDs."),
     known_types: str = typer.Option("", "--known-types", help="Comma-separated audit types."),
-    timeout: float | None = typer.Option(None, "--timeout", help="Dispatch timeout in seconds."),
+    timeout: float = typer.Option(
+        1800.0,
+        "--timeout",
+        help="Dispatch timeout in seconds (default 1800). Pass 0 to disable.",
+    ),
 ) -> None:
     """Evaluate governance and run the audit if approved."""
     try:
@@ -238,7 +242,7 @@ def cmd_run(
         approval=approval,
         governance_config=cfg,
         output_dir=output_dir,
-        dispatch_timeout_seconds=timeout,
+        dispatch_timeout_seconds=timeout if timeout and timeout > 0 else None,
     )
 
     color = _status_color(result.governance_status)

--- a/tests/unit/audit_dispatch/test_api.py
+++ b/tests/unit/audit_dispatch/test_api.py
@@ -385,6 +385,46 @@ manifest.write_text(json.dumps({{
         assert result.artifact_manifest_path is not None
         assert result.process_exit_code == 0
 
+    def test_nonterminal_run_status_reports_failed(self, tmp_path: Path) -> None:
+        # Audit Track A5: exit 0 + parseable contract files but run_status.json
+        # still says in_progress => the audit did NOT finish; COMPLETED here was
+        # the false-success hole.
+        from operations_center.audit_dispatch.lifecycle import PostExecutionDiscovery
+        from operations_center.audit_dispatch.models import FailureKind
+
+        run_id = _RUN_ID
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        prepared = _make_fake_invocation(tmp_path, run_id)
+        prepared.request.command = self._build_fake_command(tmp_path, run_id)
+        prepared.request.expected_output_dir = "output"
+
+        with (
+            patch(
+                "operations_center.audit_dispatch.api.prepare_managed_audit_invocation",
+                return_value=prepared,
+            ),
+            patch(
+                "operations_center.audit_dispatch.api._resolve_abs_working_dir",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "operations_center.audit_dispatch.api.discover_post_execution",
+                return_value=PostExecutionDiscovery(
+                    run_status_path="rs.json",
+                    artifact_manifest_path="am.json",
+                    run_status_value="in_progress",
+                ),
+            ),
+        ):
+            req = _make_request(cwd_override=str(tmp_path))
+            result = dispatch_managed_audit(req, config_dir=_CONFIG_DIR, log_dir=tmp_path / "logs")
+
+        assert result.status == DispatchStatus.FAILED
+        assert result.failure_kind == FailureKind.RUN_STATUS_NOT_TERMINAL
+        assert "in_progress" in (result.error or "")
+
     def test_audit_run_id_passed_in_env(self, tmp_path: Path) -> None:
         """Verify AUDIT_RUN_ID appears in the process environment."""
         run_id = _RUN_ID

--- a/tests/unit/audit_dispatch/test_models.py
+++ b/tests/unit/audit_dispatch/test_models.py
@@ -60,8 +60,15 @@ class TestDispatchRequestValidation:
         )
         assert req.timeout_seconds == 300.0
 
-    def test_timeout_none_is_valid(self) -> None:
+    def test_timeout_defaults_to_1800(self) -> None:
+        # Audit Track A5: a wedged producer must not hang the dispatcher forever.
         req = ManagedAuditDispatchRequest(repo_id="example_managed_repo", audit_type="audit_type_1")
+        assert req.timeout_seconds == 1800.0
+
+    def test_timeout_none_is_explicit_opt_out(self) -> None:
+        req = ManagedAuditDispatchRequest(
+            repo_id="example_managed_repo", audit_type="audit_type_1", timeout_seconds=None
+        )
         assert req.timeout_seconds is None
 
     def test_default_metadata_is_empty_dict(self) -> None:


### PR DESCRIPTION
**Track A5 of the grounded audit.**

Two defects:
1. **timeout=None everywhere**: the request model, `run_governed_audit`, and both CLIs (`audit run`, `governance run`) defaulted to no timeout — a wedged producer audit hung the dispatcher forever. All now default **1800s**; `--timeout 0` / `timeout_seconds=None` is the explicit opt-out.
2. **False success**: the COMPLETED decision never read `run_status.json`'s own status — exit 0 + parseable contract files + status still `in_progress` was reported COMPLETED. New `TERMINAL_RUN_STATUSES` (shared with the watcher so they can't drift) + `FailureKind.RUN_STATUS_NOT_TERMINAL`: non-terminal producer status now reports FAILED.

Note: the audit's premature-lock-release claim was partially wrong — the lock IS held through `executor.execute()`; release-before-discovery is read-only post-processing, left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)