### PR TITLE
fix(OperationsCenter): print per-repo progress in custodian-sweep

### DIFF
--- a/src/operations_center/entrypoints/custodian_sweep/main.py
+++ b/src/operations_center/entrypoints/custodian_sweep/main.py
@@ -29,10 +29,10 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -135,10 +135,28 @@ def _run_custodian_audit(target: _RepoTarget, *, timeout_seconds: int) -> _RepoS
 def _run_custodian_audits(
     targets: list[_RepoTarget], *, jobs: int, timeout_seconds: int
 ) -> list[_RepoSweep]:
-    """Run repo audits with bounded parallelism while preserving target order."""
+    """Run repo audits with bounded parallelism while preserving target order.
+
+    Prints one flushed progress line per completed repo to stderr — the sweep
+    can legitimately take minutes across many repos, and without interim
+    output a bounded probe (e.g. a `timeout 90` health check) is
+    indistinguishable from a genuine hang.
+    """
     if not targets:
         return []
-    runner = partial(_run_custodian_audit, timeout_seconds=timeout_seconds)
+    total = len(targets)
+    done_count = 0
+    lock = threading.Lock()
+
+    def runner(target: _RepoTarget) -> _RepoSweep:
+        nonlocal done_count
+        result = _run_custodian_audit(target, timeout_seconds=timeout_seconds)
+        with lock:
+            done_count += 1
+            n = done_count
+        print(f"[custodian-sweep] {n}/{total} {target.repo_key} done", file=sys.stderr, flush=True)
+        return result
+
     max_workers = max(1, min(jobs, len(targets)))
     if max_workers == 1:
         return [runner(target) for target in targets]

--- a/tests/test_custodian_sweep.py
+++ b/tests/test_custodian_sweep.py
@@ -258,6 +258,23 @@ def test_run_custodian_audits_falls_back_to_serial_when_jobs_is_one(monkeypatch)
     assert [sweep.repo_key for sweep in sweeps] == ["A", "B"]
 
 
+def test_run_custodian_audits_prints_progress_per_repo(monkeypatch, capsys) -> None:
+    targets = [_RepoTarget("A", Path("/tmp/a")), _RepoTarget("B", Path("/tmp/b"))]
+
+    monkeypatch.setattr(
+        sweep_module,
+        "_run_custodian_audit",
+        lambda target, *, timeout_seconds: _RepoSweep(repo_key=target.repo_key),
+    )
+
+    sweeps = _run_custodian_audits(targets, jobs=1, timeout_seconds=20)
+
+    assert [sweep.repo_key for sweep in sweeps] == ["A", "B"]
+    err = capsys.readouterr().err
+    assert "1/2 A done" in err
+    assert "2/2 B done" in err
+
+
 def test_main_uses_safer_default_timeout(monkeypatch, tmp_path: Path, capsys) -> None:
     config_path = tmp_path / "config.yaml"
     config_path.write_text("ignored: true\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- `custodian-sweep --emit` genuinely takes 3-4 minutes across 19 managed repos but printed nothing until the final summary line, making a bounded probe (`timeout 90/120s`) indistinguishable from a hang.
- Multiple recent watchdog cycles (see `logs/local/watchdog_cycles/20260714_cycle.md`, `20260715_cycle.md`) independently re-investigated this same "hang" and confirmed it was always a slow-but-healthy run.
- `_run_custodian_audits` now prints a flushed `[custodian-sweep] N/total <repo> done` progress line to stderr as each repo completes, so future bounded probes show liveness instead of silence.
- No change to the JSON summary output or Plane emit logic.

## Test plan
- [x] `pytest tests/test_custodian_sweep.py -q` — 17/18 pass (pre-existing unrelated failure `test_emit_dry_run_reports_zero_finding_skip`, confirmed present on `main` before this change — two pre-existing tests assert contradictory `_emit` dry-run behavior; left untouched, out of scope)
- [x] Added `test_run_custodian_audits_prints_progress_per_repo` covering the new stderr output
- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/unit/er000_phase0_golden/ -q` — 15/15 pass
- [x] Ran `custodian-sweep --emit` unbounded end-to-end (19 repos, ~3.5 min) — completed cleanly, confirms this was never a real hang