### PR TITLE
fix(board_worker,board_unblock): close policy-blocked retry loop + spec-author tiktoken egress

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -8950,3 +8950,19 @@ override-dependencies (the plane-bearing repograph e0b205e). Plain pip silently 
 would stay dormant AND repograph would downgrade to planeless on every pyproject change. Gated the live-registry
 tests with a declarative skipif on plane availability (custodian T3, not a per-test runtime skip). Verified: in the
 activated venv the live tests run+pass (27); planeless -> skip.
+
+## 2026-07-07 — Watchdog: policy-blocked task closed-loop + spec-author tiktoken egress fix
+
+Root cause 1: board_unblock Rule 8 (CLEAN_BLOCKED_RETRY) treated tasks blocked by a
+deterministic policy gate (review.required) identically to transient pre-execution infra
+failures — both have no executor-signal/exit-code label. Result: 5 goal tasks cycled
+Blocked->Backlog->Ready for AI->Blocked every ~30min (ghost-audit G5: 26 policy-blocked
+re-dispatches in 1h), burning backend slots for zero net progress. Fix: handle_failure
+now labels policy_blocked failures `blocked-reason: policy`; Rule 8 excludes it.
+
+Root cause 2: spec-author dispatch (`_dispatch_spec_author`) built its own env via
+build_allowlist_env but never called provision_env — unlike the goal/improve path — so
+its executor never got TIKTOKEN_CACHE_DIR and always hit a live
+openaipublic.blob.core.windows.net fetch that the egress proxy 403s. Confirmed via 3
+identical consecutive failures on the same spec-author task. Fix: wire provision_env into
+the spec-author path too.

