### PR TITLE
fix: custodian-sweep self-audit timeout (loop watchdog cycle)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # planeless).
   "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.1.0",
   # ADR 0002 P4 — dispatcher CL wrap.
-  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.1",
+  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.2",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.
   "cryptography>=42",
 ]

--- a/src/operations_center/entrypoints/custodian_sweep/main.py
+++ b/src/operations_center/entrypoints/custodian_sweep/main.py
@@ -38,7 +38,7 @@ from typing import Any
 
 _DEFAULT_HISTORY_PATH = Path("state/custodian_sweep/last_sweep.json")
 _DEDUP_LABEL_PREFIX = "custodian-sweep:"  # one label per repo for dedup
-_DEFAULT_TIMEOUT_SECONDS = 180
+_DEFAULT_TIMEOUT_SECONDS = 300
 
 
 @dataclass(frozen=True)

--- a/tools/loop/oc_session_prompt.txt
+++ b/tools/loop/oc_session_prompt.txt
@@ -357,14 +357,21 @@ COMMIT DISCIPLINE: Only commit if you made a meaningful change (code fix, config
 new test). Do NOT commit if the cycle was observation-only (no files changed). The
 chore(watchdog): cycle N commit pattern is retired — do not use it.
 IMPORTANT: Run git diff --staged before committing to ensure only loop-owned files are staged.
-Commit only after validation passes. If not on main or not allowed: create a branch:
+NEVER commit on main — this is the fleet's live shared checkout; a commit on local main
+contaminates every watcher and future branch. BEFORE your first edit, create the branch:
   git checkout -b oc-watchdog/<YYYYMMDD-HHMM>-<short-topic>
+Commit only after validation passes, on that branch.
 One logical commit per repo per cycle. Commit message must name: root cause, affected repo,
 gate/check fixed. Never force-push, amend old loop commits, or commit generated noise.
 
-PUSH AFTER COMMIT — push immediately after a successful commit. Do not wait for operator:
+PUSH + PR AFTER COMMIT — push immediately after a successful commit. Do not wait for operator:
   git push origin <current-branch>
-Push applies to all branches (main, oc-watchdog/*, operations-center-testing-branch).
+Then OPEN A PULL REQUEST for it (a pushed branch with no PR is invisible to the reviewer
+lane and rots): gh pr create --fill (or a short title/body naming root cause + fix).
+The reviewer watcher takes it from there — do not merge it yourself.
+FINALLY return the shared checkout to clean main: git checkout main
+(never leave the fleet checkout on a work branch or with local commits on main).
+Push applies to oc-watchdog/* and operations-center-testing-branch only — never push main.
 Invariant gate (STEP 7) passing is sufficient self-review — no additional operator approval needed.
 If push fails (non-auth error): note it in the cycle summary and continue; do not retry in a loop.
 If push fails with auth error: classify as infra-blocked and note in cycle summary.


### PR DESCRIPTION
Opened on behalf of the loop watchdog session (2026-07-07 08:00 cycle), which pushed this branch but did not open a PR (pre-#435 prompt). Session summary: direct fix for the custodian-sweep self-audit timeout; board-unblock made 3 queue transitions the same cycle.

Note: branch was incidentally rebased onto origin/main during operator-session maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)