### PR TITLE
feat(security): per-task GitHub App installation tokens for the executor sandbox

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,19 @@
+## 2026-07-06 — Track A6: sandbox token hardening (per-task App tokens)
+
+Audit defect: the long-lived gho_ OAuth token (write-capable everywhere,
+never expires) was forwarded into the bwrap sandbox env. New
+adapters/github_app.py mints a per-task GitHub App installation token
+(repo-scoped, ~1h TTL, contents+pull_requests write; RS256 JWT built with
+cryptography — no new dependency) in the PARENT process; harden_git_token in
+_subprocess swaps every token-carrying env var before the sandbox spawns
+(board dispatch + reviewer pipeline both wired). App key never enters the
+sandbox. Mint failure fails the TASK closed (OC_APP_TOKEN_REQUIRED=0 opts
+out). Unconfigured App = unchanged behavior + a once-per-process
+long_lived_token_in_sandbox warning. DEPLOY PREREQUISITE: register the App
+(or accept the warning), set git.github_app_id + github_app_key_path in
+operations_center.local.yaml. Spec: PlatformManifest
+docs/architecture/sandbox-token-hardening-spec.md. (C41 ensure_ascii fix.)
+
 ## 2026-07-06 — Track A4: board-path executor wall timeout
 
 Audit defect: the reviewer path caps its executor at 1800s but the board path

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -22,6 +22,14 @@ plane:
 git:
   provider: github
   token_env: GITHUB_TOKEN               # env var holding your GitHub token (global fallback)
+  # Sandbox token hardening (Track A6): when both are set, each task gets a
+  # freshly minted GitHub App installation token (repo-scoped, ~1h TTL,
+  # contents+pull_requests write) instead of the long-lived token above — the
+  # long-lived credential never enters the executor sandbox. The key file must
+  # NOT live under a path bound into the sandbox. Minting failure fails the
+  # task (opt out with OC_APP_TOKEN_REQUIRED=0).
+  # github_app_id: "123456"
+  # github_app_key_path: /secure/path/oc-github-app.private-key.pem
   open_pr_default: false                # open a PR by default after push (per-repo overrides this)
   push_on_validation_failure: true      # push a draft branch even when validation fails
   author_name: Operations Center Bot

