### PR TITLE
fix(board_worker): retry workspace-prep clone failures on ssh permission flakes

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-07-07 — fix(board_worker): retry workspace-prep clone on ssh permission flake
+
+Watchdog cycle: 6 goal-worker runs failed workspace prep with "Bad owner or
+permissions on /etc/ssh/ssh_config.d/..." / "Could not read from remote
+repository" — a transient host-side ssh StrictModes flake, not reproducible
+on manual re-clone seconds later. is_transient_failure() already retries
+backend_error failures on network-shaped patterns but didn't recognize this
+ssh/permissions class, so every hit went straight to FAILED with zero
+retries. Added the two observed patterns to the transient-reason list.
+
 ## 2026-07-06 — fix: drop stale T8 exclusion for the removed controller tests
 
 tests/test_loop_controller.py was removed by the loop migration (#428);

--- a/src/operations_center/entrypoints/board_worker/_subprocess.py
+++ b/src/operations_center/entrypoints/board_worker/_subprocess.py
@@ -70,6 +70,8 @@ _TRANSIENT_REASON_PATTERNS = (
     "remote disconnected",
     "network is unreachable",
     "temporary failure",
+    "bad owner or permissions",
+    "could not read from remote repository",
 )
 
 # Pinned, non-secret base env. Static values, never inherited from the parent.

--- a/tests/unit/entrypoints/board_worker/test_transient_failure.py
+++ b/tests/unit/entrypoints/board_worker/test_transient_failure.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for is_transient_failure's reason-pattern matching.
+
+Workspace-prep git-clone failures surface as failure_category=backend_error,
+so a real host-side ssh/permissions flake (e.g. a racy read-only /etc bind
+hitting a transiently-misowned ssh_config symlink) must be recognized as
+transient — otherwise board_worker never retries it and a passing retry
+opportunity is lost.
+"""
+
+from operations_center.entrypoints.board_worker._subprocess import is_transient_failure
+
+
+def test_ssh_bad_owner_or_permissions_is_transient() -> None:
+    result = {
+        "failure_category": "backend_error",
+        "failure_reason": (
+            "Workspace preparation failed: git clone failed: Cloning into '.'...\n"
+            "Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf\n"
+            "fatal: Could not read from remote repository.\n"
+        ),
+    }
+    assert is_transient_failure(result) is True
+
+
+def test_could_not_read_from_remote_repository_is_transient() -> None:
+    result = {
+        "failure_category": "backend_error",
+        "failure_reason": "fatal: Could not read from remote repository.",
+    }
+    assert is_transient_failure(result) is True
+
+
+def test_non_transient_reason_is_not_retried() -> None:
+    result = {
+        "failure_category": "backend_error",
+        "failure_reason": "AssertionError: expected 1 but got 2",
+    }
+    assert is_transient_failure(result) is False
+
+
+def test_transient_reason_wrong_category_is_not_retried() -> None:
+    result = {
+        "failure_category": "policy_blocked",
+        "failure_reason": "Bad owner or permissions on /etc/ssh/ssh_config.d/foo",
+    }
+    assert is_transient_failure(result) is False


### PR DESCRIPTION
Opened on behalf of the loop watchdog session (iteration 1, 2026-07-07), which pushed this branch but did not open a PR.

6 goal-worker runs failed workspace prep on a transient host-side ssh StrictModes flake ("Bad owner or permissions on /etc/ssh/ssh_config.d/..."); not reproducible on manual re-clone. Extends the is_transient_failure() pattern list so this class retries instead of terminal-failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)