### PR TITLE
docs(console): mark stale task.md objective complete

### DIFF
--- a/.console/task.md
+++ b/.console/task.md
@@ -5,7 +5,10 @@ _Replace contents when the objective changes. History belongs in log.md._
 
 ## Objective
 
-Expose the sample `gaps` and `edge_cases` lists in the extraction-health CLI so an operator can inspect them directly. Definition of done: the CLI surfaces both lists; tests cover the new output.
+**COMPLETE** (shipped in PR #374, verified again 2026-07-07 and 2026-07-13 watchdog cycles).
+Expose the sample `gaps` and `edge_cases` lists in the extraction-health CLI so an operator can inspect them directly. Definition of done: the CLI surfaces both lists; tests cover the new output — both met (111/111 tests passing in tests/unit/observer/test_extraction_health_queries.py + test_cli_extraction_health.py).
+
+No active operator directive. Proceeding to standard watchdog steps.
 
 ## Overall Plan
 


### PR DESCRIPTION
## Summary
- `.console/task.md` still showed the gaps/edge_cases extraction-health CLI objective as active, even though it shipped in PR #374 and was verified complete in two prior watchdog cycles (2026-07-07, 2026-07-13 12:41 per `.console/log.md`).
- This caused a third redundant re-verification pass this cycle for zero benefit.
- Marks the objective COMPLETE in task.md with a pointer to the prior verification, so future cycles proceed straight to standard watchdog steps.

## Test plan
- [x] Docs-only change, no code touched
- [x] `.venv/bin/pytest tests/unit/observer/test_extraction_health_queries.py tests/unit/observer/test_cli_extraction_health.py -q` — 111/111 passing (re-confirmed this cycle)