### PR TITLE
fix(loop_bridge): narrow the usage-store snapshot types for ty

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,9 @@
+## 2026-07-06 — fix: loop_bridge ty errors (post-#428)
+
+ty flagged snapshot.get(...).get("cooldowns") as not-iterable (untyped usage
+snapshot). Extracted _cooldown_details() with explicit isinstance narrowing.
+ty is not a required check, so #428 merged red — this restores green.
+
 ## 2026-07-06 — Track B: watchdog loop migrated to the PseudoOperator engine
 
 tools/loop/controller.py (1152 lines) replaced by a thin exec shim into

--- a/src/operations_center/entrypoints/loop_bridge/main.py
+++ b/src/operations_center/entrypoints/loop_bridge/main.py
@@ -53,6 +53,14 @@ _WORKER_BACKEND_FOR: dict[str, tuple[str, str]] = {
 # ── seed-cooldowns ────────────────────────────────────────────────────────────
 
 
+def _cooldown_details(snapshot: dict, backend_key: str) -> list[dict]:
+    raw = snapshot.get(backend_key)
+    details = raw.get("cooldowns") if isinstance(raw, dict) else None
+    if not isinstance(details, list):
+        return []
+    return [d for d in details if isinstance(d, dict)]
+
+
 def seed_cooldowns() -> int:
     """Print ``{backend: iso8601|null}`` seeded from the executor usage store."""
     from operations_center.execution.usage_store import UsageStore
@@ -76,9 +84,7 @@ def seed_cooldowns() -> int:
         if current is None or reset_at.strftime("%Y-%m-%dT%H:%M:%SZ") > current:
             out[backend] = reset_at.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    for detail in snapshot.get("claude_code", {}).get("cooldowns", []):
-        if not isinstance(detail, dict):
-            continue
+    for detail in _cooldown_details(snapshot, "claude_code"):
         model = detail.get("model")
         if detail.get("limit_kind") == "model_weekly" and model == "sonnet":
             apply("claude", detail.get("reset_at"))
@@ -87,9 +93,8 @@ def seed_cooldowns() -> int:
         elif detail.get("limit_kind") != "model_weekly":
             apply("claude", detail.get("reset_at"))
             apply("opus", detail.get("reset_at"))
-    for detail in snapshot.get("codex_cli", {}).get("cooldowns", []):
-        if isinstance(detail, dict):
-            apply("codex", detail.get("reset_at"))
+    for detail in _cooldown_details(snapshot, "codex_cli"):
+        apply("codex", detail.get("reset_at"))
 
     print(json.dumps(out, ensure_ascii=False))
     return 0


### PR DESCRIPTION
ty flagged the chained `.get()` cooldown iteration as not-iterable. Extracted `_cooldown_details()` with isinstance narrowing; local `ty check` clean. Restores green after #428 (ty is not a required check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)