### PR TITLE
fix(custodian): drop the stale T8 exclusion for the removed controller tests

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,8 @@
+## 2026-07-06 — fix: drop stale T8 exclusion for the removed controller tests
+
+tests/test_loop_controller.py was removed by the loop migration (#428);
+Custodian doctor flags the now-matchless glob.
+
 ## 2026-07-06 — fix: SPDX headers on the loop shim + test package init
 
 CI license check flagged the two new files from the loop migration.

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -496,8 +496,6 @@ audit:
       # code under audit — they probe via subprocess + filesystem.
       - tests/test_architecture_cleanup_guards.py
       - tests/unit/audit_dispatch/test_lock_store_concurrency.py
-      # Loop-controller tests exercise the top-level tool entrypoint directly.
-      - tests/test_loop_controller.py
       # Slow-test tracker tests exercise conftest.py hooks via subprocess — no src imports.
       - tests/test_slow_test_hooks_integration.py
       - tests/test_slow_test_tracker.py


### PR DESCRIPTION
`tests/test_loop_controller.py` was removed by the loop migration (#428); Custodian doctor fails on the matchless glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)