### PR TITLE
fix(board_unblock): exclude blocked-reason:policy from Rule 4 SELF_MODIFY_REQUEUE

### DIFF
--- a/src/operations_center/entrypoints/maintenance/board_unblock.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock.py
@@ -31,6 +31,10 @@ Applies ten rules on every run:
     Exception: tasks with "executor-signal: SIGKILL" are skipped — a SIGKILL indicates
     a systemic failure (timeout, OOM) that requires triage review before re-dispatch.
     Rule 1 cancels such tasks once retry-count reaches ≥3.
+    Exception: tasks with "blocked-reason: policy" are skipped — a deterministic policy
+    gate (e.g. review.required) will re-block identically on every retry regardless of
+    self-modify approval; requeueing burns a backend slot every cycle for no gain
+    (same failure mode Rule 8 already excludes this label for).
 
   Rule 5 — STALE_IN_REVIEW
     Tasks in "In Review" state for longer than --stale-blocked-hours (default 4h) →
@@ -440,7 +444,23 @@ def _apply_rules(
             exit_code_zero_no_signal = (
                 executor_exit_code_val.strip() == "0" and not executor_signal_val
             )
-            if "sigkill" in executor_signal_val.lower():
+            if _has_label(labels, _BLOCKED_REASON_POLICY_LABEL):
+                actions.append(
+                    {
+                        "task_id": task_id,
+                        "title": title,
+                        "rule": "SELF_MODIFY_REQUEUE",
+                        "from_state": state,
+                        "to_state": "Ready for AI",
+                        "reason": (
+                            "SKIPPED — blocked-reason:policy present; deterministic policy "
+                            "gate (e.g. review.required) requires operator review, "
+                            "self-modify:approved does not override it"
+                        ),
+                        "skipped": True,
+                    }
+                )
+            elif "sigkill" in executor_signal_val.lower():
                 actions.append(
                     {
                         "task_id": task_id,

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_cov.py
@@ -450,6 +450,21 @@ def test_rule4_sigkill_skipped():
     assert "SIGKILL" in a[0]["reason"]
 
 
+def test_rule4_blocked_reason_policy_skipped():
+    actions = _run(
+        [
+            _issue(
+                "1",
+                state="Blocked",
+                labels=["self-modify: approved", "blocked-reason: policy"],
+            )
+        ]
+    )
+    a = _by_rule(actions, "SELF_MODIFY_REQUEUE")
+    assert a and a[0]["skipped"] is True
+    assert "blocked-reason:policy" in a[0]["reason"]
+
+
 def test_rule4_exit_code_zero_no_signal_skipped():
     actions = _run(
         [


### PR DESCRIPTION
## Summary
- PR #437 taught Rule 8 (CLEAN_BLOCKED_RETRY) to exclude `blocked-reason: policy` tasks, but left Rule 4 (SELF_MODIFY_REQUEUE) unchanged.
- Task `b3962dc1` ("Restore repeated missing dependency_drift coverage") carries both `self-modify: approved` and `blocked-reason: policy` with no `blocked-by` label — Rule 4 treated the absent dependency as "operator approval already granted" and requeued it Blocked→Ready for AI every ~11 minutes for 15+ hours, recreating the exact retry loop #437 was meant to close.
- Rule 4 now skips `blocked-reason: policy` tasks the same way Rule 8 does.

## Test plan
- [x] Added `test_rule4_blocked_reason_policy_skipped` covering the new skip branch
- [x] `pytest tests/unit/entrypoints/maintenance/` — 219 passed
- [x] `pytest tests/unit/er000_phase0_golden/` — 15 passed
- [x] Verified live: `operations-center-board-unblock --apply` now reports `SKIPPED` for `b3962dc1` instead of requeuing it

Cycle: watchdog investigation 20260707T0930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)