### PR TITLE
fix(loop_bridge): fetch before the self_update sha compare

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,13 @@
+## 2026-07-07 — fix(loop_bridge): fetch before the self_update sha compare
+
+Iteration-3 deploy gap: reviewer merged #437 at 08:41Z but the 08:50Z
+pre_iteration self_update was a no-op — `git rev-parse origin/main` reads the
+LOCAL ref, which only moves when something else fetches. The session had to
+pull + restart watchers manually; the hook then "noticed" one cycle late
+(09:14Z restart). self_update now fetches origin main (quiet, 120s, failure
+tolerated → stale-ref behavior) before comparing. Regression test asserts
+fetch precedes rev-parse.
+
 ## 2026-07-07 — chore(hooks): exempt oc-watchdog/* from the log.md pre-commit gate
 
 The hook required .console/log.md in every non-trivial commit while the

--- a/src/operations_center/entrypoints/loop_bridge/main.py
+++ b/src/operations_center/entrypoints/loop_bridge/main.py
@@ -182,6 +182,17 @@ def _restart_watchers() -> None:
 
 def self_update() -> int:
     """git-pull + watcher restart when origin/main moved since the last check."""
+    # rev-parse reads the LOCAL origin/main ref; without a fetch it only moves
+    # when something else happens to fetch, so reviewer-merged fixes stayed
+    # invisible for a full cycle (the iteration-3 deploy gap, 2026-07-07).
+    # Fetch failure (offline) is tolerated — we proceed on the stale ref.
+    subprocess.run(
+        ["git", "fetch", "origin", "main", "--quiet"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
     current_sha = subprocess.run(
         ["git", "rev-parse", "origin/main"],
         cwd=REPO_ROOT,

--- a/tests/unit/entrypoints/loop_bridge/test_main.py
+++ b/tests/unit/entrypoints/loop_bridge/test_main.py
@@ -183,6 +183,30 @@ def test_self_update_pulls_and_bounces_on_new_sha(monkeypatch, tmp_path: Path) -
     assert sha_file.read_text(encoding="utf-8") == "new111"
 
 
+def test_self_update_fetches_before_comparing(monkeypatch, tmp_path: Path) -> None:
+    """Deploy-gap regression: without a fetch, the local origin/main ref never
+    moves and reviewer-merged fixes stay invisible until something else pulls."""
+    sha_file = tmp_path / "last_sha"
+    sha_file.write_text("old000", encoding="utf-8")
+    monkeypatch.setattr(bridge, "_LAST_SHA_FILE", sha_file)
+    _seed_watcher_pidfiles(monkeypatch, tmp_path, {})
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+
+        class R:
+            stdout = "new111\n"
+
+        return R()
+
+    monkeypatch.setattr(bridge.subprocess, "run", fake_run)
+    assert bridge.self_update() == 0
+    fetch_idx = calls.index(["git", "fetch", "origin", "main", "--quiet"])
+    revparse_idx = calls.index(["git", "rev-parse", "origin/main"])
+    assert fetch_idx < revparse_idx
+
+
 # ── config wiring ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Closes the deploy gap observed live at iteration 3 (2026-07-07): the reviewer lane merged #437 at 08:41Z, but the 08:50Z `pre_iteration` `self_update` hook no-opped because `git rev-parse origin/main` reads the **local** remote-tracking ref — it only moves when something else happens to fetch. The watchdog session had to detect the stale watchers itself (G5 recurrence 26→35) and pull + restart manually; the hook then noticed one full cycle late (09:14Z, after the session's pull moved the ref).

`self_update` now runs `git fetch origin main --quiet` (120s timeout, `check=False` — offline degrades to the previous stale-ref behavior) before the sha compare, so reviewer-merged fixes deploy at the next iteration boundary automatically.

## Tests
- `test_self_update_fetches_before_comparing` — fetch ordered before rev-parse
- loop_bridge suite: 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)