### PR TITLE
feat(loop): wire the Track C trust anchor — CL v0.4.1 + pinned pubkey surface

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-07-06 — Track C: loop trust-anchor wiring (awaiting operator ceremony)
+
+CL pinned v0.4.1 (signed loop config, CL #37): `cl loop run` now verifies the
+pseudo_operator section against an ed25519-signed reference — drift runs the
+SIGNED reference (restore-by-consumption), bad signature refuses, unsigned
+warns. Staged the anchoring surface: .console/operator_pubkey.ed25519
+placeholder (same paste-in pattern as eval/constitution) + CODEOWNERS pins on
+the pubkey and the signed reference files. OPERATOR CEREMONY (one human step,
+same key can anchor EVAL too): keygen offline -> paste pubkey hex ->
+`cl loop sign-config --config .console/workers.yaml --key <priv>` -> commit
+the .signed.json/.sig -> add --require-signed to loop_start. Until then the
+loop runs in loud unsigned mode.
+
 ## 2026-07-06 — fix: loop_bridge ty errors (post-#428)
 
 ty flagged snapshot.get(...).get("cooldowns") as not-iterable (untyped usage

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,9 @@
 
 # CODEOWNERS itself — so the pin cannot be quietly removed.
 /.github/CODEOWNERS   @ProtocolWarden
+
+# Loop trust anchor (Track C): the pinned operator pubkey + the signed
+# pseudo_operator reference are root-of-trust files — operator-only.
+/.console/operator_pubkey.ed25519        @ProtocolWarden
+/.console/pseudo_operator.signed.json    @ProtocolWarden
+/.console/pseudo_operator.signed.sig     @ProtocolWarden

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # planeless).
   "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.1.0",
   # ADR 0002 P4 — dispatcher CL wrap.
-  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.0",
+  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.1",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.
   "cryptography>=42",
 ]


### PR DESCRIPTION
**Track C consumer wiring** (engine: ContextLifecycle #37, tagged v0.4.1).

- pin bump v0.4.0 → v0.4.1: `cl loop run` now verifies the `pseudo_operator:` section against an ed25519-signed reference — **drift runs the signed reference** (restore-by-consumption), **bad signature refuses**, **unsigned warns loudly**
- `.console/operator_pubkey.ed25519` placeholder (same paste-in ceremony as `eval/constitution`; the **same key** can anchor both the EVAL corpus and the loop config)
- CODEOWNERS pins on the pubkey + signed-reference files

**Operator ceremony (the one human step, still pending — also pending for EVAL):** keygen offline → paste pubkey hex → `cl loop sign-config --config .console/workers.yaml --key <priv>` → commit `.signed.json`/`.sig` → add `--require-signed` to `loop_start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)