### PR TITLE
fix(reviewer): auto-expire backend-unavailable parks after cooldown

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,15 @@
+## 2026-07-07 — fix(reviewer): backend-unavailable parks auto-expire
+
+PR #443 sat parked "Needs human attention (reviewer_backend_unavailable)"
+after the Claude session limit hit — but the limit RESETS on its own, and the
+park only cleared on a human or a new push, so green watchdog PRs rotted.
+Escalations now record reason+timestamp; reviewer_backend_unavailable parks
+auto-expire after 3600s (flag comment struck through with the resolution),
+resuming autonomous review on the SAME head. Concern/quality escalations are
+untouched — only the transient-infra reason expires. 2 tests (expire +
+hold-within-cooldown) in tests/test_pr_review_watcher.py (local-only suite).
+Unparked #443 by hand this pass (operator action).
+
 ## 2026-07-07 — docs(config): document task_admission in the example config
 
 trusted_label_authors (Track A1) was configurable but undocumented in

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -1434,6 +1434,11 @@ _MAX_CI_WAIT_CYCLES = 20
 _MAX_CI_GREEN_RETRACTIONS = 3
 _DIFF_LIMIT = 60_000
 
+# A reviewer_backend_unavailable escalation is TRANSIENT infra (session limit,
+# crash) — the backend recovers on its own, so the park auto-expires after this
+# cooldown and autonomous review resumes without a human or a new push.
+_BACKEND_UNAVAILABLE_RESUME_S = 3600
+
 
 def _run_fix_pass(
     oc_root: Path,
@@ -1585,6 +1590,8 @@ def _escalate_needs_human(
     pr_number = state["pr_number"]
     if current_head_sha:
         state["escalated_head_sha"] = current_head_sha
+    state["escalated_reason"] = reason
+    state["escalated_at_utc"] = datetime.now(UTC).isoformat()
     if not state.get("escalated_needs_human"):
         marker = settings.reviewer.bot_comment_marker
         try:
@@ -2596,6 +2603,41 @@ def _phase1(
             pr_number,
         )
         _save_state(state_path, state)
+
+    # Transient-infra escalations auto-expire: a backend session limit resets
+    # on its own, so resume autonomous review after a cooldown instead of
+    # parking the PR until a human or a new push arrives.
+    if (
+        state.get("escalated_needs_human")
+        and state.get("escalated_reason") == "reviewer_backend_unavailable"
+    ):
+        raw_ts = str(state.get("escalated_at_utc") or "")
+        try:
+            escalated_at = datetime.fromisoformat(raw_ts)
+        except ValueError:
+            escalated_at = None
+        if (
+            escalated_at is None
+            or (datetime.now(UTC) - escalated_at).total_seconds() >= _BACKEND_UNAVAILABLE_RESUME_S
+        ):
+            _retract_flag(
+                state,
+                gh_client,
+                owner,
+                repo,
+                resolution="backend cooldown elapsed — automated review resumed",
+            )
+            state["escalated_needs_human"] = False
+            state.pop("escalated_head_sha", None)
+            state.pop("escalated_reason", None)
+            state.pop("escalated_at_utc", None)
+            state["backend_error_passes"] = 0
+            logger.info(
+                "pr_review_watcher: PR #%d backend-unavailable park expired; "
+                "resuming automated review",
+                pr_number,
+            )
+            _save_state(state_path, state)
 
     # Once a PR is escalated for human attention, do not keep burning review
     # passes on the same unchanged head. Resume autonomous review only after a

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -574,6 +574,74 @@ def test_phase1_skips_escalated_pr_without_new_head(tmp_path: Path) -> None:
     assert loaded["escalated_head_sha"] == "abc123"
 
 
+def test_phase1_backend_unavailable_park_autoexpires(tmp_path: Path) -> None:
+    """A session-limit park is transient infra — after the cooldown the watcher
+    must resume autonomous review without a human or a new push."""
+    from datetime import UTC, datetime, timedelta
+
+    stale = (datetime.now(UTC) - timedelta(seconds=watcher._BACKEND_UNAVAILABLE_RESUME_S + 60)).isoformat()
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="abc123",
+        escalated_reason="reviewer_backend_unavailable",
+        escalated_at_utc=stale,
+        no_verdict_passes=0,
+    )
+    gh = _make_gh()
+
+    with patch.object(watcher, "_run_direct_review") as mock_review:
+        mock_review.return_value = None
+        watcher._phase1(
+            state,
+            sp,
+            _pr_data(head_sha="abc123"),  # SAME head — only the cooldown expired
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            SETTINGS,
+        )
+
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is False
+    assert "escalated_reason" not in loaded
+
+
+def test_phase1_backend_unavailable_park_holds_within_cooldown(tmp_path: Path) -> None:
+    from datetime import UTC, datetime
+
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_head_sha="abc123",
+        escalated_reason="reviewer_backend_unavailable",
+        escalated_at_utc=datetime.now(UTC).isoformat(),
+        no_verdict_passes=0,
+    )
+    gh = _make_gh()
+
+    with patch.object(watcher, "_run_direct_review") as mock_review:
+        watcher._phase1(
+            state,
+            sp,
+            _pr_data(head_sha="abc123"),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            SETTINGS,
+        )
+
+    mock_review.assert_not_called()
+    loaded = watcher._load_state(sp)
+    assert loaded["escalated_needs_human"] is True
+
+
 def test_phase1_concern_escalation_not_retracted_on_green_ci(tmp_path: Path) -> None:
     # Regression for #313: a fix_pass_no_progress escalation carrying unresolved
     # concerns on THIS unchanged head must NOT be retracted just because CI is


### PR DESCRIPTION
## Summary
PR #443 (green watchdog fix for the custodian-sweep timeout) sat parked as **Needs human attention** (`reviewer_backend_unavailable`) because the reviewer's Claude backend hit its session limit — which resets on its own. The park only cleared on a human or a new push, so autonomous work rotted while every check was green.

## Changes
- `_escalate_needs_human` records `escalated_reason` + `escalated_at_utc`.
- `_phase1` auto-expires `reviewer_backend_unavailable` parks after `_BACKEND_UNAVAILABLE_RESUME_S` (3600s): retracts the flag comment (struck through with resolution), clears the escalation, resumes review on the SAME head.
- Concern/quality escalations unchanged — only the transient-infra reason expires; the concern-preservation invariants (#313 lesson) are untouched.

## Tests
`tests/test_pr_review_watcher.py` (local-only suite, per repo convention): expire + hold-within-cooldown; 147 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)