### PR TITLE
feat(reviewer): C1 cross-family council for guardrail PRs (COUNCIL_VERDICT.md)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,31 @@
+## 2026-07-14 — feat(reviewer): C1 cross-family council for guardrail PRs (COUNCIL_VERDICT.md)
+
+Council spec Phase 2 (C1) — keyless change control for guardrail surfaces. A PR
+whose diff touches any `reviewer.council.guardrail_paths` glob is adjudicated by
+a K=3 cross-family panel (claude/sonnet + claude/opus + codex/gpt-5, distinct
+lenses: correctness / security-capability / convergence-operational) instead of
+the single self-review; UNANIMOUS LGTM merges, any CONCERN feeds the existing
+self-heal fix ladder unchanged, and an unmet quorum PARKS (fail-closed, reusing
+the #446 auto-resume) rather than merging under-reviewed. `guardrail_paths`
+ships EMPTY (feature OFF, fail-open) so this rollout PR can't deadlock on the
+gate it introduces; populating the set is a deliberate follow-up.
+
+Structure: pure logic in `verdict.py` (`aggregate_council`, lens fragments,
+`_COUNCIL_PANEL`, `last_json_object` codex-stdout fallback) so it's covered by
+the tests/unit gate; `_run_council` in main.py stays thin. `_run_direct_review`
+generalized to `_run_member_review(*, backend, model)` (kept as a byte-identical
+alias for the single path — SAME `claude --model haiku -p --effort low` argv,
+only the model varies per seat). Per-member cooldown via `_member_on_cooldown`
+(model-aware, since sonnet vs opus are both claude_code). Both paths share a new
+`_dispatch_verdict_outcome` tail. Verdict still CODE-COMPUTED per member (INJ
+boundary intact). F14 baked in: park-cap → operator escalation
+(`council_unavailable_capped`), degraded quorum (`min_council_members`), and a
+NARROW self-fix exemption — only the reviewer's own `review/` fix branches are
+exempt; fleet `goal/` PRs touching guardrails DO get the council (that is the
+control's primary threat — fleet merging a guardrail change on a single LGTM).
+Doc truth-up: HARNESS_TRUST_HARDENING §0.1 no longer overclaims the council as
+live. 166 reviewer tests + 29 verdict unit tests; tests/unit 85.95% (gate 85%).
+
 ## 2026-07-14 — feat(reviewer): budget/cooldown-aware review — defer, don't burn (audit D1 pt1)
 
 The reviewer is part of the fleet but was claude-ONLY and consulted NO budget:

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -212,6 +212,34 @@ repos:
 #   max_self_review_loops: 2
 #   # HTML marker appended to every bot-posted comment — prevents re-processing own comments.
 #   bot_comment_marker: "<!-- operations-center:bot -->"
+#   # C1 — cross-family reviewer council for guardrail-surface PRs (COUNCIL_VERDICT.md).
+#   # A PR whose diff touches any of council.guardrail_paths is adjudicated by a
+#   # K=3 cross-family panel (claude/sonnet, claude/opus, codex) instead of the
+#   # single self-review; unanimous LGTM merges, any CONCERN feeds the existing
+#   # fix ladder, and an unmet quorum parks (fail-closed) rather than merging
+#   # under-reviewed. council.guardrail_paths defaults EMPTY ⇒ feature OFF — the
+#   # rollout PR that introduces the council must not deadlock on the gate it
+#   # introduces. Populating this list is a DELIBERATE FOLLOW-UP PR, not part of
+#   # this one; the commented set below is the COUNCIL_VERDICT.md §G1 candidate
+#   # list, left inactive here on purpose.
+#   council:
+#     guardrail_paths: []
+#       # - .console/workers.yaml
+#       # - .console/guidelines.md
+#       # - tools/loop/oc_session_prompt.txt
+#       # - .hooks/**
+#       # - scripts/operations-center.sh
+#       # - eval/**
+#       # - src/operations_center/entrypoints/pr_review_watcher/**  # council guards its own code
+#       # - src/operations_center/entrypoints/loop_bridge/**
+#       # - config/operations_center.local.yaml                     # untracked, but pin anyway
+#       # - docs/design/COUNCIL_VERDICT.md                          # this spec
+#     # A park that outlasts this many hours is surfaced to the operator with a
+#     # distinct reason (council_unavailable_capped) instead of re-parking forever.
+#     max_council_park_hours: 24
+#     # Minimum runnable panel seats required to proceed. 3 = strict unanimity of
+#     # all families; 2 allows a degraded quorum (unanimity among the two available).
+#     min_council_members: 3
 
 # ---------------------------------------------------------------------------
 # Scheduled tasks — periodic Plane work-item seeders

--- a/docs/design/HARNESS_TRUST_HARDENING.md
+++ b/docs/design/HARNESS_TRUST_HARDENING.md
@@ -59,10 +59,14 @@ that re-opens the INJ verdict hole. None is complete alone.
 > unblocking it. The operator may encode a judgment **once** (offline, anchored);
 > the system must reconfirm and correct **forever** after.
 
-(While the operator's signing ceremony is deferred, guardrail-surface changes are
-gated by cross-family council review instead — see
+(While the operator's signing ceremony is deferred, guardrail-surface changes
+will be gated by cross-family council review instead — see
 [COUNCIL_VERDICT.md](COUNCIL_VERDICT.md) for the mechanism and its honest residual
-gaps vs. the signature.)
+gaps vs. the signature. Status: the council engine — per-member dispatch,
+aggregation, quorum park, degraded-quorum and park-cap mitigations — shipped
+under C1, but `reviewer.council.guardrail_paths` ships EMPTY, so the gate is
+not live on any real path yet. Populating it is a deliberate, tracked
+follow-up, not an oversight.)
 
 This is a hard constraint on every capability, not a feature of EVAL alone. It has
 three operational tests every design here must pass:

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -285,6 +285,31 @@ class MaintenanceWindow(BaseModel):
     days: list[int] = Field(default_factory=list)  # empty = all days
 
 
+class CouncilSettings(BaseModel):
+    """C1 — cross-family reviewer council for guardrail-surface PRs.
+
+    See docs/design/COUNCIL_VERDICT.md (G1/C1). A PR whose diff touches any
+    ``guardrail_paths`` glob is adjudicated by a K=3 cross-family panel (claude
+    sonnet, claude opus, codex) instead of the single self-review; unanimous
+    LGTM merges, any CONCERN feeds the existing fix ladder, and a family on
+    cooldown parks the PR (fail-closed) until it recovers.
+
+    ``guardrail_paths`` defaults EMPTY ⇒ the feature is OFF (fail-open to today's
+    single review). Populating the set is a deliberate follow-up PR — the rollout
+    PR that introduces the council must not deadlock on the gate it introduces.
+    """
+
+    # Repo-relative globs; empty ⇒ feature OFF (no PR is a guardrail PR).
+    guardrail_paths: list[str] = Field(default_factory=list)
+    # F14 mitigation — park cap: a council park that outlasts this many hours is
+    # surfaced to the operator with a distinct reason instead of re-parking forever.
+    max_council_park_hours: int = 24
+    # F14 mitigation — degraded quorum floor: the minimum number of runnable panel
+    # families required to proceed. 3 = strict unanimity of all families; 2 =
+    # allow a degraded quorum (unanimity among the two available families).
+    min_council_members: int = 3
+
+
 class ReviewerSettings(BaseModel):
     # GitHub logins whose comments are always ignored (bots, CI accounts)
     bot_logins: list[str] = Field(default_factory=list)
@@ -330,6 +355,9 @@ class ReviewerSettings(BaseModel):
     # extra scrutiny on high-blast-radius diffs without putting a human in the
     # per-correction loop. False (default) preserves prior behavior.
     require_sensitive_path_ack: bool = False
+    # C1 — cross-family council for guardrail-surface PRs (COUNCIL_VERDICT.md).
+    # Empty council.guardrail_paths (default) ⇒ feature OFF ⇒ today's single review.
+    council: CouncilSettings = Field(default_factory=CouncilSettings)
 
 
 class RepoSettings(BaseModel):

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -88,9 +88,13 @@ from operations_center.entrypoints.pr_review_watcher.inj import (
     sanitize_for_comment,
 )
 from operations_center.entrypoints.pr_review_watcher.verdict import (
+    _COUNCIL_PANEL,
     CONCERNS,
+    aggregate_council,
     compute_verdict,
+    council_lens_fragment,
     failing_summary,
+    last_json_object,
     sensitive_paths_in_diff,
     verdict_schema_prompt,
 )
@@ -99,6 +103,10 @@ from operations_center.policy.defaults import sensitive_path_patterns
 logger = logging.getLogger(__name__)
 
 _STATE_SUBDIR = Path("state") / "pr_reviews"
+# C1 — per-PR council audit record (per-member backend/model/lens/verdict +
+# the aggregate). Separate from _STATE_SUBDIR (the review state machine's own
+# bookkeeping) so the council record is a pure, append-free audit artifact.
+_COUNCIL_SUBDIR = Path("state") / "council"
 
 
 # ── State file helpers ────────────────────────────────────────────────────────
@@ -110,6 +118,10 @@ def _state_key(repo_key: str, pr_number: int) -> str:
 
 def _state_path(oc_root: Path, repo_key: str, pr_number: int) -> Path:
     return oc_root / _STATE_SUBDIR / f"{_state_key(repo_key, pr_number)}.json"
+
+
+def _council_state_path(oc_root: Path, repo_key: str, pr_number: int) -> Path:
+    return oc_root / _COUNCIL_SUBDIR / f"{_state_key(repo_key, pr_number)}.json"
 
 
 def _prune_orphan_state_files(oc_root: Path, repo_key: str, open_numbers: set[int]) -> None:
@@ -549,16 +561,59 @@ def _select_review_backend(settings, *, usage_store=None, now=None):
         return None
 
 
-def _run_direct_review(
+def _build_member_argv(backend: str, model: str, prompt: str) -> list[str] | None:
+    """Build the CLI argv for one review-panel member.
+
+    Mirrors :func:`worker_backend_probe._probe_command` — the same binary/flag
+    shape the controller and the cooldown-probe already use — so the reviewer's
+    own invocation matches the rest of the fleet instead of a bespoke one-off.
+    Returns ``None`` for an unsupported ``(backend, model)`` pair.
+    """
+    if backend == "claude_code":
+        # Preserve the live single-review invocation exactly (only the model
+        # varies per council seat): `--effort low` keeps reviews cheap+fast, and
+        # NOT passing --dangerously-skip-permissions matches the path that has
+        # run in production — a reviewer in an empty tmpdir needs neither.
+        return [
+            "claude",
+            "--model",
+            model,
+            "-p",
+            "--effort",
+            "low",
+            prompt,
+        ]
+    if backend == "codex_cli":
+        return [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            prompt,
+        ]
+    return None
+
+
+def _run_member_review(
     oc_root: Path,
     goal_text: str,
     state_key: str,
+    *,
+    backend: str = "claude_code",
+    model: str = "haiku",
 ) -> dict | None:
-    """Run a self-review via a direct ``claude -p`` call in an empty temp directory.
+    """Run one review-panel member (the self-review's sole member, or one
+    council seat) via a direct CLI call in an empty temp directory.
 
     Bypasses the TeamExecutor pipeline so the workspace's CLAUDE.md cannot
-    override the review goal.  The diff is already embedded in ``goal_text``
-    so no repo clone is needed.  Returns the parsed verdict dict or None.
+    override the review goal. The diff is already embedded in ``goal_text`` so
+    no repo clone is needed. Returns the parsed verdict dict or None.
+
+    The member is expected to write ``verdict.json`` to its cwd (the typed
+    schema from ``verdict_schema_prompt()``). Some backends (codex, observed
+    not to reliably honor the file-write contract) may instead print their
+    answer to stdout — in that case the last balanced JSON object on stdout is
+    used as a fallback (:func:`verdict.last_json_object`) before this is
+    treated as a genuine no-verdict.
     """
     conflicted = _oc_source_conflict_markers(oc_root)
     if conflicted:
@@ -570,36 +625,43 @@ def _run_direct_review(
             "to run the reviewer (it would crash at import)."
         )
 
+    argv = _build_member_argv(backend, model, goal_text)
+    if argv is None:
+        raise ReviewerBackendError(
+            f"no CLI invocation known for backend={backend!r} model={model!r} "
+            f"(state_key={state_key})"
+        )
+
     with tempfile.TemporaryDirectory(prefix="oc-review-direct-") as tmpdir:
         tmp = Path(tmpdir)
         verdict_path = tmp / "verdict.json"
         try:
             proc = subprocess.run(
-                [
-                    "claude",
-                    "--model",
-                    "claude-haiku-4-5-20251001",
-                    "-p",
-                    "--effort",
-                    "low",
-                    goal_text,
-                ],
+                argv,
                 cwd=str(tmp),
                 capture_output=True,
                 text=True,
                 timeout=300,
             )
         except subprocess.TimeoutExpired:
-            raise ReviewerBackendError(f"direct review timed out (300s) for state_key={state_key}")
+            raise ReviewerBackendError(
+                f"member review timed out (300s) for state_key={state_key} "
+                f"backend={backend} model={model}"
+            )
+
+        raw: dict | None = None
         if verdict_path.exists():
             try:
                 raw = json.loads(verdict_path.read_text(encoding="utf-8"))
             except Exception:
-                logger.warning(
-                    "pr_review_watcher: malformed verdict.json from direct review for %s",
-                    state_key,
-                )
-                return None  # clean exit, bad JSON — genuine no-verdict
+                raw = None
+        if raw is None:
+            # Fallback for a backend that answered on stdout instead of writing
+            # the file (observed with codex) — scan for the last balanced JSON
+            # object before concluding there is genuinely no verdict.
+            raw = last_json_object(proc.stdout)
+
+        if raw is not None:
             # INJ Phase 1 (D-INJ-1): the merge decision is COMPUTED BY CODE from
             # the model's typed per-check statuses — any model-authored "result"
             # in `raw` is ignored. This is the trust boundary: an injected diff
@@ -614,24 +676,113 @@ def _run_direct_review(
             else:
                 summary = (raw.get("summary") if isinstance(raw, dict) else None) or ""
             return {"result": result, "failing_checks": failing, "summary": summary}
-        # No verdict.json written.
+
+        # No parseable verdict anywhere (file absent/malformed, stdout not JSON).
         if proc.returncode != 0:
             # Non-zero exit = crash, signal kill, or rate-limit — infra failure,
             # not a PR quality problem.  Don't charge the no_verdict budget.
             stdout_tail = (proc.stdout or "").strip()[-500:]
             raise ReviewerBackendError(
                 f"reviewer process exited with rc={proc.returncode} "
-                f"for state_key={state_key} (stdout_tail={stdout_tail!r})"
+                f"for state_key={state_key} backend={backend} model={model} "
+                f"(stdout_tail={stdout_tail!r})"
             )
-        # returncode == 0, no verdict.json — the reviewer ran cleanly but chose
-        # not to write a file.  Genuine no-verdict; charge the budget.
+        # returncode == 0, no verdict anywhere — the reviewer ran cleanly but
+        # produced nothing usable.  Genuine no-verdict; charge the budget.
         stdout_tail = (proc.stdout or "").strip()[-500:]
         logger.warning(
-            "pr_review_watcher: no verdict.json from direct review for %s (rc=0, stdout_tail=%r)",
+            "pr_review_watcher: no verdict from member review for %s "
+            "backend=%s model=%s (rc=0, stdout_tail=%r)",
             state_key,
+            backend,
+            model,
             stdout_tail,
         )
         return None
+
+
+def _run_direct_review(
+    oc_root: Path,
+    goal_text: str,
+    state_key: str,
+) -> dict | None:
+    """Back-compat name for the single self-review member (claude/haiku).
+
+    Kept as a thin alias — rather than renaming this call site inline — so the
+    existing test suite (which patches ``_run_direct_review`` directly) keeps
+    working unchanged. Prefer :func:`_run_member_review` for any new caller
+    that needs a specific backend/model (e.g. the C1 council).
+    """
+    return _run_member_review(oc_root, goal_text, state_key, backend="claude_code", model="haiku")
+
+
+def _member_on_cooldown(usage_store, backend: str, model: str, *, now: datetime) -> bool:
+    """True when this council member's ``(backend, model)`` is currently cooled.
+
+    Model-aware (unlike ``_select_review_backend``, which is backend-grained
+    and can't tell a cooled sonnet from a runnable opus): a lone
+    ``model_weekly`` cooldown for a DIFFERENT model does not cool this member —
+    the backend's other models remain runnable. An account-wide cooldown
+    (``session_5h`` / ``global_weekly`` / unattributed) cools every model of
+    the backend, including this one.
+
+    Fails OPEN (not cooled) on a store-read error: a broken usage store must
+    never itself deadlock the council quorum check (degrade-never-halt).
+    """
+    try:
+        details = usage_store.worker_backend_cooldown_details(backend, now=now)
+    except Exception as exc:  # noqa: BLE001 — never block the gate on a store read
+        logger.warning(
+            "pr_review_watcher: council cooldown check failed for %s/%s — "
+            "treating as available: %s",
+            backend,
+            model,
+            exc,
+        )
+        return False
+    from operations_center.backends.limit_classifier import MODEL_WEEKLY
+
+    for entry in details:
+        if entry.get("limit_kind") == MODEL_WEEKLY:
+            if entry.get("model") == model:
+                return True
+            continue
+        return True  # account-wide / unattributed — blocks every model of the backend
+    return False
+
+
+# Branch prefixes that are exempt from the council and fall back to single
+# review. Deliberately NARROW: only the reviewer's OWN fix-pass branches
+# (``review/<suffix>``, created by _run_fix_pass when a PR has no task branch).
+# It must NOT include the fleet's primary feature branches (goal/, test/,
+# improve/, spec-author/): the council's PRIMARY purpose (COUNCIL_VERDICT.md
+# threat table, row 1) is to stop the FLEET from merging a guardrail change on
+# a single-reviewer LGTM — and nearly every PR here is fleet-authored on a
+# goal/ branch, so exempting those would make the council inert against its own
+# reason to exist. Genuine deadlock (a guardrail PR parked because a family is
+# cooled) is bounded instead by the park-cap escalation (F14) + degraded quorum;
+# spec C1.4 explicitly permits guardrail parks to wait for a human.
+_COUNCIL_EXEMPT_BRANCH_PREFIXES = ("review/",)
+
+
+def _council_exempt_self_fix(state: dict, pr_data: dict) -> bool:
+    """F14 bootstrap-deadlock guard: True only when this PR is the reviewer's
+    OWN fix-pass branch (``review/…``), so the reviewer's self-heal fixes are
+    never gated by the very council they might be fixing — the narrowest escape
+    that keeps the control plane self-healing.
+
+    NOTE (operator policy): this exemption is intentionally scoped to the
+    reviewer's own ``review/`` branches, NOT the fleet's primary feature
+    branches. A fleet ``goal/`` PR that touches a guardrail surface DOES get the
+    full council — that is the control's primary threat (fleet quietly merges a
+    guardrail change). Deadlock avoidance for a legitimately-parked guardrail PR
+    is handled by the park-cap escalation + degraded quorum, not by widening
+    this exemption. Widening it (e.g. to exempt goal/ PRs) is a trust-model
+    change for the operator to decide before ``guardrail_paths`` is populated.
+    """
+    del state  # unused — branch identity alone determines the exemption
+    head_ref = str(((pr_data or {}).get("head") or {}).get("ref") or "").strip().lower()
+    return bool(head_ref) and head_ref.startswith(_COUNCIL_EXEMPT_BRANCH_PREFIXES)
 
 
 def _run_pipeline(
@@ -2643,7 +2794,56 @@ def _phase1(
             escalated_at = datetime.fromisoformat(raw_ts)
         except ValueError:
             escalated_at = None
-        if (
+
+        # F14 park-cap: a COUNCIL park (unmet cross-family quorum) is capped
+        # independently of the generic 1h backend-unavailable resume above.
+        # Without this, the 1h auto-resume clears the escalation, _run_council
+        # immediately re-parks on the same unmet quorum (the general resume
+        # window is far shorter than a real capacity outage), and the pair
+        # repeats forever with no operator-visible signal. council_park_started_at
+        # is set ONCE by _run_council on first park and is NOT reset by this
+        # block's resume/re-park cycling, so the cap tracks total time parked,
+        # not time since the most recent re-park.
+        _council_capped_hold = False
+        if state.get("council_park"):
+            cap_hours = getattr(settings.reviewer.council, "max_council_park_hours", 24)
+            started_raw = str(state.get("council_park_started_at") or raw_ts)
+            try:
+                started_at = datetime.fromisoformat(started_raw)
+            except ValueError:
+                started_at = escalated_at
+            if (
+                started_at is not None
+                and (datetime.now(UTC) - started_at).total_seconds() >= cap_hours * 3600
+            ):
+                _council_capped_hold = True
+                if state.get("escalated_reason") != "council_unavailable_capped":
+                    detail = (
+                        f"Reviewer council has been parked (insufficient cross-family "
+                        f"quorum) for over {cap_hours}h — this is no longer a transient "
+                        "backend cooldown. Surfacing distinctly instead of continuing to "
+                        "silently auto-resume and re-park."
+                    )
+                    state["escalated_needs_human"] = False  # force a fresh, distinct comment
+                    _escalate_needs_human(
+                        state,
+                        state_path,
+                        gh_client,
+                        owner,
+                        repo,
+                        settings,
+                        reason="council_unavailable_capped",
+                        detail=detail,
+                        current_head_sha=current_head_sha,
+                    )
+                    logger.error(
+                        "pr_review_watcher: PR #%d council park capped at %dh; escalated "
+                        "distinctly (council_unavailable_capped)",
+                        pr_number,
+                        cap_hours,
+                    )
+
+        if not _council_capped_hold and (
             escalated_at is None
             or (datetime.now(UTC) - escalated_at).total_seconds() >= _BACKEND_UNAVAILABLE_RESUME_S
         ):
@@ -2659,6 +2859,8 @@ def _phase1(
             state.pop("escalated_reason", None)
             state.pop("escalated_at_utc", None)
             state["backend_error_passes"] = 0
+            state.pop("council_park", None)
+            state.pop("council_park_started_at", None)
             logger.info(
                 "pr_review_watcher: PR #%d backend-unavailable park expired; "
                 "resuming automated review",
@@ -3213,6 +3415,46 @@ def _phase1(
     )
     doc_rubric = _DOC_ONLY_REVIEW_RUBRIC if docs_only else ""
 
+    # These budgets are read by BOTH review modes' post-verdict tail
+    # (_dispatch_verdict_outcome) — must be set before the C1 fork below, since
+    # a guardrail PR may return via _run_council without ever reaching the
+    # single-review goal_text/setdefault block further down.
+    state.setdefault("fix_attempts", 0)
+    state.setdefault("no_verdict_passes", 0)
+    state.setdefault("env_unclean_passes", 0)
+    state.setdefault("backend_error_passes", 0)
+    state.setdefault("no_verdict_escalation_count", 0)
+
+    # C1 — cross-family council fork (COUNCIL_VERDICT.md G1/C1). guardrail_paths
+    # defaults to [] (not a list on a bare MagicMock in older/ad-hoc settings
+    # either) — isinstance-gated so the feature stays OFF unless a REAL glob
+    # list is configured, never accidentally on via a truthy mock/sentinel.
+    council = getattr(reviewer, "council", None)
+    _raw_guardrail_paths = getattr(council, "guardrail_paths", None)
+    guardrail_paths = _raw_guardrail_paths if isinstance(_raw_guardrail_paths, list) else []
+    guardrail_hits = sensitive_paths_in_diff(_pr_files, guardrail_paths) if guardrail_paths else []
+    if guardrail_hits and not _council_exempt_self_fix(state, pr_data):
+        _run_council(
+            state,
+            state_path,
+            pr_data,
+            gh_client,
+            owner,
+            repo,
+            oc_root,
+            config_path,
+            settings,
+            current_head_sha=current_head_sha,
+            diff=diff,
+            diff_excerpt=diff_excerpt,
+            title=title,
+            spec_section=spec_section,
+            custodian_section=custodian_section,
+            guardrail_hits=guardrail_hits,
+            nonce=nonce,
+        )
+        return
+
     goal_text = (
         "## TASK TYPE: Read-only code review\n"
         "## SINGLE REQUIRED ACTION: Write verdict.json — no other file changes allowed\n\n"
@@ -3241,12 +3483,6 @@ def _phase1(
         repo_key,
         state["self_review_loops"],
     )
-
-    state.setdefault("fix_attempts", 0)
-    state.setdefault("no_verdict_passes", 0)
-    state.setdefault("env_unclean_passes", 0)
-    state.setdefault("backend_error_passes", 0)
-    state.setdefault("no_verdict_escalation_count", 0)
 
     # D1: consult the shared fleet ladder BEFORE spawning a claude review. If
     # claude is on cooldown or over the 25% budget reserve, don't burn it —
@@ -3429,13 +3665,63 @@ def _phase1(
         summary = "Failed checks: " + ", ".join(str(c) for c in failing_checks)
     else:
         summary = str(verdict.get("summary") or "(no summary)")
+
+    _dispatch_verdict_outcome(
+        state,
+        state_path,
+        pr_data,
+        gh_client,
+        owner,
+        repo,
+        oc_root,
+        config_path,
+        settings,
+        result=result,
+        failing_checks=failing_checks,
+        summary=summary,
+        current_head_sha=current_head_sha,
+        diff=diff,
+    )
+
+
+def _dispatch_verdict_outcome(
+    state: dict,
+    state_path: Path,
+    pr_data: dict,
+    gh_client,
+    owner: str,
+    repo: str,
+    oc_root: Path,
+    config_path: Path,
+    settings,
+    *,
+    result: str,
+    failing_checks: list,
+    summary: str,
+    current_head_sha: str,
+    diff: str,
+) -> None:
+    """Shared post-verdict tail: LGTM merges; any CONCERNS feeds the existing
+    fix ladder (post-once concern comment, Self-Heal Ladder, fix-pass dispatch,
+    close-and-requeue on exhaustion).
+
+    Both the single self-review path and the C1 council path call this once
+    they have a final ``{result, failing_checks, summary}`` — the council
+    aggregates its per-member verdicts into exactly this shape first
+    (``verdict.aggregate_council``). There is ONE merge/fix-ladder/close
+    implementation regardless of which review mode produced the verdict.
+    """
+    pr_number = int(state["pr_number"])
+    repo_key = state["repo_key"]
+    state_key = state["state_key"]
+    reviewer = settings.reviewer
     normalized_summary = _normalize_concerns_summary(summary)
 
     # Track when concerns are raised (for improved retraction guard)
     if result == "CONCERNS" and current_head_sha:
         _track_concern_raised(state, summary, current_head_sha)
 
-    logger.info("pr_review_watcher: PR #%d self-review verdict=%s", pr_number, result)
+    logger.info("pr_review_watcher: PR #%d review verdict=%s", pr_number, result)
 
     # Surface the verdict as a required status check on the reviewed head, so an
     # unresolved CONCERNS verdict blocks merge for humans (manual gh pr merge)
@@ -3740,6 +4026,263 @@ def _phase1(
     except Exception:
         pass
     _save_state(state_path, state)
+
+
+def _run_council(
+    state: dict,
+    state_path: Path,
+    pr_data: dict,
+    gh_client,
+    owner: str,
+    repo: str,
+    oc_root: Path,
+    config_path: Path,
+    settings,
+    *,
+    current_head_sha: str,
+    diff: str,
+    diff_excerpt: str,
+    title: str,
+    spec_section: str,
+    custodian_section: str,
+    guardrail_hits: list[str],
+    nonce: str,
+    usage_store=None,
+) -> None:
+    """C1 — cross-family reviewer council for a guardrail-surface PR.
+
+    Kept thin: the aggregation logic (unanimity, fail-safe empty-panel, union
+    of failing checks, attributed summary) lives in ``verdict.aggregate_council``,
+    pure and unit-tested. This orchestrator's job is only to (1) build the
+    shared evidence bundle once, (2) work out which panel seats are actually
+    runnable right now, (3) park on an unmet quorum instead of burning cooled
+    backends, (4) dispatch the runnable seats, and (5) hand the aggregate off
+    to the SAME post-verdict tail (``_dispatch_verdict_outcome``) the ordinary
+    self-review path uses — one merge/fix-ladder implementation, not two.
+
+    ``usage_store`` is injectable (mirroring ``_select_review_backend``) so
+    tests can pre-load specific cooldowns; production callers omit it and get
+    the real on-disk store.
+    """
+    pr_number = int(state["pr_number"])
+    repo_key = state["repo_key"]
+    state_key = state["state_key"]
+    council = settings.reviewer.council
+    # Defensive — _phase1 already sets these before forking here, but
+    # _run_council must not assume a particular caller ordering.
+    state.setdefault("fix_attempts", 0)
+    state.setdefault("no_verdict_passes", 0)
+    state.setdefault("env_unclean_passes", 0)
+    state.setdefault("backend_error_passes", 0)
+    state.setdefault("no_verdict_escalation_count", 0)
+
+    if usage_store is None:
+        from operations_center.execution.usage_store import UsageStore
+
+        usage_store = UsageStore()
+    now = datetime.now(UTC)
+
+    available = [
+        member for member in _COUNCIL_PANEL if not _member_on_cooldown(usage_store, *member[:2], now=now)
+    ]
+    min_members = getattr(council, "min_council_members", 3)
+
+    if len(available) < min_members:
+        cooled = sorted(f"{b}/{m}" for (b, m, _lens) in _COUNCIL_PANEL if (b, m, _lens) not in available)
+        detail = (
+            f"Guardrail-surface PR requires a {min_members}-member cross-family council "
+            f"(COUNCIL_VERDICT.md C1); only {len(available)}/{len(_COUNCIL_PANEL)} panel seats "
+            f"are runnable right now (cooled: {', '.join(cooled) or 'n/a'}). Parked — not merged "
+            "(unresolved) and not closed (work preserved); automated review resumes once enough "
+            "panel members recover, the PR head changes, or a human intervenes."
+        )
+        state["council_park"] = True
+        state.setdefault("council_park_started_at", now.isoformat())
+        state["council_available_members"] = len(available)
+        logger.warning(
+            "pr_review_watcher: PR #%d council quorum unmet (%d/%d available) — parking",
+            pr_number,
+            len(available),
+            min_members,
+        )
+        _escalate_needs_human(
+            state,
+            state_path,
+            gh_client,
+            owner,
+            repo,
+            settings,
+            reason="reviewer_backend_unavailable",
+            detail=detail,
+            current_head_sha=current_head_sha,
+        )
+        return
+
+    # Quorum met — clear any prior park bookkeeping (F14 park-cap timer resets
+    # only once the council actually runs again, not on every poll).
+    state.pop("council_park", None)
+    state.pop("council_park_started_at", None)
+    degraded_quorum = len(available) < len(_COUNCIL_PANEL)
+
+    base_goal_text = (
+        "## TASK TYPE: Read-only code review (cross-family council seat)\n"
+        "## SINGLE REQUIRED ACTION: Write verdict.json — no other file changes allowed\n\n"
+        f"{UNTRUSTED_PREAMBLE}\n\n"
+        "This PR touches guardrail-surface paths and is adjudicated by a cross-family "
+        "review council (COUNCIL_VERDICT.md C1) instead of a single self-review — "
+        "unanimous LGTM across all available seats is required to merge; any CONCERNS "
+        "blocks the merge and feeds the existing auto-fix ladder.\n\n"
+        f"Guardrail paths touched: {', '.join(sorted(guardrail_hits)[:10])}\n\n"
+        "Review the following pull-request diff for correctness, style, and spec compliance.\n\n"
+        f"PR #{pr_number} title: {fence('pr-title', title, nonce)}\n\n"
+        f"{fence('pr-diff', diff_excerpt, nonce)}"
+        f"{spec_section}"
+        f"{custodian_section}\n\n"
+        f"**Review checklist** — report a status for each:\n"
+        f"1. spec_compliance: if a campaign spec is provided above, the diff implements EXACTLY what\n"
+        f"   it requires — correct filenames, member names, member count, exports, tests, version bumps.\n"
+        f"2. custodian_findings: if Custodian findings are listed above, each is resolved by the diff.\n"
+        f"3. code_quality: correctness, style, potential bugs.\n"
+        f"4. no_tooling_artifacts: no .baseline-validation.json, run-status.md, etc. in the diff.\n\n"
+        f"{verdict_schema_prompt()}"
+    )
+    tail = (
+        "\n\nCRITICAL: Do NOT modify any source files in the repository. "
+        "Do NOT run tests, build, or push. "
+        "Your ONLY permitted action is writing verdict.json to the current directory."
+    )
+
+    member_results: list[dict] = []
+    try:
+        for backend, model, lens in available:
+            member_goal_text = base_goal_text + council_lens_fragment(lens) + tail
+            member_state_key = f"{state_key}-council-{backend}-{model}"
+            verdict = _run_member_review(
+                oc_root, member_goal_text, member_state_key, backend=backend, model=model
+            )
+            if verdict is None:
+                verdict = {
+                    "result": CONCERNS,
+                    "failing_checks": ["no_verdict"],
+                    "summary": f"{backend}/{model} produced no parseable verdict",
+                }
+            member_results.append({**verdict, "backend": backend, "model": model, "lens": lens})
+    except OCSourceTreeUncleanError as exc:
+        state["env_unclean_passes"] = state.get("env_unclean_passes", 0) + 1
+        logger.error(
+            "pr_review_watcher: PR #%d council review SKIPPED (not budget-charged) — %s "
+            "(env_unclean_pass=%d/%d)",
+            pr_number,
+            exc,
+            state["env_unclean_passes"],
+            settings.reviewer.max_self_review_loops,
+        )
+        if state["env_unclean_passes"] >= settings.reviewer.max_self_review_loops:
+            _escalate_needs_human(
+                state,
+                state_path,
+                gh_client,
+                owner,
+                repo,
+                settings,
+                reason="oc_source_tree_unclean",
+                detail=str(exc),
+                current_head_sha=current_head_sha,
+            )
+            state["env_unclean_passes"] = 0
+        _save_state(state_path, state)
+        return
+    except ReviewerBackendError as exc:
+        state["backend_error_passes"] = state.get("backend_error_passes", 0) + 1
+        logger.warning(
+            "pr_review_watcher: PR #%d council review SKIPPED (not budget-charged) — "
+            "backend error: %s (backend_error_pass=%d/%d)",
+            pr_number,
+            exc,
+            state["backend_error_passes"],
+            settings.reviewer.max_self_review_loops,
+        )
+        if state["backend_error_passes"] >= settings.reviewer.max_self_review_loops:
+            _escalate_needs_human(
+                state,
+                state_path,
+                gh_client,
+                owner,
+                repo,
+                settings,
+                reason="reviewer_backend_unavailable",
+                detail=str(exc),
+                current_head_sha=current_head_sha,
+            )
+            state["backend_error_passes"] = 0
+        _save_state(state_path, state)
+        return
+
+    state["env_unclean_passes"] = 0
+    state["backend_error_passes"] = 0
+    aggregate = aggregate_council(member_results)
+
+    # F14 — record the audit trail: per-member backend/model/lens/verdict, the
+    # aggregate, and the degraded-quorum flag. A pure audit artifact, separate
+    # from the review state machine's own bookkeeping (_STATE_SUBDIR).
+    _save_state(
+        _council_state_path(oc_root, repo_key, pr_number),
+        {
+            "pr_number": pr_number,
+            "repo_key": repo_key,
+            "head_sha": current_head_sha,
+            "panel_size": len(_COUNCIL_PANEL),
+            "available_members": len(available),
+            "degraded_quorum": degraded_quorum,
+            "guardrail_hits": sorted(guardrail_hits),
+            "result": aggregate["result"],
+            "per_member": aggregate["per_member"],
+            "summary": aggregate["summary"],
+        },
+    )
+
+    # One PR comment summarizing every seat, attributed by backend/model/lens.
+    member_lines = [
+        f"- `{m['backend']}/{m['model']}` ({m['lens']}): **{m['result']}**"
+        + (f" — {', '.join(m['failing_checks'])}" if m.get("failing_checks") else "")
+        for m in aggregate["per_member"]
+    ]
+    degraded_note = (
+        f"\n\n_Degraded quorum: {len(available)}/{len(_COUNCIL_PANEL)} seats available._"
+        if degraded_quorum
+        else ""
+    )
+    comment_body = (
+        f"{settings.reviewer.bot_comment_marker}\n"
+        f"**Council review: {aggregate['result']}** (cross-family panel, "
+        f"guardrail paths: {', '.join(sorted(guardrail_hits)[:10])})\n\n"
+        + "\n".join(member_lines)
+        + degraded_note
+        + f"\n\n{sanitize_for_comment(aggregate['summary'])}"
+    )
+    try:
+        gh_client.post_comment(owner, repo, pr_number, comment_body)
+    except Exception as exc:  # noqa: BLE001 — a comment failure must not block the merge decision
+        logger.warning(
+            "pr_review_watcher: failed to post council verdict comment PR #%d — %s", pr_number, exc
+        )
+
+    _dispatch_verdict_outcome(
+        state,
+        state_path,
+        pr_data,
+        gh_client,
+        owner,
+        repo,
+        oc_root,
+        config_path,
+        settings,
+        result=aggregate["result"],
+        failing_checks=aggregate["failing_checks"],
+        summary=aggregate["summary"],
+        current_head_sha=current_head_sha,
+        diff=diff,
+    )
 
 
 # ── Plane task lookup ─────────────────────────────────────────────────────────

--- a/src/operations_center/entrypoints/pr_review_watcher/verdict.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/verdict.py
@@ -18,6 +18,7 @@ missing, unknown, or malformed computes to CONCERNS — never an auto-LGTM.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -187,14 +188,168 @@ def verdict_schema_prompt() -> str:
     return "\n".join(lines)
 
 
+# ── C1 council mode (COUNCIL_VERDICT.md G1/C1) ────────────────────────────────
+#
+# A guardrail-path PR is adjudicated by a K=3 cross-family panel instead of the
+# single self-review. Each member runs a different backend/model with a distinct
+# review LENS so the panel's diversity comes from independent training + focus,
+# not just sampling noise (per COUNCIL_VERDICT.md "Why cross-family, not seeds").
+# The heavy logic lives here (pure, unit-tested) rather than in main.py.
+
+# Review lens prompt fragments — appended after ``verdict_schema_prompt()`` so
+# each member weights the SAME typed checklist through a different focus. They
+# steer emphasis only; the merge decision is still code-computed per member.
+LENS_CORRECTNESS = (
+    "\n\n## Your review lens: CORRECTNESS\n"
+    "You are the correctness reviewer on a cross-family council. Weigh logic errors, "
+    "broken invariants, off-by-one/edge-case bugs, and whether the change does what it "
+    "claims. Report the shared typed checks above through this lens."
+)
+LENS_SECURITY_CAPABILITY = (
+    "\n\n## Your review lens: SECURITY / CAPABILITY-CHANGE\n"
+    "You are the security & capability-change reviewer on a cross-family council. Weigh "
+    "whether this diff widens a trust boundary, weakens a guardrail/gate, grants or "
+    "un-sandboxes a capability, or could be an injected change to control-plane code. "
+    "Report the shared typed checks above through this lens."
+)
+LENS_CONVERGENCE_OPERATIONAL = (
+    "\n\n## Your review lens: CONVERGENCE / OPERATIONAL\n"
+    "You are the convergence & operational reviewer on a cross-family council. Weigh "
+    "whether this change keeps the fleet able to judge/fix/merge itself (no bootstrap "
+    "deadlock, no hard halt), and its operational blast radius. Report the shared typed "
+    "checks above through this lens."
+)
+
+_LENS_FRAGMENTS: dict[str, str] = {
+    "correctness": LENS_CORRECTNESS,
+    "security-capability": LENS_SECURITY_CAPABILITY,
+    "convergence-operational": LENS_CONVERGENCE_OPERATIONAL,
+}
+
+# The panel: one member per backend-family rung, each with a distinct lens. Each
+# entry is (worker_backend, model, lens). ``model`` is the CLI --model alias
+# (claude) / the codex model tag — main.py maps these to argv.
+_COUNCIL_PANEL: tuple[tuple[str, str, str], ...] = (
+    ("claude_code", "sonnet", "correctness"),
+    ("claude_code", "opus", "security-capability"),
+    ("codex_cli", "codex", "convergence-operational"),
+)
+
+
+def council_lens_fragment(lens: str) -> str:
+    """Return the prompt fragment for a council member's review lens (or '')."""
+    return _LENS_FRAGMENTS.get(lens, "")
+
+
+def _member_label(member: dict) -> str:
+    """A short, attributable label for a council member, e.g.
+    ``claude_code/opus (security-capability)``."""
+    backend = member.get("backend") or "?"
+    model = member.get("model") or "?"
+    lens = member.get("lens") or "?"
+    return f"{backend}/{model} ({lens})"
+
+
+def aggregate_council(member_results: list[dict]) -> dict:
+    """Aggregate per-member verdicts into a single council verdict.
+
+    Each ``member_results`` entry is one member's ``compute_verdict`` output
+    (``{"result", "failing_checks", "summary"}``) plus ``{backend, model, lens}``
+    metadata. UNANIMOUS LGTM ⇒ ``{"result": "LGTM", ...}``. Any member CONCERNS ⇒
+    ``{"result": "CONCERNS", "failing_checks": <union>, "summary": <merged +
+    attributed>, ...}``. Both cases include ``per_member`` for the audit record.
+
+    Fail-safe: an empty panel is CONCERNS (a council never merges on zero members;
+    the caller enforces the quorum floor, this is defense in depth).
+    """
+    per_member: list[dict] = []
+    union_failing: list[str] = []
+    concern_lines: list[str] = []
+    all_lgtm = bool(member_results)  # empty ⇒ not-LGTM (fail-safe)
+
+    for m in member_results:
+        result = str(m.get("result") or CONCERNS).upper()
+        failing = [str(f) for f in (m.get("failing_checks") or [])]
+        summary = str(m.get("summary") or "")
+        per_member.append(
+            {
+                "backend": m.get("backend"),
+                "model": m.get("model"),
+                "lens": m.get("lens"),
+                "result": result,
+                "failing_checks": failing,
+                "summary": summary,
+            }
+        )
+        if result != LGTM:
+            all_lgtm = False
+            for f in failing:
+                if f not in union_failing:
+                    union_failing.append(f)
+            detail = ", ".join(failing) if failing else (summary or "CONCERNS")
+            concern_lines.append(f"- {_member_label(m)}: {detail}")
+
+    if all_lgtm:
+        approvers = ", ".join(_member_label(m) for m in member_results)
+        return {
+            "result": LGTM,
+            "failing_checks": [],
+            "summary": f"Council unanimous LGTM ({approvers}).",
+            "per_member": per_member,
+        }
+    merged = "Council concerns (attributed by member):\n" + "\n".join(concern_lines)
+    return {
+        "result": CONCERNS,
+        "failing_checks": union_failing,
+        "summary": merged,
+        "per_member": per_member,
+    }
+
+
+def last_json_object(text: object) -> dict | None:
+    """Return the last top-level JSON object decodable from ``text``, else None.
+
+    Robustness for the codex member's verdict: codex may not honor the
+    ``verdict.json`` file-write contract, but it prints its answer to stdout. We
+    scan for the last balanced ``{...}`` that parses as a JSON object so a
+    verdict on stdout is still usable without a live spike to pin codex's exact
+    file behavior. Non-string / no-object input ⇒ None (fail-safe → CONCERNS).
+    """
+    if not isinstance(text, str) or "{" not in text:
+        return None
+    decoder = json.JSONDecoder()
+    best: dict | None = None
+    idx = 0
+    while True:
+        start = text.find("{", idx)
+        if start == -1:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, start)
+        except ValueError:
+            idx = start + 1
+            continue
+        if isinstance(obj, dict):
+            best = obj
+        idx = end
+    return best
+
+
 __all__ = [
     "CONCERNS",
+    "LENS_CONVERGENCE_OPERATIONAL",
+    "LENS_CORRECTNESS",
+    "LENS_SECURITY_CAPABILITY",
     "LGTM",
     "REVIEW_CHECKS",
     "ReviewCheck",
     "VALID_STATUS",
+    "_COUNCIL_PANEL",
+    "aggregate_council",
     "compute_verdict",
+    "council_lens_fragment",
     "failing_summary",
+    "last_json_object",
     "sensitive_paths_in_diff",
     "verdict_schema_prompt",
 ]

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -3531,3 +3531,469 @@ def test_select_review_backend_respects_dynamic_disabled(monkeypatch, tmp_path):
     sel = watcher._select_review_backend(_ladder_settings(dynamic=False), usage_store=store, now=now)
     # operator opted out of the ladder globally → always the preferred backend
     assert sel is not None and sel.selected_backend == "claude_code"
+
+
+# ── C1: reviewer council mode (cross-family panel) ────────────────────────────
+
+_GUARDRAIL_FILE = "src/operations_center/entrypoints/pr_review_watcher/main.py"
+_GUARDRAIL_DIFF = f"diff --git a/{_GUARDRAIL_FILE} b/{_GUARDRAIL_FILE}\n+print('x')"
+
+
+def _council_settings(
+    *,
+    guardrail_paths=(_GUARDRAIL_FILE,),
+    max_council_park_hours: int = 24,
+    min_council_members: int = 3,
+) -> MagicMock:
+    from operations_center.config.settings import CouncilSettings
+
+    reviewer = MagicMock(
+        bot_logins=[],
+        allowed_reviewer_logins=[],
+        max_self_review_loops=2,
+        max_fix_attempts=2,
+        max_fix_strategy_level=2,
+        bot_comment_marker="<!-- operations-center:bot -->",
+        require_branch_protection=False,
+        council=CouncilSettings(
+            guardrail_paths=list(guardrail_paths),
+            max_council_park_hours=max_council_park_hours,
+            min_council_members=min_council_members,
+        ),
+    )
+    return MagicMock(
+        reviewer=reviewer,
+        repos={},
+        plane=MagicMock(base_url="http://plane.local", project_id="proj", workspace_slug="ws"),
+    )
+
+
+def _contributor_pr_data(*, head_ref: str = "contributor-branch", head_sha: str = "cc1") -> dict:
+    return {
+        "number": PR_NUMBER,
+        "title": "touches guardrail code",
+        "draft": False,
+        "head": {"ref": head_ref, "sha": head_sha},
+    }
+
+
+def _guardrail_gh(**overrides) -> MagicMock:
+    gh = _make_gh(**overrides)
+    gh.get_pr_diff.return_value = _GUARDRAIL_DIFF
+    return gh
+
+
+def _member_result(result: str, failing=None, summary: str = "ok") -> dict:
+    return {"result": result, "failing_checks": failing or [], "summary": summary}
+
+
+def test_phase1_guardrail_paths_empty_uses_single_review_no_fork(tmp_path: Path) -> None:
+    """Default (empty) guardrail_paths ⇒ feature OFF ⇒ today's single review,
+    even on a diff that touches what would otherwise be a guardrail path."""
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+
+    with (
+        patch.object(watcher, "_run_council") as mock_council,
+        patch.object(
+            watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+        ) as mock_direct,
+    ):
+        watcher._phase1(
+            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+        )
+
+    mock_council.assert_not_called()
+    mock_direct.assert_called_once()
+
+
+def test_phase1_guardrail_hit_forks_to_council(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with (
+        patch.object(watcher, "_run_council") as mock_council,
+        patch.object(watcher, "_run_direct_review") as mock_direct,
+    ):
+        watcher._phase1(
+            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    mock_council.assert_called_once()
+    mock_direct.assert_not_called()
+    # guardrail_hits propagated to the council call
+    assert watcher._files_from_diff(_GUARDRAIL_DIFF) == [_GUARDRAIL_FILE]
+
+
+def test_council_exempt_self_fix_uses_single_review(tmp_path: Path) -> None:
+    """F14 bootstrap-deadlock guard: the reviewer's OWN fix-pass branch
+    (``review/…``) touching guardrail paths falls back to single review so the
+    reviewer's self-heal is never gated by the council it may be fixing."""
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with (
+        patch.object(watcher, "_run_council") as mock_council,
+        patch.object(
+            watcher, "_run_direct_review", return_value={"result": "LGTM", "summary": "ok"}
+        ) as mock_direct,
+    ):
+        watcher._phase1(
+            state,
+            sp,
+            _contributor_pr_data(head_ref=f"review/{PR_NUMBER}"),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            settings,
+        )
+
+    mock_council.assert_not_called()
+    mock_direct.assert_called_once()
+
+
+def test_council_reviews_fleet_goal_branch_guardrail_pr(tmp_path: Path) -> None:
+    """The council's PRIMARY threat: a fleet-authored goal/ PR that touches a
+    guardrail surface MUST get the council, NOT a single-reviewer LGTM (that is
+    exactly the "fleet quietly merges a guardrail change" row of the threat
+    table). Only review/ fix-pass branches are exempt — goal/ is not."""
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with (
+        patch.object(watcher, "_run_council") as mock_council,
+        patch.object(watcher, "_run_direct_review") as mock_direct,
+    ):
+        watcher._phase1(
+            state,
+            sp,
+            _contributor_pr_data(head_ref=f"goal/{PR_NUMBER}"),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            settings,
+        )
+
+    mock_council.assert_called_once()
+    mock_direct.assert_not_called()
+
+
+class TestCouncilExemptSelfFix:
+    def test_reviewer_review_branch_is_exempt(self):
+        pr = _contributor_pr_data(head_ref="review/42")
+        assert watcher._council_exempt_self_fix({}, pr) is True
+
+    def test_fleet_feature_branches_are_NOT_exempt(self):
+        # These reach the council — the whole point of the control.
+        for prefix in ("goal/", "test/", "improve/", "spec-author/"):
+            pr = _contributor_pr_data(head_ref=f"{prefix}42")
+            assert watcher._council_exempt_self_fix({}, pr) is False
+
+    def test_contributor_branch_is_not_exempt(self):
+        pr = _contributor_pr_data(head_ref="fix-typo")
+        assert watcher._council_exempt_self_fix({}, pr) is False
+
+    def test_missing_head_ref_is_not_exempt(self):
+        assert watcher._council_exempt_self_fix({}, {"head": {}}) is False
+
+
+def _run_council_args(
+    tmp_path: Path,
+    state: dict,
+    sp: Path,
+    pr_data: dict,
+    gh: MagicMock,
+    settings: MagicMock,
+    *,
+    guardrail_hits=(_GUARDRAIL_FILE,),
+) -> dict:
+    return dict(
+        state=state,
+        state_path=sp,
+        pr_data=pr_data,
+        gh_client=gh,
+        owner="owner",
+        repo="repo",
+        oc_root=tmp_path,
+        config_path=tmp_path / "cfg.yaml",
+        settings=settings,
+        current_head_sha="cc1",
+        diff=_GUARDRAIL_DIFF,
+        diff_excerpt=_GUARDRAIL_DIFF,
+        title="touches guardrail code",
+        spec_section="",
+        custodian_section="",
+        guardrail_hits=list(guardrail_hits),
+        nonce="test-nonce",
+    )
+
+
+def test_run_council_unanimous_lgtm_merges(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with (
+        patch.object(watcher, "_member_on_cooldown", return_value=False),
+        patch.object(
+            watcher, "_run_member_review", return_value=_member_result("LGTM")
+        ) as mock_member,
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+    ):
+        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+
+    assert mock_member.call_count == 3
+    mock_merge.assert_called_once()
+    assert mock_merge.call_args.kwargs["reason"] == "self_review_lgtm"
+    # status published exactly once, on the aggregate — not per member
+    gh.set_commit_status.assert_called_once()
+    assert gh.set_commit_status.call_args.kwargs["state"] == "success"
+
+
+def test_run_council_any_concern_feeds_fix_ladder(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    def _member_side_effect(oc_root, goal_text, state_key, *, backend, model):
+        if backend == "claude_code" and model == "opus":
+            return _member_result("CONCERNS", failing=["code_quality"], summary="bug found")
+        return _member_result("LGTM")
+
+    with (
+        patch.object(watcher, "_member_on_cooldown", return_value=False),
+        patch.object(watcher, "_run_member_review", side_effect=_member_side_effect),
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+        patch.object(watcher, "_run_fix_pass", return_value=True) as mock_fix,
+    ):
+        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+
+    mock_merge.assert_not_called()
+    mock_fix.assert_called_once()
+    gh.set_commit_status.assert_called_once()
+    assert gh.set_commit_status.call_args.kwargs["state"] == "failure"
+
+
+def test_run_council_records_state_and_posts_one_comment(tmp_path: Path) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with (
+        patch.object(watcher, "_member_on_cooldown", return_value=False),
+        patch.object(watcher, "_run_member_review", return_value=_member_result("LGTM")),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+
+    gh.post_comment.assert_called_once()
+    body = gh.post_comment.call_args[0][3]
+    assert "<!-- operations-center:bot -->" in body
+    assert "claude_code/sonnet" in body
+    assert "claude_code/opus" in body
+    assert "codex_cli/codex" in body
+
+    council_path = watcher._council_state_path(tmp_path, REPO_KEY, PR_NUMBER)
+    assert council_path.exists()
+    recorded = json.loads(council_path.read_text(encoding="utf-8"))
+    assert recorded["result"] == "LGTM"
+    assert len(recorded["per_member"]) == 3
+    assert recorded["degraded_quorum"] is False
+
+
+def test_run_council_each_member_dispatched_on_its_own_family(tmp_path: Path, monkeypatch) -> None:
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+    argvs: list[list[str]] = []
+
+    def _fake_run(cmd, cwd, capture_output, text, timeout):
+        import subprocess as _sp
+
+        argvs.append(cmd)
+        (Path(cwd) / "verdict.json").write_text(
+            json.dumps(
+                {
+                    "checks": [
+                        {"check_id": "code_quality", "status": "pass", "evidence_span": "x"},
+                        {"check_id": "no_tooling_artifacts", "status": "pass", "evidence_span": "x"},
+                    ],
+                    "summary": "ok",
+                }
+            ),
+            encoding="utf-8",
+        )
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch.object(watcher, "_member_on_cooldown", return_value=False),
+        patch.object(watcher, "_oc_source_conflict_markers", return_value=[]),
+        patch(
+            "operations_center.entrypoints.pr_review_watcher.main.subprocess.run",
+            side_effect=_fake_run,
+        ),
+        patch.object(watcher, "_merge_and_done"),
+    ):
+        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+
+    assert len(argvs) == 3
+    sonnet_calls = [a for a in argvs if "--model" in a and a[a.index("--model") + 1] == "sonnet"]
+    opus_calls = [a for a in argvs if "--model" in a and a[a.index("--model") + 1] == "opus"]
+    codex_calls = [a for a in argvs if a[:2] == ["codex", "exec"]]
+    assert len(sonnet_calls) == 1
+    assert len(opus_calls) == 1
+    assert len(codex_calls) == 1
+
+
+def test_run_council_quorum_unmet_parks(tmp_path: Path, monkeypatch) -> None:
+    """Both claude_code seats cooled (session_5h, account-wide) leaves only
+    codex — 1 < min_council_members(3) — parks instead of burning cooled
+    backends or silently downgrading to a lesser quorum."""
+    from datetime import datetime, timezone
+
+    from operations_center.execution.usage_store import UsageStore
+
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "u.json"))
+    now = datetime.now(timezone.utc)
+    store = UsageStore()
+    _cool_claude(store, now)
+
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings()
+
+    with patch.object(watcher, "_run_member_review") as mock_member:
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings),
+            usage_store=store,
+        )
+
+    mock_member.assert_not_called()
+    assert state["escalated_needs_human"] is True
+    assert state["escalated_reason"] == "reviewer_backend_unavailable"
+    assert state["council_park"] is True
+    assert state["council_available_members"] == 1
+
+
+def test_phase1_council_park_within_cap_still_auto_resumes(tmp_path: Path) -> None:
+    """A council park that has NOT yet exceeded max_council_park_hours behaves
+    like any other backend-unavailable park: the generic 1h resume window
+    still applies (F14 only changes behavior once the cap is exceeded)."""
+    from datetime import timedelta
+
+    from datetime import datetime as dt
+    from datetime import UTC as _UTC
+
+    settings = _council_settings(max_council_park_hours=24)
+    now = dt.now(_UTC)
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_reason="reviewer_backend_unavailable",
+        escalated_at_utc=(now - timedelta(hours=2)).isoformat(),  # past the 1h resume window
+        escalated_head_sha="cc1",
+        council_park=True,
+        council_park_started_at=(now - timedelta(hours=2)).isoformat(),  # well within the 24h cap
+    )
+    # A non-guardrail diff — council is configured, but this PR's diff doesn't
+    # hit it, so once resumed it falls through to the ordinary single-review
+    # path (mocked below) rather than a real council dispatch. The resume
+    # mechanism under test lives entirely in the #446-style block, before the
+    # guardrail fork is even reached.
+    gh = _make_gh()
+
+    with patch.object(watcher, "_run_direct_review", return_value=None) as mock_direct:
+        watcher._phase1(
+            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    assert state["escalated_needs_human"] is False
+    assert "council_park" not in state
+    mock_direct.assert_called_once()  # resumed all the way to a real review pass
+
+
+def test_phase1_council_park_cap_escalates_distinctly(tmp_path: Path) -> None:
+    """F14 park-cap: once a council park outlasts max_council_park_hours, stop
+    silently auto-resuming/re-parking and surface a distinct reason instead."""
+    from datetime import timedelta
+
+    from datetime import datetime as dt
+    from datetime import UTC as _UTC
+
+    settings = _council_settings(max_council_park_hours=24)
+    now = dt.now(_UTC)
+    state, sp = _make_state(
+        tmp_path,
+        phase="self_review",
+        escalated_needs_human=True,
+        escalated_reason="reviewer_backend_unavailable",
+        escalated_at_utc=(now - timedelta(hours=2)).isoformat(),
+        escalated_head_sha="cc1",
+        council_park=True,
+        council_park_started_at=(now - timedelta(hours=25)).isoformat(),  # past the 24h cap
+    )
+    gh = _guardrail_gh()
+
+    with patch.object(watcher, "_run_council") as mock_council:
+        watcher._phase1(
+            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+        )
+
+    mock_council.assert_not_called()  # capped hold — never even reaches the fork this poll
+    assert state["escalated_reason"] == "council_unavailable_capped"
+    assert state["escalated_needs_human"] is True
+    gh.post_comment.assert_called_once()
+    assert "council_unavailable_capped" in gh.post_comment.call_args[0][3]
+
+
+def test_run_council_degraded_quorum_two_of_three_merges_on_unanimity(tmp_path: Path, monkeypatch) -> None:
+    """F14 degraded quorum: with min_council_members=2, one cooled seat still
+    allows the other two to proceed — unanimity among the AVAILABLE members
+    merges, and the state/comment record the degraded flag."""
+    from datetime import datetime, timezone
+
+    from operations_center.execution.usage_store import UsageStore
+
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "u.json"))
+    now = datetime.now(timezone.utc)
+    store = UsageStore()
+    from datetime import timedelta
+
+    store.record_worker_backend_cooldown(
+        worker_backend="codex_cli",
+        reset_at=now + timedelta(hours=2),
+        now=now,
+        limit_kind="session_5h",
+        model=None,
+    )
+
+    state, sp = _make_state(tmp_path, phase="self_review")
+    gh = _guardrail_gh()
+    settings = _council_settings(min_council_members=2)
+
+    with (
+        patch.object(
+            watcher, "_run_member_review", return_value=_member_result("LGTM")
+        ) as mock_member,
+        patch.object(watcher, "_merge_and_done") as mock_merge,
+    ):
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings),
+            usage_store=store,
+        )
+
+    assert mock_member.call_count == 2  # codex skipped — cooled
+    mock_merge.assert_called_once()
+
+    council_path = watcher._council_state_path(tmp_path, REPO_KEY, PR_NUMBER)
+    recorded = json.loads(council_path.read_text(encoding="utf-8"))
+    assert recorded["degraded_quorum"] is True
+    assert recorded["available_members"] == 2

