### PR TITLE
docs(config): document task_admission.trusted_label_authors in the example config

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,12 @@
+## 2026-07-07 — docs(config): document task_admission in the example config
+
+trusted_label_authors (Track A1) was configurable but undocumented in
+operations_center.example.yaml — a fresh provision would silently run with
+the autonomy lane fail-closed and no pointer to why. Commented section added
+beside the git/github_app hardening notes. (Applied live on this host today:
+the fleet's Plane identity is allowlisted and the goal lane executes
+autonomy-labeled tasks without strips.)
+
 ## 2026-07-07 — fix(loop_bridge): fetch before the self_update sha compare
 
 Iteration-3 deploy gap: reviewer merged #437 at 08:41Z but the 08:50Z

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -38,6 +38,19 @@ git:
   signing_key: null                     # GPG key ID if sign_commits: true
 
 # ---------------------------------------------------------------------------
+# Task admission (label provenance, Track A1)
+# ---------------------------------------------------------------------------
+# Trusted source labels (source: autonomy / source: board_worker) let a task
+# bypass the review gate. Dispatch forwards such a label ONLY when the Plane
+# issue creator matches trusted_label_authors (id, email, or display name,
+# case-insensitive — same matching as author_allowlist). Empty/omitted FAILS
+# CLOSED: every trusted label is stripped and the task routes through normal
+# review. Allowlist the Plane identity the fleet creates tasks with.
+# task_admission:
+#   trusted_label_authors:
+#     - "<plane-user-uuid-or-email-of-the-fleet-service-account>"
+
+# ---------------------------------------------------------------------------
 # Team executor settings
 # ---------------------------------------------------------------------------
 # See src/operations_center/backends/team_executor/


### PR DESCRIPTION
`trusted_label_authors` (Track A1 label-provenance gate) was configurable but undocumented in `operations_center.example.yaml` — a fresh provision silently runs with the autonomy lane fail-closed and no pointer to why every `source: autonomy` label gets stripped at dispatch. Adds a commented `task_admission:` section beside the existing git/github_app hardening notes, with the identity-matching rules and the fail-closed default spelled out.

Context: applied live today — allowlisting the fleet's Plane identity unblocked the goal lane (tasks now execute without label strips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)