### PR TITLE
fix(loop): session_end hook enforces post-session checkout invariants

### DIFF
--- a/.console/workers.yaml
+++ b/.console/workers.yaml
@@ -43,6 +43,10 @@ pseudo_operator:
     pre_iteration: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "self-update"]
     seed_cooldowns: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "seed-cooldowns"]
     on_cooldown: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "on-cooldown"]
+    # Post-session invariant enforcement: return a stranded clean checkout to
+    # main and open a PR for the session's pushed-but-PR-less branch. The
+    # prompt's STEP 10 asks sessions to do this; the hook guarantees it.
+    session_end: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "session-end"]
 
 workers:
   - id: "investigation-worker"

--- a/src/operations_center/entrypoints/loop_bridge/main.py
+++ b/src/operations_center/entrypoints/loop_bridge/main.py
@@ -15,6 +15,10 @@ invoked by the engine as hook commands configured in ``.console/workers.yaml``:
   self-update      — detect code merged since the last check, ``git pull``
                      and bounce the watcher children so fixes take effect
                      without manual intervention (hook: ``pre_iteration``).
+  session-end JSON — enforce post-session checkout invariants: return a
+                     stranded clean checkout to main and open a PR for the
+                     session's pushed-but-PR-less branch (hook:
+                     ``session_end``).
 
 All commands are best-effort by contract (the engine logs and continues on
 hook failure) but exit non-zero on genuine errors so the failure is visible.
@@ -225,11 +229,115 @@ def self_update() -> int:
     return 0
 
 
+def _git(*argv: str, timeout: int = 60) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *argv],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def session_end(payload_json: str) -> int:
+    """Enforce post-session checkout invariants (hook: ``session_end``).
+
+    Sessions are PROMPTED to branch, push, open a PR, and return the shared
+    checkout to clean main (STEP 10), but a session that dies or drifts can
+    leave the checkout stranded on its branch with the work pushed and no PR
+    (observed iter_0001 2026-07-13) — which also breaks the next iteration's
+    ``self-update`` pull. The prompt is guidance; this hook is the guarantee:
+
+      1. Checkout on a non-main branch and CLEAN → record the branch, switch
+         back to main. A DIRTY tree is never touched (in-flight work wins) —
+         log loudly and leave it for the next session.
+      2. If the stranded branch is pushed, ahead of origin/main, and has no
+         open PR → open one on the session's behalf (best-effort; needs gh).
+    """
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError:
+        payload = {}
+    iteration = payload.get("iteration")
+
+    branch = _git("symbolic-ref", "--quiet", "--short", "HEAD").stdout.strip()
+    if not branch or branch == "main":
+        return 0
+    if _git("status", "--porcelain").stdout.strip():
+        logger.warning(
+            "loop_bridge: session (iter %s) left checkout DIRTY on %r — not touching it",
+            iteration,
+            branch,
+        )
+        return 0
+    logger.info(
+        "loop_bridge: session (iter %s) left checkout on %r — returning to main", iteration, branch
+    )
+    if _git("checkout", "main").returncode != 0:
+        logger.warning("loop_bridge: checkout main failed — leaving %r in place", branch)
+        return 0
+
+    # Best-effort PR for the stranded branch's pushed work. Scope is ONLY the
+    # branch the session stranded us on — never sweep other local branches.
+    if _git("rev-parse", "--verify", "--quiet", f"origin/{branch}").returncode != 0:
+        logger.warning("loop_bridge: stranded branch %r was never pushed — no PR opened", branch)
+        return 0
+    ahead = _git("rev-list", "--count", f"origin/main..origin/{branch}").stdout.strip()
+    if ahead in ("", "0"):
+        return 0
+    try:
+        listed = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if listed.returncode != 0 or json.loads(listed.stdout or "[]"):
+            return 0
+        subject = _git("log", "-1", "--format=%s", f"origin/{branch}").stdout.strip()
+        created = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--head",
+                branch,
+                "--title",
+                subject or f"loop session branch {branch}",
+                "--body",
+                f"Opened by loop_bridge session-end (iteration {iteration}): the session "
+                f"pushed this branch but exited without opening a PR.",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if created.returncode == 0:
+            logger.info("loop_bridge: opened PR for %r: %s", branch, created.stdout.strip())
+        else:
+            logger.warning(
+                "loop_bridge: gh pr create failed for %r: %s",
+                branch,
+                (created.stderr or created.stdout).strip()[:200],
+            )
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        logger.warning("loop_bridge: PR check/create for %r failed: %s", branch, exc)
+    return 0
+
+
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     args = sys.argv[1:]
     if not args:
