### PR TITLE
chore(loop): prompt branch discipline + CL pin v0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # planeless).
   "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.1.0",
   # ADR 0002 P4 — dispatcher CL wrap.
-  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.1",
+  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.2",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.
   "cryptography>=42",
 ]

--- a/tools/loop/oc_session_prompt.txt
+++ b/tools/loop/oc_session_prompt.txt
@@ -357,14 +357,21 @@ COMMIT DISCIPLINE: Only commit if you made a meaningful change (code fix, config
 new test). Do NOT commit if the cycle was observation-only (no files changed). The
 chore(watchdog): cycle N commit pattern is retired — do not use it.
 IMPORTANT: Run git diff --staged before committing to ensure only loop-owned files are staged.
-Commit only after validation passes. If not on main or not allowed: create a branch:
+NEVER commit on main — this is the fleet's live shared checkout; a commit on local main
+contaminates every watcher and future branch. BEFORE your first edit, create the branch:
   git checkout -b oc-watchdog/<YYYYMMDD-HHMM>-<short-topic>
+Commit only after validation passes, on that branch.
 One logical commit per repo per cycle. Commit message must name: root cause, affected repo,
 gate/check fixed. Never force-push, amend old loop commits, or commit generated noise.
 
-PUSH AFTER COMMIT — push immediately after a successful commit. Do not wait for operator:
+PUSH + PR AFTER COMMIT — push immediately after a successful commit. Do not wait for operator:
   git push origin <current-branch>
-Push applies to all branches (main, oc-watchdog/*, operations-center-testing-branch).
+Then OPEN A PULL REQUEST for it (a pushed branch with no PR is invisible to the reviewer
+lane and rots): gh pr create --fill (or a short title/body naming root cause + fix).
+The reviewer watcher takes it from there — do not merge it yourself.
+FINALLY return the shared checkout to clean main: git checkout main
+(never leave the fleet checkout on a work branch or with local commits on main).
+Push applies to oc-watchdog/* and operations-center-testing-branch only — never push main.
 Invariant gate (STEP 7) passing is sufficient self-review — no additional operator approval needed.
 If push fails (non-auth error): note it in the cycle summary and continue; do not retry in a loop.
 If push fails with auth error: classify as infra-blocked and note in cycle summary.


### PR DESCRIPTION
## Summary
Fixes from monitoring the first live `cl loop` run (2026-07-07):

1. **CL pin v0.4.1 → v0.4.2** — picks up ContextLifecycle #39: env files are now resolved with real shell semantics, so `export GITHUB_TOKEN=$(gh auth token ...)` reaches sessions as an actual token instead of the unexpanded `$(...)` literal (the "invalid token" iteration 1 flagged and worked around).

2. **Session-prompt branch discipline (STEP 10)** — the watchdog session committed `af43df54` on *local main* of the live shared checkout (the old text read as commit-first-branch-later and listed main as pushable) and never opened a PR for its pushed branch (now open as #434; local main was reset to origin/main). The prompt now: create the `oc-watchdog/*` branch BEFORE the first edit, never commit or push main, open a PR right after pushing, and return the shared checkout to clean main.

## Verification
- Engine-style sourcing of `.env.operations-center.local` now yields a valid 40-char `gho_` token (api.github.com → 200).
- Loop restarted on CL v0.4.2 (editable install), iteration running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)