### PR TITLE
wire(loop): budget_guard hook + CL v0.4.3 pin

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -9032,3 +9032,12 @@ honest residual-gap table vs. the Track C signature (local checker patching + Gi
 account compromise stay open; the key remains a compatible later upgrade). Rollout:
 Custodian DC1/DC7 satisfied (front matter + linked from HARNESS_TRUST_HARDENING). CL committed-truth check first, then reviewer council mode (fail-open empty path set,
 populated in a follow-up that is the council's first live case), then EVAL panel.
+
+## 2026-07-13 — budget_guard wired (CL v0.4.3 pin + workers.yaml hook)
+
+CL v0.4.3 ships the per-iteration budget_guard hook (extend-only cooldown merge).
+Wired in workers.yaml to `loop_bridge budget-guard` (#452) and bumped the CL pin.
+Deploy: OC venv already on v0.4.3; loop restart (also activates #449 session_end)
+after this + #452 merge. With this live, over-budget claude usage diverts the loop
+ladder to codex until the 5h bucket rolls — the operator's 25% reserve is enforced
+mechanically across loop + board workers (usage-store synthetic cooldown).

--- a/.console/workers.yaml
+++ b/.console/workers.yaml
@@ -47,6 +47,10 @@ pseudo_operator:
     # main and open a PR for the session's pushed-but-PR-less branch. The
     # prompt's STEP 10 asks sessions to do this; the hook guarantees it.
     session_end: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "session-end"]
+    # Subscription budget guard (operator directive 2026-07-13): leave ~25% of
+    # every 5h claude bucket unspent. Emits {claude/opus: bucket_end|null};
+    # the engine merges extend-only, so over-budget diverts the ladder to codex.
+    budget_guard: [".venv/bin/python", "-m", "operations_center.entrypoints.loop_bridge.main", "budget-guard"]
 
 workers:
   - id: "investigation-worker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   # planeless).
   "platform-manifest @ git+https://github.com/ProtocolWarden/PlatformManifest.git@v1.1.0",
   # ADR 0002 P4 — dispatcher CL wrap.
-  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.2",
+  "context-lifecycle @ git+https://github.com/ProtocolWarden/ContextLifecycle.git@v0.4.3",
   # EVAL answer-key signatures (Ed25519) — operations_center.eval.signing.
   "cryptography>=42",
 ]

--- a/tests/unit/entrypoints/loop_bridge/test_main.py
+++ b/tests/unit/entrypoints/loop_bridge/test_main.py
@@ -219,6 +219,7 @@ def test_workers_yaml_pseudo_operator_section_is_valid() -> None:
     assert cfg.delay.state_delays["HEALTHY"] == 3600
     assert cfg.hooks.pre_iteration and cfg.hooks.seed_cooldowns and cfg.hooks.on_cooldown
     assert cfg.hooks.session_end
+    assert cfg.hooks.budget_guard
     assert cfg.prompt_path.exists()
 
 


### PR DESCRIPTION
CL v0.4.3 (ContextLifecycle#42) ships the per-iteration `budget_guard` engine hook with extend-only cooldown merge. This wires it in `workers.yaml` to `loop_bridge budget-guard` (#452) and bumps the CL pin v0.4.2→v0.4.3; the fail-closed workers.yaml schema test now pins the hook wiring.

Sequencing: merges cleanly in either order with #452 — if this lands first, the hook is a loud no-op (unknown subcommand, engine logs and continues) until #452 follows. Deploy: loop restart after both (also activates the #449 session_end hook); OC venv already updated to v0.4.3 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)