--- a/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
+++ b/tests/unit/entrypoints/pr_review_watcher/test_verdict.py
@@ -10,11 +10,15 @@ malformed / unknown inputs fail safe to CONCERNS, never an auto-LGTM.
 from __future__ import annotations
 
 from operations_center.entrypoints.pr_review_watcher.verdict import (
-    failing_summary,
+    _COUNCIL_PANEL,
     CONCERNS,
     LGTM,
     REVIEW_CHECKS,
+    aggregate_council,
     compute_verdict,
+    council_lens_fragment,
+    failing_summary,
+    last_json_object,
     sensitive_paths_in_diff,
     verdict_schema_prompt,
 )
@@ -156,3 +160,97 @@ class TestSensitivePathsInDiff:
         # A malformed file list must never crash the merge gate.
         assert sensitive_paths_in_diff(None, ["*.env"]) == []
         assert sensitive_paths_in_diff(["keep", 5, None], ["*"]) == ["keep"]
+
+
+# ── C1 council mode (COUNCIL_VERDICT.md G1/C1) ────────────────────────────────
+
+
+def _member(backend: str, model: str, lens: str, result: str, failing=None, summary="") -> dict:
+    return {
+        "backend": backend,
+        "model": model,
+        "lens": lens,
+        "result": result,
+        "failing_checks": failing or [],
+        "summary": summary,
+    }
+
+
+class TestAggregateCouncil:
+    def test_unanimous_lgtm(self):
+        members = [_member(b, m, lens, LGTM) for (b, m, lens) in _COUNCIL_PANEL]
+        out = aggregate_council(members)
+        assert out["result"] == LGTM
+        assert out["failing_checks"] == []
+        assert len(out["per_member"]) == 3
+        assert "unanimous" in out["summary"].lower()
+
+    def test_any_concern_forces_concerns_and_unions_failing_checks(self):
+        members = [
+            _member("claude_code", "sonnet", "correctness", LGTM),
+            _member(
+                "claude_code",
+                "opus",
+                "security-capability",
+                CONCERNS,
+                failing=["code_quality"],
+            ),
+            _member(
+                "codex_cli",
+                "codex",
+                "convergence-operational",
+                CONCERNS,
+                failing=["code_quality", "no_tooling_artifacts"],
+            ),
+        ]
+        out = aggregate_council(members)
+        assert out["result"] == CONCERNS
+        assert set(out["failing_checks"]) == {"code_quality", "no_tooling_artifacts"}
+        # Attributed — each dissenting member's label appears in the summary.
+        assert "claude_code/opus" in out["summary"]
+        assert "codex_cli/codex" in out["summary"]
+
+    def test_empty_panel_is_concerns_fail_safe(self):
+        out = aggregate_council([])
+        assert out["result"] == CONCERNS
+        assert out["per_member"] == []
+
+    def test_malformed_member_result_defaults_to_concerns(self):
+        # A member missing/garbling its "result" must never read as LGTM.
+        out = aggregate_council([{"backend": "claude_code", "model": "sonnet", "lens": "x"}])
+        assert out["result"] == CONCERNS
+
+    def test_result_is_case_normalized(self):
+        members = [_member(b, m, lens, "lgtm") for (b, m, lens) in _COUNCIL_PANEL]
+        assert aggregate_council(members)["result"] == LGTM
+
+
+class TestCouncilLensFragment:
+    def test_known_lenses_return_nonempty_distinct_fragments(self):
+        fragments = {lens: council_lens_fragment(lens) for (_b, _m, lens) in _COUNCIL_PANEL}
+        assert all(fragments.values())
+        assert len(set(fragments.values())) == len(fragments)  # each lens is distinct
+
+    def test_unknown_lens_returns_empty_string(self):
+        assert council_lens_fragment("not-a-real-lens") == ""
+
+
+class TestLastJsonObject:
+    def test_parses_trailing_json_object_from_stdout(self):
+        text = 'Here is my review:\n{"checks": [], "summary": "ok"}\n'
+        assert last_json_object(text) == {"checks": [], "summary": "ok"}
+
+    def test_returns_last_object_when_multiple_present(self):
+        text = '{"a": 1}\nsome commentary\n{"b": 2}'
+        assert last_json_object(text) == {"b": 2}
+
+    def test_no_object_returns_none(self):
+        assert last_json_object("no json here at all") is None
+        assert last_json_object("[1, 2, 3]") is None  # a list, not an object
+
+    def test_non_string_input_returns_none(self):
+        assert last_json_object(None) is None
+        assert last_json_object(12345) is None
+
+    def test_malformed_braces_do_not_crash(self):
+        assert last_json_object("{not valid json") is None