-        print("usage: loop_bridge {seed-cooldowns|on-cooldown JSON|self-update}", file=sys.stderr)
+        print(
+            "usage: loop_bridge {seed-cooldowns|on-cooldown JSON|self-update|session-end JSON}",
+            file=sys.stderr,
+        )
         return 2
     cmd = args[0]
     if cmd == "seed-cooldowns":
@@ -241,6 +349,8 @@ def main() -> int:
         return on_cooldown(args[1])
     if cmd == "self-update":
         return self_update()
+    if cmd == "session-end":
+        return session_end(args[1] if len(args) > 1 else "{}")
     print(f"unknown loop_bridge command {cmd!r}", file=sys.stderr)
     return 2
 

--- a/tests/unit/entrypoints/loop_bridge/test_main.py
+++ b/tests/unit/entrypoints/loop_bridge/test_main.py
@@ -41,9 +41,7 @@ def test_seed_cooldowns_maps_models_to_backends(monkeypatch, tmp_path: Path, cap
     assert out["codex"] is None
 
 
-def test_seed_cooldowns_account_wide_limit_cools_both(
-    monkeypatch, tmp_path: Path, capsys
-) -> None:
+def test_seed_cooldowns_account_wide_limit_cools_both(monkeypatch, tmp_path: Path, capsys) -> None:
     monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "usage.json"))
     now = datetime.now(timezone.utc)
     reset_at = now + timedelta(hours=3)
@@ -76,7 +74,9 @@ def test_on_cooldown_records_into_usage_store(monkeypatch, tmp_path: Path) -> No
     assert bridge.on_cooldown(payload) == 0
     snapshot = UsageStore().current_worker_backend_cooldowns(now=datetime.now(timezone.utc))
     details = snapshot.get("claude_code", {}).get("cooldowns", [])
-    assert any(d.get("model") == "sonnet" and d.get("limit_kind") == "model_weekly" for d in details)
+    assert any(
+        d.get("model") == "sonnet" and d.get("limit_kind") == "model_weekly" for d in details
+    )
 
 
 def test_on_cooldown_unknown_backend_is_noop(monkeypatch, tmp_path: Path) -> None:
@@ -117,9 +117,7 @@ def test_restart_watchers_never_touches_watchdog(monkeypatch, tmp_path: Path) ->
     _seed_watcher_pidfiles(monkeypatch, tmp_path, {"watchdog": 999, "review": 4242})
     monkeypatch.setattr(bridge.os, "kill", lambda pid, sig: None)
     bounced: list[str] = []
-    monkeypatch.setattr(
-        bridge.subprocess, "run", lambda cmd, **kw: bounced.append(cmd[3]) or None
-    )
+    monkeypatch.setattr(bridge.subprocess, "run", lambda cmd, **kw: bounced.append(cmd[3]) or None)
 
     bridge._restart_watchers()
 
@@ -141,9 +139,7 @@ def test_restart_watchers_skips_dead_wrapper(monkeypatch, tmp_path: Path) -> Non
     assert calls == []
 
 
