### PR TITLE
fix(tests): stop test_cleanup_with_zero_retention date-cutoff flake

### DIFF
--- a/tests/unit/observer/test_snapshot_edge_cases.py
+++ b/tests/unit/observer/test_snapshot_edge_cases.py
@@ -273,7 +273,9 @@ class TestSnapshotManagerEdgeCases:
     ) -> None:
         """Test cleanup with zero retention count."""
         manager = SnapshotManager(
-            LocalSnapshotRepository(root=tmp_path / "snapshots", retention_count=1)
+            LocalSnapshotRepository(
+                root=tmp_path / "snapshots", retention_count=1, retention_days=36500
+            )
         )
 
         manager.save_snapshot(test_snapshot)


### PR DESCRIPTION
## Summary
- `test_cleanup_with_zero_retention` (tests/unit/observer/test_snapshot_edge_cases.py) uses a `test_snapshot` fixture hardcoded to `observed_at=2026-06-07T12:00:00Z`. `LocalSnapshotRepository` defaults `retention_days=30`, so as wall-clock time advances past the 30-day mark the date-based cutoff in `cleanup()` deletes the snapshot before the `retention_count=1` behavior under test is ever exercised.
- This is currently failing on `main` (`Test (pytest)` and `Flaky test detection` CI jobs), and is also the reason PR #443 (unrelated custodian detector fix) shows CI failures.
- Fix: pass `retention_days=36500` when constructing the repository in this test, since its intent is to verify count-based retention, not the date cutoff.

## Test plan
- [x] `pytest tests/unit/observer/test_snapshot_edge_cases.py -q` — 19 passed
- [x] `pytest tests/unit/observer/test_snapshot_repository.py test_snapshot_performance.py test_snapshot_manager.py test_flaky_test_storage.py -q` — 101 passed
- [x] `pytest tests/unit/er000_phase0_golden/ -q` — 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)