--- a/src/operations_center/adapters/github_app.py
+++ b/src/operations_center/adapters/github_app.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Per-task GitHub App installation tokens (sandbox token hardening, Track A6).
+
+The board worker used to forward the operator's long-lived OAuth token
+(``gho_…``, write-capable across every owned repo, valid until revoked) into
+the bwrap sandbox — the environment that runs arbitrary LLM-generated code.
+This module mints a **per-task installation token** instead: ``ghs_…``, fixed
+~1 hour TTL, scoped to exactly the task's repository with
+``contents:write`` + ``pull_requests:write``. If the sandbox leaks it, the
+blast radius is one repo for under an hour, and the credential cannot be
+renewed from inside (the App private key never enters the sandbox).
+
+Flow (all in the PARENT worker process, before the sandbox spawns):
+  1. Build a short-lived RS256 JWT from the App id + private key.
+  2. ``GET /repos/{owner}/{repo}/installation`` → installation id.
+  3. ``POST /app/installations/{id}/access_tokens`` with the repo +
+     permission restriction → the scoped token.
+
+Spec: PlatformManifest docs/architecture/sandbox-token-hardening-spec.md.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+from pathlib import Path
+
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+logger = logging.getLogger(__name__)
+
+_API = "https://api.github.com"
+# The token must outlive clock skew on GitHub's side; iat is backdated 60s and
+# the JWT expires after 9 minutes (GitHub caps at 10).
+_JWT_BACKDATE_S = 60
+_JWT_TTL_S = 540
+
+
+class GitHubAppTokenError(RuntimeError):
+    """Installation-token minting failed (config, key, or API error)."""
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _app_jwt(app_id: str, private_key_pem: bytes) -> str:
+    """RS256 App JWT built directly with `cryptography` (no PyJWT dependency)."""
+    try:
+        key = serialization.load_pem_private_key(private_key_pem, password=None)
+    except (ValueError, TypeError) as exc:
+        raise GitHubAppTokenError(f"cannot load GitHub App private key: {exc}") from exc
+    now = int(time.time())
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}, ensure_ascii=False).encode())
+    payload = _b64url(
+        json.dumps(
+            {"iat": now - _JWT_BACKDATE_S, "exp": now + _JWT_TTL_S, "iss": str(app_id)},
+            ensure_ascii=False,
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}".encode()
+    signature = key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    return f"{header}.{payload}.{_b64url(signature)}"
+
+
+def mint_installation_token(
+    *,
+    app_id: str,
+    private_key_path: str | Path,
+    owner: str,
+    repo: str,
+    api_url: str = _API,
+) -> str:
+    """Mint a repo-scoped, ~1h-TTL installation token for ``owner/repo``.
+
+    Raises GitHubAppTokenError on any failure — the caller decides whether to
+    degrade to the configured long-lived token (observable warning) or fail.
+    """
+    try:
+        pem = Path(private_key_path).read_bytes()
+    except OSError as exc:
+        raise GitHubAppTokenError(
+            f"cannot read GitHub App key file {private_key_path}: {exc}"
+        ) from exc
+    jwt = _app_jwt(app_id, pem)
+    headers = {
+        "Authorization": f"Bearer {jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        inst = httpx.get(
+            f"{api_url}/repos/{owner}/{repo}/installation", headers=headers, timeout=30
+        )
+        if inst.status_code != 200:
+            raise GitHubAppTokenError(
+                f"installation lookup for {owner}/{repo} failed: "
+                f"{inst.status_code} {inst.text[:200]}"
+            )
+        installation_id = inst.json()["id"]
+        resp = httpx.post(
+            f"{api_url}/app/installations/{installation_id}/access_tokens",
+            headers=headers,
+            json={
+                "repositories": [repo],
+                "permissions": {"contents": "write", "pull_requests": "write"},
+            },
+            timeout=30,
+        )
+    except httpx.HTTPError as exc:
+        raise GitHubAppTokenError(f"GitHub App token request failed: {exc}") from exc
+    if resp.status_code != 201:
+        raise GitHubAppTokenError(
+            f"installation token mint failed: {resp.status_code} {resp.text[:200]}"
+        )
+    token = resp.json().get("token")
+    if not token:
+        raise GitHubAppTokenError("installation token response had no 'token' field")
+    logger.info(
+        'github_app: minted per-task installation token for %s/%s '
+        '{"event": "app_token_minted", "repo": "%s/%s"}',
+        owner,
+        repo,
+        owner,
+        repo,
+    )
+    return token
+
+
+__all__ = ["GitHubAppTokenError", "mint_installation_token"]

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -20,6 +20,14 @@ class PlaneSettings(BaseModel):
 
 class GitSettings(BaseModel):
     token_env: str | None = None
+    # Sandbox token hardening (audit Track A6). When both are set, the board
+    # worker mints a per-task GitHub App installation token (~1h TTL, scoped to
+    # the task's repo, contents+pull_requests write only) and forwards THAT
+    # into the executor sandbox instead of the long-lived token in token_env.
+    # The App private key itself never enters the sandbox. Spec:
+    # PlatformManifest docs/architecture/sandbox-token-hardening-spec.md.
+    github_app_id: str | None = None
+    github_app_key_path: str | None = None
     open_pr_default: bool = True
     push_on_validation_failure: bool = True
     author_name: str = "Operations Center Bot"

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -212,6 +212,79 @@ def git_token_passthrough(settings: Any, repo_cfg: Any) -> tuple[str, ...]:
     return (name,) if isinstance(name, str) else ()
 
 
+# Env var names that may carry the git token into the executor env (mirrors
+# sandbox._GIT_TOKEN_ENVS; the WorkspaceManager inside the executor reads the
+# configured token_env, which is one of these in every live config).
+_GIT_TOKEN_VARS = ("GITHUB_TOKEN", "GIT_TOKEN")
+_warned_long_lived_token = False
+
+
+def harden_git_token(env: dict, *, settings: Any, clone_url: str) -> dict:
+    """Swap the long-lived git token in ``env`` for a per-task App token.
+
+    Sandbox token hardening (audit Track A6): when git.github_app_id +
+    git.github_app_key_path are configured, every token-carrying env var is
+    replaced with a freshly minted installation token (~1h TTL, one-repo
+    scope, contents+pull_requests write). The long-lived operator credential
+    then never enters the sandbox. Minting failure fails CLOSED via
+    ContainmentRequiredError (the worker fails the task, not the fleet);
+    opt out with OC_APP_TOKEN_REQUIRED=0 to degrade to the configured token
+    with an observable warning.
+
+    Unconfigured App => env returned unchanged, with a once-per-process
+    warning that a long-lived credential is entering the sandbox.
+    """
+    global _warned_long_lived_token
+    from .sandbox import ContainmentRequiredError, sandbox_enabled
+
+    token_vars = [v for v in _GIT_TOKEN_VARS if env.get(v)]
+    if not token_vars:
+        return env
+    git_cfg = getattr(settings, "git", None)
+    app_id = getattr(git_cfg, "github_app_id", None)
+    key_path = getattr(git_cfg, "github_app_key_path", None)
+    if not (app_id and key_path):
+        if sandbox_enabled() and not _warned_long_lived_token:
+            _warned_long_lived_token = True
+            logger.warning(
+                "board_worker: forwarding a LONG-LIVED git token into the sandbox — "
+                "configure git.github_app_id + git.github_app_key_path for per-task "
+                'tokens {"event": "long_lived_token_in_sandbox"}'
+            )
+        return env
+    from operations_center.adapters.github_app import GitHubAppTokenError, mint_installation_token
+    from operations_center.adapters.github_pr import GitHubPRClient
+
+    try:
+        owner, repo = GitHubPRClient.owner_repo_from_clone_url(clone_url)
+        token = mint_installation_token(
+            app_id=str(app_id), private_key_path=str(key_path), owner=owner, repo=repo
+        )
+    except (GitHubAppTokenError, ValueError) as exc:
+        required = str(os.environ.get("OC_APP_TOKEN_REQUIRED", "1")).strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+        logger.error(
+            'board_worker: per-task App token mint FAILED — %s '
+            '{"event": "token_hardening_degraded", "required": %s}',
+            exc,
+            str(required).lower(),
+        )
+        if required:
+            raise ContainmentRequiredError(
+                f"per-task App token required (git.github_app_id configured; opt out "
+                f"with OC_APP_TOKEN_REQUIRED=0) but minting failed: {exc}"
+            ) from exc
+        return env
+    hardened = dict(env)
+    for var in token_vars:
+        hardened[var] = token
+    return hardened
+
+
 def build_env(oc_root: Path) -> dict:
     """Deprecated: use build_allowlist_env() instead."""
     return build_allowlist_env(oc_root)

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from operations_center.injection import wrap_untrusted_goal
 
-from ._subprocess import build_allowlist_env, git_token_passthrough, run_executor
+from ._subprocess import build_allowlist_env, git_token_passthrough, harden_git_token, run_executor
 from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv_python
 from .wheelhouse import provision_env
 from ._text import append_rejection_patterns, desc_text, extract_goal, task_type_from_kind
@@ -91,6 +91,9 @@ def dispatch_issue(
     oc_root = Path(__file__).resolve().parents[4]
     python = venv_python(oc_root)
     env = build_allowlist_env(oc_root, passthrough=git_token_passthrough(settings, repo_cfg))
+    # Track A6: swap the long-lived git token for a per-task App installation
+    # token (repo-scoped, ~1h TTL) before anything sandbox-bound sees the env.
+    env = harden_git_token(env, settings=settings, clone_url=clone_url)
     env.update(provision_env(repo_key, repo_path, python_bin=python))  # offline deps
     short_id = task_id[:8]
 

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -60,6 +60,7 @@ from operations_center.close_invariants import (
 from operations_center.entrypoints.board_worker._subprocess import (
     build_allowlist_env,
     git_token_passthrough,
+    harden_git_token,
 )
 from operations_center.entrypoints.board_worker.netns import (
     EgressContainmentRequiredError,
@@ -735,6 +736,12 @@ def _run_pipeline(
         if _sandbox_enabled():
             exec_env = build_allowlist_env(
                 oc_root, passthrough=git_token_passthrough(settings, repo_cfg)
+            )
+            # Track A6: per-task App installation token instead of the
+            # long-lived credential — the reviewer executor runs the
+            # least-trusted input of all.
+            exec_env = harden_git_token(
+                exec_env, settings=settings, clone_url=getattr(repo_cfg, "clone_url", "")
             )
             run_exec_cmd = maybe_sandbox(
                 exec_cmd,

--- a/tests/unit/entrypoints/board_worker/test_token_hardening.py
+++ b/tests/unit/entrypoints/board_worker/test_token_hardening.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Sandbox token hardening (audit Track A6).
+
+The long-lived operator git token must never enter the executor sandbox when a
+GitHub App is configured — a per-task installation token (repo-scoped, ~1h
+TTL) replaces it in the forwarded env. Minting failure fails CLOSED per task
+unless explicitly opted out.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from operations_center.adapters import github_app
+from operations_center.entrypoints.board_worker import _subprocess
+from operations_center.entrypoints.board_worker.sandbox import ContainmentRequiredError
+
+CLONE_URL = "https://github.com/acme/widgets.git"
+
+
+def _settings(app_id=None, key_path=None):
+    return SimpleNamespace(
+        git=SimpleNamespace(github_app_id=app_id, github_app_key_path=key_path)
+    )
+
+
+def test_unconfigured_app_leaves_env_and_warns_once(monkeypatch, caplog):
+    monkeypatch.setattr(_subprocess, "_warned_long_lived_token", False)
+    monkeypatch.setenv("OC_BWRAP_SANDBOX", "1")
+    env = {"GITHUB_TOKEN": "gho_longlived"}
+    with caplog.at_level("WARNING"):
+        out = _subprocess.harden_git_token(env, settings=_settings(), clone_url=CLONE_URL)
+    assert out["GITHUB_TOKEN"] == "gho_longlived"
+    assert any("long_lived_token_in_sandbox" in r.message for r in caplog.records)
+
+
+def test_no_token_in_env_is_a_noop():
+    out = _subprocess.harden_git_token(
+        {"PATH": "/bin"}, settings=_settings("1", "/k"), clone_url=CLONE_URL
+    )
+    assert out == {"PATH": "/bin"}
+
+
+def test_configured_app_swaps_all_token_vars(monkeypatch):
+    monkeypatch.setattr(
+        "operations_center.adapters.github_app.mint_installation_token",
+        lambda **kw: "ghs_ephemeral",
+    )
+    env = {"GITHUB_TOKEN": "gho_longlived", "GIT_TOKEN": "gho_longlived", "PATH": "/bin"}
+    out = _subprocess.harden_git_token(
+        env, settings=_settings("12345", "/tmp/key.pem"), clone_url=CLONE_URL
+    )
+    assert out["GITHUB_TOKEN"] == "ghs_ephemeral"
+    assert out["GIT_TOKEN"] == "ghs_ephemeral"
+    assert "gho_longlived" not in out.values()
+    # original env untouched (hardened copy returned)
+    assert env["GITHUB_TOKEN"] == "gho_longlived"
+
+
+def test_mint_failure_fails_closed_by_default(monkeypatch):
+    def boom(**kw):
+        raise github_app.GitHubAppTokenError("api down")
+
+    monkeypatch.setattr("operations_center.adapters.github_app.mint_installation_token", boom)
+    monkeypatch.delenv("OC_APP_TOKEN_REQUIRED", raising=False)
+    with pytest.raises(ContainmentRequiredError):
+        _subprocess.harden_git_token(
+            {"GITHUB_TOKEN": "gho_x"}, settings=_settings("1", "/k"), clone_url=CLONE_URL
+        )
+
+
+def test_mint_failure_degrades_when_opted_out(monkeypatch, caplog):
+    def boom(**kw):
+        raise github_app.GitHubAppTokenError("api down")
+
+    monkeypatch.setattr("operations_center.adapters.github_app.mint_installation_token", boom)
+    monkeypatch.setenv("OC_APP_TOKEN_REQUIRED", "0")
+    with caplog.at_level("ERROR"):
+        out = _subprocess.harden_git_token(
+            {"GITHUB_TOKEN": "gho_x"}, settings=_settings("1", "/k"), clone_url=CLONE_URL
+        )
+    assert out["GITHUB_TOKEN"] == "gho_x"
+    assert any("token_hardening_degraded" in r.message for r in caplog.records)
+
+
+# ── github_app adapter ────────────────────────────────────────────────────────
+
+
+def _rsa_pem() -> bytes:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+
+
+def test_app_jwt_shape():
+    token = github_app._app_jwt("42", _rsa_pem())
+    header_b64, payload_b64, sig_b64 = token.split(".")
+
+    def _decode(part: str) -> dict:
+        return json.loads(base64.urlsafe_b64decode(part + "=" * (-len(part) % 4)))
+
+    assert _decode(header_b64) == {"alg": "RS256", "typ": "JWT"}
+    payload = _decode(payload_b64)
+    assert payload["iss"] == "42"
+    assert payload["exp"] - payload["iat"] == 600  # 60s backdate + 540s ttl
+    assert sig_b64
+
+
+def test_mint_installation_token_happy_path(monkeypatch, tmp_path):
+    key_file = tmp_path / "app.pem"
+    key_file.write_bytes(_rsa_pem())
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append(("GET", url))
+        return SimpleNamespace(status_code=200, json=lambda: {"id": 77}, text="")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append(("POST", url, json))
+        assert json["repositories"] == ["widgets"]
+        assert json["permissions"] == {"contents": "write", "pull_requests": "write"}
+        return SimpleNamespace(
+            status_code=201, json=lambda: {"token": "ghs_new"}, text=""
+        )
+
+    monkeypatch.setattr(github_app.httpx, "get", fake_get)
+    monkeypatch.setattr(github_app.httpx, "post", fake_post)
+    token = github_app.mint_installation_token(
+        app_id="42", private_key_path=key_file, owner="acme", repo="widgets"
+    )
+    assert token == "ghs_new"
+    assert calls[0][1].endswith("/repos/acme/widgets/installation")
+    assert "/app/installations/77/access_tokens" in calls[1][1]
+
+
+def test_mint_installation_token_missing_key_raises(tmp_path):
+    with pytest.raises(github_app.GitHubAppTokenError):
+        github_app.mint_installation_token(
+            app_id="42", private_key_path=tmp_path / "nope.pem", owner="a", repo="b"
+        )


### PR DESCRIPTION
**Track A6 of the grounded audit** — spec: PlatformManifest `docs/architecture/sandbox-token-hardening-spec.md`.

The long-lived OAuth token (write-capable across every owned repo, valid until revoked) was forwarded into the bwrap sandbox env — the process that runs arbitrary LLM-generated code.

- new `adapters/github_app.py`: per-task installation token (repo-scoped, ~1h TTL, `contents`+`pull_requests` write only); RS256 App JWT built with `cryptography` — no new dependency
- `harden_git_token` swaps every token-carrying env var in the **parent** process before the sandbox spawns; wired into board dispatch AND the reviewer pipeline
- the App private key never enters the sandbox
- mint failure fails the **task** closed via `ContainmentRequiredError` (existing handlers); `OC_APP_TOKEN_REQUIRED=0` opts out to an observable degrade
- unconfigured App: unchanged behavior + a once-per-process `long_lived_token_in_sandbox` warning

**Deploy prerequisite:** register the GitHub App and set `git.github_app_id` + `git.github_app_key_path` in `operations_center.local.yaml` (key file outside any sandbox-bound path). Until then the warning fires but nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)