### PR DESCRIPTION
## What

Council spec (`docs/design/COUNCIL_VERDICT.md`) **Phase 2 / C1** — keyless change control for guardrail surfaces, the adjudicated-review substitute for the operator's signing key.

A PR whose diff touches any `reviewer.council.guardrail_paths` glob is adjudicated by a **K=3 cross-family panel** instead of the single self-review:

- **Members**: claude/sonnet (correctness lens), claude/opus (security-capability lens), codex/gpt-5 (convergence-operational lens) — diversity from independent training + focus, not sampling noise.
- **Quorum**: **unanimous LGTM** merges. Any CONCERN feeds the existing self-heal fix ladder unchanged. An unmet quorum (a family cooled) **parks fail-closed**, reusing the #446 auto-resume path.
- **Record**: `state/council/<repo>-<pr>.json` + one attributed PR comment; `reviewer-verdict` status set only on quorum.
- **Verdict is still code-computed per member** (INJ boundary intact) — an injected diff can flip a re-checkable enum but cannot author the verdict.

**`guardrail_paths` ships EMPTY ⇒ feature OFF (fail-open to today's single review)** so this rollout PR can't deadlock on the gate it introduces. Populating the §G1 set is a deliberate follow-up PR (which then rides through the council itself).

## How

- Pure logic in `verdict.py` (`aggregate_council`, lens fragments, `_COUNCIL_PANEL`, `last_json_object` codex-stdout fallback) — covered by the `tests/unit` 85% gate. `_run_council` in `main.py` stays thin.
- `_run_direct_review` generalized to `_run_member_review(*, backend, model)`, kept as a **byte-identical alias** for the single path (same `claude --model haiku -p --effort low` argv; only the model varies per seat). Member argv mirrors `worker_backend_probe._probe_command`.
- Per-member **model-aware** cooldown (`_member_on_cooldown`) — sonnet vs opus are both `claude_code`, so the backend-grained selector can't distinguish them.
- Both single + council paths share a new `_dispatch_verdict_outcome` tail.

## F14 mitigations (deadlock avoidance)

- **Park-cap**: a council park outlasting `max_council_park_hours` escalates a distinct `council_unavailable_capped` reason to the operator instead of re-parking forever.
- **Degraded quorum**: `min_council_members` lets the panel proceed with unanimity among available families.
- **Narrow self-fix exemption**: only the reviewer's own `review/` fix branches fall back to single review. Fleet `goal/` PRs touching guardrails **DO** get the council — that is the control's primary threat (fleet quietly merges a guardrail change on a single LGTM). Widening this is an explicit operator trust-model decision, flagged in-code.

## Doc

`HARNESS_TRUST_HARDENING.md` §0.1 no longer overclaims the council as live — it now states the engine shipped under C1 but `guardrail_paths` is empty so the gate isn't live yet.

## Tests

166 reviewer tests (`tests/test_pr_review_watcher.py`, +16) incl. fork/unanimous-merge/concern-ladder/cooldown-park/per-family-dispatch/state+comment and all three F14 mitigations; 29 `verdict.py` unit tests. `tests/unit` full suite 8468 pass at **85.95%** (gate 85%). ruff clean.

## Follow-ups (not this PR)

- Populate `guardrail_paths` with the §G1 set (the council's first live case).
- Live-validate the codex member writes a schema-conformant verdict (the `last_json_object` stdout fallback de-risks this; mirrors open D1-pt2).
- C3 (EVAL cross-family panel) reuses this plumbing.

Council spec Phase 2 (C1). Depends conceptually on C2 (ContextLifecycle #43, keyless launch-time anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)