### PR TITLE
fix(board_worker): verify the PUSHED branch's scope out-of-process

### DIFF
--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -19,6 +19,7 @@ from ._subprocess import is_transient_failure, persist_failure_diagnostics, venv
 from .wheelhouse import provision_env
 from ._text import append_rejection_patterns, desc_text, extract_goal, task_type_from_kind
 from .labels import GITHUB_DIR, add_label, build_forwarded_labels, label_value
+from .scope_check import verify_pushed_scope
 from .outcomes import (
     fail_task,
     handle_failure,
@@ -304,6 +305,21 @@ def dispatch_issue(
             and result.get("branch_pushed") is False
             and result.get("failure_category") == "scope_too_wide"
         )
+
+        # Track A8: out-of-process scope verification. The executor's own scope
+        # gates run INSIDE the sandbox; the parent re-diffs the PUSHED branch
+        # from the remote (the committed tree) against the declared allowlist.
+        if success and not scope_too_wide:
+            scope_error = verify_pushed_scope(
+                bundle=bundle,
+                result=result,
+                repo_path=repo_path,
+                base_branch=base_branch,
+                task_branch=f"{role}/{short_id}",
+            )
+            if scope_error:
+                fail_task(client, task_id, role, scope_error)
+                return False
 
         if success and not scope_too_wide:
             logger.info(

--- a/src/operations_center/entrypoints/board_worker/scope_check.py
+++ b/src/operations_center/entrypoints/board_worker/scope_check.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Parent-side scope verification of the PUSHED branch (audit Track A8).
+
+The executor's own scope gates (workspace.py: diff caps + the allowed_paths
+allowlist check) run INSIDE the bwrap-sandboxed process — the same process the
+agent's code-writing adapter runs in. A compromised or misbehaving executor
+can push out-of-scope changes and still write a clean result.json; the parent
+worker previously trusted those self-reported fields verbatim.
+
+This module re-verifies OUT-OF-PROCESS, against the COMMITTED tree: the parent
+fetches the pushed task branch from the remote (not the agent-writable
+workspace) and diffs it against the base branch. Only when the task declared a
+non-empty ``allowed_paths`` allowlist is there anything to enforce — same
+semantics as the in-sandbox gate, but now on an independently observed diff.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+
+from operations_center.application.scope_policy import ChangedFilePolicyChecker
+
+logger = logging.getLogger(__name__)
+
+_GIT_TIMEOUT_S = 120
+
+
+class ScopeVerificationError(RuntimeError):
+    """The pushed branch could not be independently verified (fetch/diff
+    failure). Fail closed: an unverifiable diff must not be treated as
+    in-scope."""
+
+
+def _git(repo_path: str, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", repo_path, *args],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_S,
+    )
+    if proc.returncode != 0:
+        raise ScopeVerificationError(
+            f"git {' '.join(args)} failed in {repo_path}: {proc.stderr.strip()[:300]}"
+        )
+    return proc.stdout
+
+
+def pushed_scope_violations(
+    *,
+    repo_path: str,
+    base_branch: str,
+    task_branch: str,
+    allowed_paths: list[str],
+) -> list[str]:
+    """Changed files on the REMOTE task branch that fall outside ``allowed_paths``.
+
+    Fetches both refs from origin and diffs ``origin/base...origin/task`` (the
+    task side of the merge base), so the verdict comes from the committed tree
+    the reviewer/merge path will actually consume — not from any state the
+    sandboxed executor controls. Empty ``allowed_paths`` means no allowlist was
+    declared: returns [] (nothing to enforce — same fail-open-by-declaration
+    semantics as the in-sandbox gate).
+
+    Raises ScopeVerificationError when the fetch/diff itself fails — the caller
+    fails the task rather than trusting an unverifiable diff.
+    """
+    if not allowed_paths:
+        return []
+    _git(repo_path, "fetch", "--quiet", "origin", base_branch, task_branch)
+    out = _git(
+        repo_path,
+        "diff",
+        "--name-only",
+        f"origin/{base_branch}...origin/{task_branch}",
+    )
+    changed = [line.strip() for line in out.splitlines() if line.strip()]
+    violations = ChangedFilePolicyChecker().find_violations(changed, list(allowed_paths))
+    if violations:
+        logger.error(
+            'board_worker: pushed branch %s touches paths OUTSIDE the task allowlist: %s '
+            '{"event": "pushed_scope_violation", "branch": "%s", "violations": %d}',
+            task_branch,
+            ", ".join(violations[:10]),
+            task_branch,
+            len(violations),
+        )
+    return violations
+
+
+def verify_pushed_scope(
+    *,
+    bundle: dict,
+    result: dict,
+    repo_path: str,
+    base_branch: str,
+    task_branch: str,
+) -> str | None:
+    """Dispatch-facing wrapper: the failure message when the pushed branch is
+    out of scope or unverifiable, else None. No allowlist declared / branch not
+    pushed => nothing to enforce."""
+    if not result.get("branch_pushed"):
+        return None
+    allowed = ((bundle.get("proposal") or {}).get("target") or {}).get("allowed_paths") or []
+    if not allowed:
+        return None
+    try:
+        violations = pushed_scope_violations(
+            repo_path=repo_path,
+            base_branch=base_branch,
+            task_branch=task_branch,
+            allowed_paths=list(allowed),
+        )
+    except ScopeVerificationError as exc:
+        return f"pushed-branch scope verification failed: {exc}"
+    if violations:
+        return "pushed branch touches paths outside the task allowlist: " + ", ".join(
+            violations[:20]
+        )
+    return None
+
+
+__all__ = ["ScopeVerificationError", "pushed_scope_violations", "verify_pushed_scope"]

--- a/tests/unit/entrypoints/board_worker/test_scope_check.py
+++ b/tests/unit/entrypoints/board_worker/test_scope_check.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Parent-side pushed-branch scope verification (audit Track A8).
+
+The in-sandbox scope gates are agent-bypassable; these tests pin the parent's
+independent verdict over the committed (remote) tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from operations_center.entrypoints.board_worker import scope_check
+
+
+def _fake_git(monkeypatch, *, diff_output: str, fail_on: str | None = None):
+    calls: list[list[str]] = []
+
+    def fake(repo_path, *args):
+        calls.append(list(args))
+        if fail_on and args[0] == fail_on:
+            raise scope_check.ScopeVerificationError(f"git {args[0]} failed")
+        if args[0] == "diff":
+            return diff_output
+        return ""
+
+    monkeypatch.setattr(scope_check, "_git", fake)
+    return calls
+
+
+def test_empty_allowlist_enforces_nothing(monkeypatch):
+    calls = _fake_git(monkeypatch, diff_output="anything.py\n")
+    out = scope_check.pushed_scope_violations(
+        repo_path="/r", base_branch="main", task_branch="goal/abc", allowed_paths=[]
+    )
+    assert out == []
+    assert calls == []  # no git work when nothing is declared
+
+
+def test_fetches_remote_and_diffs_committed_tree(monkeypatch):
+    calls = _fake_git(monkeypatch, diff_output="src/ok/a.py\n")
+    out = scope_check.pushed_scope_violations(
+        repo_path="/r", base_branch="main", task_branch="goal/abc", allowed_paths=["src/ok"]
+    )
+    assert out == []
+    assert calls[0][:2] == ["fetch", "--quiet"]
+    assert "origin/main...origin/goal/abc" in calls[1]
+
+
+def test_out_of_scope_files_reported(monkeypatch):
+    _fake_git(monkeypatch, diff_output="src/ok/a.py\nsecrets/creds.yaml\n.github/workflows/x.yml\n")
+    out = scope_check.pushed_scope_violations(
+        repo_path="/r", base_branch="main", task_branch="goal/abc", allowed_paths=["src/ok"]
+    )
+    # ChangedFilePolicyChecker normalizes leading "./"-style segments.
+    assert out == ["github/workflows/x.yml", "secrets/creds.yaml"]
+
+
+def test_fetch_failure_raises_fail_closed(monkeypatch):
+    _fake_git(monkeypatch, diff_output="", fail_on="fetch")
+    with pytest.raises(scope_check.ScopeVerificationError):
+        scope_check.pushed_scope_violations(
+            repo_path="/r", base_branch="main", task_branch="goal/abc", allowed_paths=["src"]
+        )
+
+
+# ── verify_pushed_scope (dispatch-facing wrapper) ─────────────────────────────
+
+
+def test_verify_skips_when_branch_not_pushed():
+    assert (
+        scope_check.verify_pushed_scope(
+            bundle={"proposal": {"target": {"allowed_paths": ["src"]}}},
+            result={"branch_pushed": False},
+            repo_path="/r",
+            base_branch="main",
+            task_branch="goal/abc",
+        )
+        is None
+    )
+
+
+def test_verify_reports_violations(monkeypatch):
+    _fake_git(monkeypatch, diff_output="evil.py\n")
+    msg = scope_check.verify_pushed_scope(
+        bundle={"proposal": {"target": {"allowed_paths": ["src"]}}},
+        result={"branch_pushed": True},
+        repo_path="/r",
+        base_branch="main",
+        task_branch="goal/abc",
+    )
+    assert msg is not None and "outside the task allowlist" in msg and "evil.py" in msg
+
+
+def test_verify_fail_closed_on_unverifiable_diff(monkeypatch):
+    _fake_git(monkeypatch, diff_output="", fail_on="fetch")
+    msg = scope_check.verify_pushed_scope(
+        bundle={"proposal": {"target": {"allowed_paths": ["src"]}}},
+        result={"branch_pushed": True},
+        repo_path="/r",
+        base_branch="main",
+        task_branch="goal/abc",
+    )
+    assert msg is not None and "verification failed" in msg


### PR DESCRIPTION
**Track A8 of the grounded audit.**

The executor's scope gates (diff caps + `allowed_paths` allowlist in `_validate_patch_before_commit`) run **inside** the bwrap-sandboxed process — the same process the agent's code-writing adapter runs in — and the parent trusted the executor's self-reported `result.json` verbatim.

- new `board_worker/scope_check.py`: after a successful run with `branch_pushed`, the parent fetches the task branch **from the remote** and diffs `origin/base...origin/task` — the committed tree the reviewer/merge path will consume, not any state the sandbox controls
- enforces the declared allowlist with the same `ChangedFilePolicyChecker` (one matching semantics)
- violations or an unverifiable diff (fetch failure) **fail the task closed**
- empty allowlist = nothing declared to enforce (matches the inner gate)
- structured `pushed_scope_violation` log event; 7 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)