### PR TITLE
fix(config): git_token self-heals past the boot keyring race

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -9009,3 +9009,14 @@ identical consecutive failures on the same spec-author task. Fix: wire provision
 the spec-author path too.
 
 ## 2026-07-07 — Work order verified already complete: gaps/edge_cases CLI exposure (PR #374, pre-existing)
+
+## 2026-07-13 — git_token() boot-keyring self-heal (post-reboot fleet outage)
+
+Root cause: fleet auto-started at boot (systemd linger) sources .env.operations-center.local
+before the login keyring is unlocked, so `gh auth token` yields nothing and
+GITHUB_TOKEN/GIT_TOKEN are exported EMPTY for the life of every worker process. The review
+watcher hit "no GitHub token — set GIT_TOKEN in .env" for 31 consecutive cycles (4.5h,
+last_success_at=null) until a manual fleet restart; every reboot reproduces this. Fix:
+Settings.git_token() now falls back to `gh auth token` at call time when the env var is
+empty and caches the recovered value back into os.environ (so the board-worker token
+passthrough heals too). Any gh failure degrades to the prior no-token behavior.

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -722,7 +724,19 @@ class Settings(BaseModel):
     def git_token(self) -> str | None:
         if self.git.token_env is None:
             return None
-        return os.environ.get(self.git.token_env)
+        token = os.environ.get(self.git.token_env)
+        if token:
+            return token
+        # A fleet started at boot (systemd linger) sources .env before the login
+        # keyring is unlocked, so `gh auth token` yields nothing and the token env
+        # var is exported EMPTY — permanently, since env is captured at process
+        # start. Re-resolve at call time and cache back into os.environ so every
+        # consumer (including the board-worker env passthrough) heals once the
+        # keyring becomes available, instead of erroring until a manual restart.
+        token = _gh_auth_token_fallback()
+        if token:
+            os.environ[self.git.token_env] = token
+        return token
 
     def repo_git_token(self, repo_key: str) -> str | None:
         repo = self.repos.get(repo_key)
@@ -732,6 +746,29 @@ class Settings(BaseModel):
 
     def execution_controls(self) -> ExecutionControlSettings:
         return ExecutionControlSettings.from_env()
+
+
+def _gh_auth_token_fallback() -> str | None:
+    """Best-effort token recovery via `gh auth token` when the env var is empty.
+
+    Never raises: any failure (gh missing, keyring still locked, timeout)
+    returns None and the caller degrades to its existing no-token behavior.
+    """
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        out = subprocess.run(  # noqa: S603
+            [gh, "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    token = out.stdout.strip()
+    return token or None
 
 
 def _resolve_binary(binary: str, config_dir: Path) -> str:

--- a/tests/unit/config/test_git_token_selfheal.py
+++ b/tests/unit/config/test_git_token_selfheal.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""git_token() self-heals when the token env var is empty (boot keyring race).
+
+A fleet started at boot (systemd linger) sources .env before the login keyring
+is unlocked, so GITHUB_TOKEN/GIT_TOKEN get exported EMPTY and stay empty for
+the life of the process. git_token() must fall back to `gh auth token` at call
+time and cache the recovered value back into os.environ so all consumers
+(including the board-worker env passthrough) heal without a manual restart.
+"""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from operations_center.config import settings as settings_mod
+
+
+@pytest.fixture
+def settings():
+    s = SimpleNamespace(git=SimpleNamespace(token_env="TEST_GIT_TOKEN"))
+    return s
+
+
+def _git_token(s):
+    return settings_mod.Settings.git_token(s)
+
+
+def test_env_var_set_returns_it_without_subprocess(settings, monkeypatch):
+    monkeypatch.setenv("TEST_GIT_TOKEN", "tok-from-env")
+
+    def boom(*a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("gh fallback must not run when env var is set")
+
+    monkeypatch.setattr(settings_mod.subprocess, "run", boom)
+    assert _git_token(settings) == "tok-from-env"
+
+
+def test_empty_env_var_recovers_via_gh_and_caches(settings, monkeypatch):
+    monkeypatch.setenv("TEST_GIT_TOKEN", "")
+    monkeypatch.setattr(settings_mod.shutil, "which", lambda _: "/usr/bin/gh")
+    monkeypatch.setattr(
+        settings_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="tok-recovered\n", returncode=0),
+    )
+    assert _git_token(settings) == "tok-recovered"
+    # cached back so passthrough/env consumers see it too
+    import os
+
+    assert os.environ["TEST_GIT_TOKEN"] == "tok-recovered"
+
+
+def test_gh_failure_degrades_to_none(settings, monkeypatch):
+    monkeypatch.setenv("TEST_GIT_TOKEN", "")
+    monkeypatch.setattr(settings_mod.shutil, "which", lambda _: "/usr/bin/gh")
+
+    def raise_timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=10)
+
+    monkeypatch.setattr(settings_mod.subprocess, "run", raise_timeout)
+    assert _git_token(settings) is None
+    import os
+
+    assert os.environ["TEST_GIT_TOKEN"] == ""
+
+
+def test_gh_missing_degrades_to_none(settings, monkeypatch):
+    monkeypatch.setenv("TEST_GIT_TOKEN", "")
+    monkeypatch.setattr(settings_mod.shutil, "which", lambda _: None)
+    assert _git_token(settings) is None
+
+
+def test_token_env_none_returns_none(monkeypatch):
+    s = SimpleNamespace(git=SimpleNamespace(token_env=None))
+    assert _git_token(s) is None


### PR DESCRIPTION
## Problem
A fleet auto-started at boot (systemd linger) sources `.env.operations-center.local` before the login keyring is unlocked. `GITHUB_TOKEN=$(gh auth token ...)` resolves empty, `GIT_TOKEN=$GITHUB_TOKEN` exports empty, and since env is captured at process start, every token-consuming role is broken for the life of the process. Today's reboot left the review watcher crash-looping for 4.5h (`no GitHub token — set GIT_TOKEN in .env`, 31 consecutive failures, `last_success_at=null`) until a manual fleet restart. Every reboot reproduces this.

## Fix
`Settings.git_token()` now self-heals: when the configured env var is empty, it re-resolves via `gh auth token` at call time (10s timeout, never raises) and caches the recovered value back into `os.environ` — so the board-worker token passthrough and all other env consumers heal too, without a restart. Any gh failure (binary missing, keyring still locked, timeout) degrades to the prior no-token behavior. The review watcher constructs its GitHub client per cycle, so the fleet converges automatically the moment the keyring unlocks.

## Tests
- env var set → returned directly, fallback never invoked
- empty env var → recovered via gh, cached back into os.environ
- gh timeout / gh missing → None (prior degrade path)
- token_env None → None

Full unit suite: 8416 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)