### PR TITLE
fix(license): SPDX headers on the loop shim + loop_bridge test init

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,7 @@
+## 2026-07-06 — fix: SPDX headers on the loop shim + test package init
+
+CI license check flagged the two new files from the loop migration.
+
 ## 2026-07-06 — fix: untrack the stale build/ artifact dir
 
 #428's git add -A committed 556 stale build/lib files (a local setuptools

--- a/tests/unit/entrypoints/loop_bridge/__init__.py
+++ b/tests/unit/entrypoints/loop_bridge/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden

--- a/tools/loop/controller.py
+++ b/tools/loop/controller.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
 """DEPRECATED shim — the OC watchdog loop moved to ContextLifecycle.
 
 The engine is `context_lifecycle.pseudo_operator` (Track B of the grounded


### PR DESCRIPTION
CI license check flagged the two new files from the loop migration (#428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)