### PR TITLE
docs(console): mark gaps/edge_cases work order complete (task.md stale)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -9130,3 +9130,15 @@ Deploy: OC venv already on v0.4.3; loop restart (also activates #449 session_end
 after this + #452 merge. With this live, over-budget claude usage diverts the loop
 ladder to codex until the 5h bucket rolls — the operator's 25% reserve is enforced
 mechanically across loop + board workers (usage-store synthetic cooldown).
+
+## 2026-07-14 — gaps/edge_cases CLI exposure: already shipped (task.md was stale)
+
+Verified the active task.md work order (expose sample `gaps`/`edge_cases` lists in the
+extraction-health CLI) was already fully implemented and merged in PR #374
+(a675c1f7, "Expose sample gaps and edge_cases lists in CLI for operator inspection"),
+with follow-on work (#387 dashboard, #417 message_quality_rate) layered on top since.
+`ExtractionHealth.gaps`/`.edge_cases` fields, `get_extraction_health()` sample
+collection, and the table-format CLI sections all exist; 111/111 tests pass in
+`tests/unit/observer/test_extraction_health_queries.py` +
+`tests/unit/observer/test_cli_extraction_health.py`. task.md just hadn't been marked
+done. No code change needed this cycle.

--- a/.console/task.md
+++ b/.console/task.md
@@ -3,9 +3,14 @@
 _The active assignment. One objective at a time._
 _Replace contents when the objective changes. History belongs in log.md._
 
-## Objective
+## Objective — ✅ COMPLETE (verified 2026-07-14)
 
 Expose the sample `gaps` and `edge_cases` lists in the extraction-health CLI so an operator can inspect them directly. Definition of done: the CLI surfaces both lists; tests cover the new output.
+
+Shipped in PR #374 (a675c1f7). Verified 2026-07-14: `ExtractionHealth.gaps`/`.edge_cases`
+fields, sample collection in `get_extraction_health()`, and table-format CLI sections all
+present; 111/111 tests pass. No operator directive is currently active — proceeding to
+standard watchdog steps. Awaiting a new objective from the operator.
 
 ## Overall Plan
 


### PR DESCRIPTION
## Summary
- `.console/task.md` still targeted the extraction-health `gaps`/`edge_cases` CLI exposure objective, but it was already shipped in PR #374 (`a675c1f7`) — `ExtractionHealth.gaps`/`.edge_cases` fields, sample collection, and table-format CLI sections all exist.
- Two prior watchdog cycles (2026-07-14 06:xx and 07:47) re-verified the same already-complete objective without updating `task.md`, risking continued no-op re-verification cycles.
- Marks the objective `✅ COMPLETE` in `task.md` and logs the outcome in `log.md` per the STEP 10 work-order-completion exception. No source code change — `111/111` extraction-health tests and `15/15` golden invariant tests pass unchanged.

## Test plan
- [x] `.venv/bin/pytest tests/unit/observer/test_extraction_health_queries.py tests/unit/observer/test_cli_extraction_health.py -q` → 111 passed
- [x] `.venv/bin/pytest tests/unit/er000_phase0_golden/ -q` → 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)