-def test_self_update_first_run_records_baseline_without_pull(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_self_update_first_run_records_baseline_without_pull(monkeypatch, tmp_path: Path) -> None:
     sha_file = tmp_path / "last_sha"
     monkeypatch.setattr(bridge, "_LAST_SHA_FILE", sha_file)
     calls: list[list[str]] = []
@@ -222,4 +218,99 @@ def test_workers_yaml_pseudo_operator_section_is_valid() -> None:
     assert cfg.delay.kind == "schedule_state"
     assert cfg.delay.state_delays["HEALTHY"] == 3600
     assert cfg.hooks.pre_iteration and cfg.hooks.seed_cooldowns and cfg.hooks.on_cooldown
+    assert cfg.hooks.session_end
     assert cfg.prompt_path.exists()
+
+
+# ── session-end ───────────────────────────────────────────────────────────────
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def _fake_run_factory(monkeypatch, responses: dict[tuple[str, ...], _FakeProc]):
+    """subprocess.run stub keyed on a command-prefix tuple; records all calls."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        for prefix, proc in responses.items():
+            if tuple(cmd[: len(prefix)]) == prefix:
+                return proc
+        return _FakeProc()
+
+    monkeypatch.setattr(bridge.subprocess, "run", fake_run)
+    return calls
+
+
+def test_session_end_noop_on_main(monkeypatch) -> None:
+    calls = _fake_run_factory(monkeypatch, {("git", "symbolic-ref"): _FakeProc(stdout="main\n")})
+    assert bridge.session_end('{"iteration": 3}') == 0
+    assert all(c[:2] != ["git", "checkout"] for c in calls)
+
+
+def test_session_end_dirty_tree_untouched(monkeypatch) -> None:
+    calls = _fake_run_factory(
+        monkeypatch,
+        {
+            ("git", "symbolic-ref"): _FakeProc(stdout="oc-watchdog/x\n"),
+            ("git", "status"): _FakeProc(stdout=" M src/foo.py\n"),
+        },
+    )
+    assert bridge.session_end("{}") == 0
+    assert all(c[:2] != ["git", "checkout"] for c in calls)
+
+
+def test_session_end_returns_clean_checkout_and_opens_pr(monkeypatch) -> None:
+    calls = _fake_run_factory(
+        monkeypatch,
+        {
+            ("git", "symbolic-ref"): _FakeProc(stdout="oc-watchdog/x\n"),
+            ("git", "status"): _FakeProc(stdout=""),
+            ("git", "checkout"): _FakeProc(),
+            ("git", "rev-parse", "--verify"): _FakeProc(returncode=0),
+            ("git", "rev-list"): _FakeProc(stdout="1\n"),
+            ("git", "log"): _FakeProc(stdout="fix: something\n"),
+            ("gh", "pr", "list"): _FakeProc(stdout="[]"),
+            ("gh", "pr", "create"): _FakeProc(stdout="https://x/pull/9"),
+        },
+    )
+    assert bridge.session_end('{"iteration": 1}') == 0
+    assert ["git", "checkout", "main"] in calls
+    create = [c for c in calls if c[:3] == ["gh", "pr", "create"]]
+    assert create and "fix: something" in create[0]
+
+
+def test_session_end_unpushed_branch_no_pr(monkeypatch) -> None:
+    calls = _fake_run_factory(
+        monkeypatch,
+        {
+            ("git", "symbolic-ref"): _FakeProc(stdout="oc-watchdog/x\n"),
+            ("git", "status"): _FakeProc(stdout=""),
+            ("git", "checkout"): _FakeProc(),
+            ("git", "rev-parse", "--verify"): _FakeProc(returncode=1),
+        },
+    )
+    assert bridge.session_end("{}") == 0
+    assert ["git", "checkout", "main"] in calls
+    assert all(c[0] != "gh" for c in calls)
+
+
+def test_session_end_existing_pr_not_duplicated(monkeypatch) -> None:
+    calls = _fake_run_factory(
+        monkeypatch,
+        {
+            ("git", "symbolic-ref"): _FakeProc(stdout="oc-watchdog/x\n"),
+            ("git", "status"): _FakeProc(stdout=""),
+            ("git", "checkout"): _FakeProc(),
+            ("git", "rev-parse", "--verify"): _FakeProc(returncode=0),
+            ("git", "rev-list"): _FakeProc(stdout="2\n"),
+            ("gh", "pr", "list"): _FakeProc(stdout='[{"number": 448}]'),
+        },
+    )
+    assert bridge.session_end("{}") == 0
+    assert all(c[:3] != ["gh", "pr", "create"] for c in calls)


### PR DESCRIPTION
## Problem
Post-reboot iteration 1 (2026-07-13) ended rc=0 but skipped its entire STEP 10: the shared checkout was left stranded on `oc-watchdog/20260713-1241-extraction-health-cli` (clean, pushed, **no PR**), no `schedule.json` was written (engine fell back to 600s), and the session's final message was "I'll stop polling now and wait for the scheduled wakeup" — it pattern-matched an interactive harness it doesn't have. A stranded checkout also silently breaks the next iteration's `self-update` `git pull --ff-only`. Prompt discipline (#435/#438) is guidance, not a guarantee.

## Fix
Wire the CL engine's `session_end` hook (already declared in `HookCommands`, previously unused by OC) to a new `loop_bridge session-end` subcommand:
- checkout on a non-main branch and **clean** → return to main
- the stranded branch, if pushed + ahead of main + PR-less → open a PR on the session's behalf (best-effort via gh)
- a **dirty** tree is never touched (in-flight work wins, loud log)
- scope is only the stranded branch — never a sweep of other local branches

This instance was recovered manually (checkout → main, PR #448); this makes the recovery mechanical.

## Tests
5 new session-end tests (noop-on-main, dirty-untouched, clean→checkout+PR, unpushed→no gh, existing-PR→no duplicate) + workers.yaml fail-closed schema test extended to pin the hook wiring. loop_bridge suite: 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)