--- a/src/operations_center/entrypoints/board_worker/dispatch.py
+++ b/src/operations_center/entrypoints/board_worker/dispatch.py
@@ -461,6 +461,12 @@ def _dispatch_spec_author(
     oc_root = Path(__file__).resolve().parents[4]
     python = venv_python(oc_root)
     env = build_allowlist_env(oc_root, passthrough=git_token_passthrough(settings, repo_cfg))
+    # Same offline tiktoken cache the goal/improve dispatch path wires in
+    # (see dispatch_issue below) — without it the spec-author executor hits a
+    # live openaipublic.blob.core.windows.net fetch that the egress proxy 403s,
+    # failing every spec-author run with the same backend_error (confirmed via
+    # 3 consecutive identical failures on the same task in watch-all logs).
+    env.update(provision_env(repo_key, _repo_local_path(settings, repo_key), python_bin=python))
     short_id = task_id[:8]
 
     logger.info(

--- a/src/operations_center/entrypoints/board_worker/outcomes.py
+++ b/src/operations_center/entrypoints/board_worker/outcomes.py
@@ -488,6 +488,15 @@ def handle_failure(
             )
         if executor_exit_code is not None:
             add_label(client, issue, f"executor-exit-code: {executor_exit_code}")
+        if category == "policy_blocked":
+            # Deterministic policy gate (e.g. review.required) — the executor never
+            # ran, so this has no executor-signal/exit-code label and would otherwise
+            # match Rule 8 CLEAN_BLOCKED_RETRY's "pre-execution infra failure" pattern
+            # and get recycled Blocked->Backlog->Ready for AI every cycle forever,
+            # hitting the same policy gate each time (confirmed via ghost-audit G5:
+            # 26 policy-blocked re-dispatches in one hour). This label marks the block
+            # as policy-driven so Rule 8 can exclude it.
+            add_label(client, issue, "blocked-reason: policy")
         if executor_signal:
             add_label(client, issue, f"executor-signal: {executor_signal}")
             if "sigkill" in executor_signal.lower():

--- a/src/operations_center/entrypoints/maintenance/board_unblock.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock.py
@@ -66,6 +66,9 @@ Applies ten rules on every run:
       - No "executor-exit-code:" label (executor never ran — pre-execution failure)
       - Not "self-modify: approved" (those are handled by Rule 4)
       - Not "thin-goal" (board_worker adds this when goal text is too short; needs human to enrich)
+      - Not "blocked-reason: policy" (deterministic policy gate — e.g. review.required —
+        that will re-block identically on every retry; recycling it Blocked->Backlog->
+        Ready for AI is a closed loop, not a transient infra failure)
       - Blocked for at least --clean-blocked-min-minutes (default 5) minutes
     → move to Backlog for retry.
     These represent pre-execution failures (workspace preparation errors, missing
@@ -246,6 +249,7 @@ _SOURCE_IMPROVE_SUGGESTION_LABEL = "source: improve-suggestion"
 _SOURCE_BOARD_WORKER_LABEL = "source: board_worker"
 _HANDOFF_IMPROVEMENT_LABEL = "handoff-reason: improvement_applied"
 _PR_URL_PREFIX = "pr-url:"
+_BLOCKED_REASON_POLICY_LABEL = "blocked-reason: policy"
 
 
 def _labels(issue: dict[str, Any]) -> list[str]:
@@ -615,6 +619,7 @@ def _apply_rules(
             and not _has_label_prefix(labels, _SIGKILL_SIGNAL_PREFIX)
             and not _has_label_prefix(labels, "executor-exit-code:")
             and not _has_label_prefix(labels, _BLOCKED_BY_PREFIX)
+            and not _has_label(labels, _BLOCKED_REASON_POLICY_LABEL)
         )
         if is_clean_blocked:
             updated_at = _parse_updated_at(issue)

--- a/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_dispatch_cov.py
@@ -575,6 +575,43 @@ def test_dispatch_spec_author_happy(monkeypatch):
     assert kwargs["spec_slug"] == "x"
 
 
+def test_dispatch_spec_author_wires_provision_env(monkeypatch):
+    # Regression: spec-author used to build its own env via build_allowlist_env
+    # without calling provision_env, so its executor never got TIKTOKEN_CACHE_DIR
+    # and hit a live openaipublic.blob.core.windows.net fetch that the egress
+    # proxy 403s on every run (same backend_error every time — a closed loop).
+    _install_common_patches(monkeypatch)
+    monkeypatch.setattr(dispatch, "venv_python", lambda r: "/py")
+    monkeypatch.setattr(dispatch, "build_allowlist_env", lambda r, **kw: {})
+
+    import operations_center.entrypoints.board_worker._text as text_mod
+
+    monkeypatch.setattr(
+        text_mod, "parse_spec_author_payload", lambda d: {"target_path": "p", "spec_slug": "s"}
+    )
+    monkeypatch.setattr(text_mod, "build_spec_author_goal_text", lambda p, rid: "G")
+
+    proc = MagicMock(return_value=True)
+    monkeypatch.setattr(dispatch, "process_spec_author", proc)
+    pe = MagicMock(return_value={"TIKTOKEN_CACHE_DIR": "/cache/tk"})
+    monkeypatch.setattr(dispatch, "provision_env", pe)
+
+    dispatch._dispatch_spec_author(
+        issue=_make_issue(),
+        role="goal",
+        settings=_make_settings(),
+        client=MagicMock(),
+        config_path="/cfg.yaml",
+        description="yaml here",
+        labels=[],
+        task_id="t1",
+    )
+    pe.assert_called_once()
+    assert pe.call_args.args[0] == dispatch.SPEC_AUTHOR_REPO_KEY
+    env_passed = proc.call_args.kwargs["env"]
+    assert env_passed["TIKTOKEN_CACHE_DIR"] == "/cache/tk"
+
+
 def test_dispatch_spec_author_no_repo_cfg_uses_file_url(monkeypatch):
     _install_common_patches(monkeypatch)
     monkeypatch.setattr(dispatch, "venv_python", lambda r: "/py")

--- a/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
+++ b/tests/unit/entrypoints/board_worker/test_outcomes_cov.py
@@ -663,6 +663,29 @@ def test_handle_failure_clean_code_failure_increments_code_fail_count():
     assert "code-fail-count: 1" in _all_update_labels(client)
 
 
+def test_handle_failure_policy_blocked_adds_policy_label():
+    # policy_blocked (e.g. review.required) has no executor-signal/exit-code label
+    # since the executor never ran — without this label, board_unblock's Rule 8
+    # CLEAN_BLOCKED_RETRY would treat it as a retryable pre-execution infra failure
+    # and recycle it Blocked->Backlog->Ready for AI forever against a policy gate
+    # that never changes.
+    client = _make_client()
+    issue = {"id": "p1", "labels": []}
+    outcomes.handle_failure(
+        client, issue, "goal", "goal", {"failure_category": "policy_blocked"}, _make_settings()
+    )
+    assert "blocked-reason: policy" in _all_update_labels(client)
+
+
+def test_handle_failure_non_policy_category_no_policy_label():
+    client = _make_client()
+    issue = {"id": "p2", "labels": []}
+    outcomes.handle_failure(
+        client, issue, "goal", "goal", {"failure_category": "validation_failed"}, _make_settings()
+    )
+    assert "blocked-reason: policy" not in _all_update_labels(client)
+
+
 def test_handle_failure_transient_category_does_not_count():
     # Env/transient categories are NOT code failures — must not bump the counter.
     for cat in ("backend_error", "timeout", "unknown", "scope_too_wide"):

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
@@ -692,6 +692,24 @@ def test_rule8_no_updated_at_no_action():
     assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
 
 
+def test_rule8_policy_blocked_excluded():
+    # A deterministic policy gate (e.g. review.required) re-blocks identically on
+    # every retry — recycling it Blocked->Backlog->Ready for AI is a closed loop,
+    # not a transient pre-execution infra failure. Confirmed live via ghost-audit
+    # G5 (26 policy-blocked re-dispatches in one hour) before this exclusion.
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["task-kind: goal", "blocked-reason: policy"],
+                updated_at=_STALE,
+            )
+        ]
+    )
+    assert not _by_rule(actions, "CLEAN_BLOCKED_RETRY")
+
+
 # ---------------------------------------------------------------------------
 # Rule 9 — SPEC_AUTHOR_BACKLOG_PROMOTE
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Root cause 1: `board_unblock` Rule 8 (CLEAN_BLOCKED_RETRY) recycled policy-blocked tasks (review.required) as if they were transient pre-execution infra failures, since both lack executor-signal/exit-code labels. Confirmed a closed loop via ghost-audit G5 (26 policy-blocked re-dispatches in 1h) across 5 goal tasks. `handle_failure` now labels these `blocked-reason: policy`; Rule 8 excludes it.
- Root cause 2: `_dispatch_spec_author` never called `provision_env`, unlike the goal/improve dispatch path, so spec-author executors never got `TIKTOKEN_CACHE_DIR` and hit a live `openaipublic.blob.core.windows.net` fetch the egress proxy 403s. Confirmed via 3 identical consecutive spec-author failures. Now wires `provision_env` in.

## Test plan
- [x] `tests/unit/entrypoints/board_worker/test_outcomes_cov.py` — new tests for the `blocked-reason: policy` label
- [x] `tests/unit/entrypoints/maintenance/test_board_unblock_cov.py` — new test for Rule 8's exclusion
- [x] `tests/unit/entrypoints/board_worker/test_dispatch_cov.py` — new test for `provision_env` wiring in spec-author dispatch
- [x] `tests/unit/entrypoints/board_worker/` full suite: 382/382 passed
- [x] `tests/unit/er000_phase0_golden/`: 15/15 passed
- [x] ruff clean on all touched files

🤖 Generated as part of an autonomous watchdog cycle (20260707T0825).