### PR TITLE
fix(watch): stop_watch_role never signals the tracked supervisor PID

### DIFF
--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -541,6 +541,23 @@ stop_watch_role() {
   local pid_file
   pid_file="$(watch_pid_file "${role}")"
 
+  # Signal the tracked supervisor directly. start_watch_role launches every
+  # role via `setsid /bin/bash -lc "..." &`, so the recorded pid is both the
+  # supervisor's pid AND its process-group id. Each supervisor installs
+  # `trap 'kill $_child_pid; exit 0' TERM INT` (or kills all siblings for the
+  # multi-process "spec" role), so signaling the group with a negative pid
+  # reaches the supervisor and every child/sibling it spawned in one shot —
+  # this is the only reliable stop path for roles like review/intake/propose
+  # whose child command line has no "--role X" flag (see stray-kill fallback
+  # below, which only matches board_worker.main --role invocations).
+  if [[ -f "${pid_file}" ]]; then
+    local supervisor_pid
+    supervisor_pid="$(cat "${pid_file}" 2>/dev/null)"
+    if [[ -n "${supervisor_pid}" ]] && kill -0 "${supervisor_pid}" >/dev/null 2>&1; then
+      kill -TERM -- "-${supervisor_pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
   # Always kill any stray watcher processes for this role, regardless of the
   # PID file.  Multiple watcher processes for the same role can accumulate if
   # previous stops failed or the PID file was overwritten without terminating


### PR DESCRIPTION
Opened on behalf of loop session iter_0001 (2026-07-13), which pushed this branch but exited before opening the PR.

Root cause: stop_watch_role() only deleted the watcher's PID file and
relied on `pgrep -f "worker.main.*--role X"` to kill stray processes.
That pattern only matches board_worker.main --role invocations (goal/
test/improve) — it never matches review (reviewer.main), intake
(intake.main), or propose (pipeline_trigger.main), none of which take
a --role flag. Those supervisors' long-running --watch child never
exits on its own, so the `[[ ! -f pid_file ]] && exit 0` check the
comment describes was never reached: watch-stop silently no-op'd for
these roles, leaving orphaned supervisor+child processes running
indefinitely.

Observed live: the review watcher had been crash-looping every ~60s
since boot with an empty GITHUB_TOKEN baked into its environment (a
transient `gh auth token` failure at source time) — restarting it via
watch-stop/watch never actually replaced the process, so it never
picked up the (later valid) token.

Fix: send `kill -TERM -- -<supervisor_pid>` (process-group signal;
setsid makes the supervisor its own group leader) before pid-file
cleanup, reaching each supervisor's existing TERM/INT trap regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)