### PR TITLE
feat(reviewer): activate the council — populate guardrail_paths (§G1)

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,24 @@
+## 2026-07-15 — feat(reviewer): ACTIVATE the council — populate guardrail_paths (§G1)
+
+The council's go-live. C1/C2/C3 all merged; `reviewer.council.guardrail_paths`
+shipped EMPTY (OFF) so the rollout couldn't deadlock on its own gate. This is
+the deliberate follow-up that populates it with the COUNCIL_VERDICT.md §G1 set,
+so guardrail-surface PRs (OC control plane: pr_review_watcher/**, loop_bridge/**,
+.hooks/**, scripts/operations-center.sh, .console/workers.yaml+guidelines.md,
+eval/**, oc_session_prompt.txt, operations_center.local.yaml, COUNCIL_VERDICT.md)
+are now adjudicated by the K=3 cross-family panel instead of single self-review.
+Set as the `CouncilSettings.guardrail_paths` DEFAULT (not the untracked live
+local.yaml) so the activation is tracked+reviewable and the running fleet picks
+it up on its next self-update/restart (local.yaml has no council block ⇒ falls
+back to the default). This PR touches only settings.py + example.yaml — neither
+is in §G1 — so it is NOT itself a guardrail PR: it merges via ordinary single
+review, THEN the council is live (chicken-and-egg resolved). Residual (accepted,
+matches §G1): settings.py itself isn't guarded, so emptying the list is single-
+reviewed — guarding it would fire the panel on every unrelated settings edit.
+Both prior operator decisions hold: narrow `review/`-only exemption; codex
+validated live. Pinned by a new default-is-populated test. 166 reviewer + 38
+settings tests green.
+
 ## 2026-07-15 — feat(eval): C3 cross-family EVAL panel — close same-family generator↔evaluator (COUNCIL_VERDICT.md)
 
 Council spec Phase 3 (C3), the last council phase. The guide-gap audit's HIGH

--- a/config/operations_center.example.yaml
+++ b/config/operations_center.example.yaml
@@ -217,23 +217,22 @@ repos:
 #   # K=3 cross-family panel (claude/sonnet, claude/opus, codex) instead of the
 #   # single self-review; unanimous LGTM merges, any CONCERN feeds the existing
 #   # fix ladder, and an unmet quorum parks (fail-closed) rather than merging
-#   # under-reviewed. council.guardrail_paths defaults EMPTY ⇒ feature OFF — the
-#   # rollout PR that introduces the council must not deadlock on the gate it
-#   # introduces. Populating this list is a DELIBERATE FOLLOW-UP PR, not part of
-#   # this one; the commented set below is the COUNCIL_VERDICT.md §G1 candidate
-#   # list, left inactive here on purpose.
+#   # under-reviewed. council.guardrail_paths now DEFAULTS to the §G1 set below
+#   # (the council is LIVE) — you only need this block to OVERRIDE it (e.g. set
+#   # guardrail_paths: [] to disable, or a different set per deployment). The
+#   # default set is shown here for reference:
 #   council:
-#     guardrail_paths: []
-#       # - .console/workers.yaml
-#       # - .console/guidelines.md
-#       # - tools/loop/oc_session_prompt.txt
-#       # - .hooks/**
-#       # - scripts/operations-center.sh
-#       # - eval/**
-#       # - src/operations_center/entrypoints/pr_review_watcher/**  # council guards its own code
-#       # - src/operations_center/entrypoints/loop_bridge/**
-#       # - config/operations_center.local.yaml                     # untracked, but pin anyway
-#       # - docs/design/COUNCIL_VERDICT.md                          # this spec
+#     guardrail_paths:
+#       - .console/workers.yaml
+#       - .console/guidelines.md
+#       - tools/loop/oc_session_prompt.txt
+#       - .hooks/**
+#       - scripts/operations-center.sh
+#       - eval/**
+#       - src/operations_center/entrypoints/pr_review_watcher/**  # council guards its own code
+#       - src/operations_center/entrypoints/loop_bridge/**
+#       - config/operations_center.local.yaml                     # untracked, but pin anyway
+#       - docs/design/COUNCIL_VERDICT.md                          # this spec
 #     # A park that outlasts this many hours is surfaced to the operator with a
 #     # distinct reason (council_unavailable_capped) instead of re-parking forever.
 #     max_council_park_hours: 24

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -294,13 +294,35 @@ class CouncilSettings(BaseModel):
     LGTM merges, any CONCERN feeds the existing fix ladder, and a family on
     cooldown parks the PR (fail-closed) until it recovers.
 
-    ``guardrail_paths`` defaults EMPTY ⇒ the feature is OFF (fail-open to today's
-    single review). Populating the set is a deliberate follow-up PR — the rollout
-    PR that introduces the council must not deadlock on the gate it introduces.
+    ``guardrail_paths`` shipped EMPTY at rollout (feature OFF, fail-open) so the
+    PR that introduced the council could not deadlock on the gate it introduces.
+    It is now POPULATED with the COUNCIL_VERDICT.md §G1 set — the council is LIVE
+    for OC's control-plane surfaces. A deployment can still disable it by setting
+    ``reviewer.council.guardrail_paths: []`` in its config. NOTE: this list's own
+    home (settings.py) is not itself in the set, matching §G1; a change that
+    empties the list is therefore single-reviewed, not council-gated — an
+    accepted residual (guarding settings.py would fire the panel on every
+    unrelated settings edit).
     """
 
-    # Repo-relative globs; empty ⇒ feature OFF (no PR is a guardrail PR).
-    guardrail_paths: list[str] = Field(default_factory=list)
+    # Repo-relative globs; empty ⇒ feature OFF. Populated with COUNCIL_VERDICT.md
+    # §G1 — OC's control-plane guardrail surfaces. Generic entries (.hooks/**,
+    # scripts, .console/*) legitimately match other repos the reviewer sees too;
+    # OC-specific entries simply never match a non-OC diff (fail-open).
+    guardrail_paths: list[str] = Field(
+        default_factory=lambda: [
+            ".console/workers.yaml",
+            ".console/guidelines.md",
+            "tools/loop/oc_session_prompt.txt",
+            ".hooks/**",
+            "scripts/operations-center.sh",
+            "eval/**",
+            "src/operations_center/entrypoints/pr_review_watcher/**",
+            "src/operations_center/entrypoints/loop_bridge/**",
+            "config/operations_center.local.yaml",
+            "docs/design/COUNCIL_VERDICT.md",
+        ]
+    )
     # F14 mitigation — park cap: a council park that outlasts this many hours is
     # surfaced to the operator with a distinct reason instead of re-parking forever.
     max_council_park_hours: int = 24
@@ -384,7 +406,8 @@ class ReviewerSettings(BaseModel):
     # per-correction loop. False (default) preserves prior behavior.
     require_sensitive_path_ack: bool = False
     # C1 — cross-family council for guardrail-surface PRs (COUNCIL_VERDICT.md).
-    # Empty council.guardrail_paths (default) ⇒ feature OFF ⇒ today's single review.
+    # guardrail_paths now defaults to the §G1 set ⇒ the council is LIVE for OC's
+    # control-plane surfaces (set it to [] in config to disable).
     council: CouncilSettings = Field(default_factory=CouncilSettings)
 
 

--- a/tests/unit/config/test_reviewer_defaults.py
+++ b/tests/unit/config/test_reviewer_defaults.py
@@ -13,3 +13,20 @@ from operations_center.config.settings import ReviewerSettings
 
 def test_require_branch_protection_defaults_on():
     assert ReviewerSettings().require_branch_protection is True
+
+
+def test_council_guardrail_paths_populated_by_default():
+    """The council is a security control: guardrail_paths ships POPULATED with
+    the COUNCIL_VERDICT.md §G1 set so cross-family adjudication is LIVE for OC's
+    control-plane surfaces. A regression back to [] would silently disable the
+    gate (fall through to single self-review on guardrail PRs)."""
+    from operations_center.config.settings import CouncilSettings
+
+    paths = CouncilSettings().guardrail_paths
+    assert isinstance(paths, list) and paths, "guardrail_paths must be non-empty (council ON)"
+    # The council must guard its OWN code and the loop bridge (control plane).
+    assert "src/operations_center/entrypoints/pr_review_watcher/**" in paths
+    assert "src/operations_center/entrypoints/loop_bridge/**" in paths
+    # And the operator-authority surfaces.
+    assert ".hooks/**" in paths
+    assert "scripts/operations-center.sh" in paths


### PR DESCRIPTION
## What

**The council's go-live.** C1 (#469), C2 (ContextLifecycle #43), and C3 (#479) all merged with `reviewer.council.guardrail_paths` shipped **empty** (feature OFF) so the rollout couldn't deadlock on its own gate. This is the deliberate follow-up that **populates** it with the `COUNCIL_VERDICT.md` §G1 set.

After this merges + deploys, a PR whose diff touches any OC control-plane surface —
- `.console/workers.yaml`, `.console/guidelines.md`
- `tools/loop/oc_session_prompt.txt`
- `.hooks/**`, `scripts/operations-center.sh`
- `eval/**`
- `src/operations_center/entrypoints/pr_review_watcher/**` (the council guards its own code)
- `src/operations_center/entrypoints/loop_bridge/**`
- `config/operations_center.local.yaml`, `docs/design/COUNCIL_VERDICT.md`

— is adjudicated by the **K=3 cross-family panel** (claude/sonnet + opus + codex, unanimous) instead of the single self-review.

## How / why this shape

- Set as the **`CouncilSettings.guardrail_paths` default** (tracked, reviewable), not the untracked live `operations_center.local.yaml`. local.yaml has no council block, so it falls back to this default — the running fleet activates on its next self-update + restart, with the activation fully captured in git.
- This PR touches only `settings.py` + `operations_center.example.yaml` — **neither is in §G1** — so it is **not itself a guardrail PR**: it merges via ordinary single review, and *then* the council is live (chicken-and-egg resolved).
- Both prior operator decisions hold: the self-fix exemption stays **narrow** (`review/` only — fleet `goal/` guardrail PRs get the full council), and **codex is validated** live as a panel member.

## Residual (accepted, matches §G1)

`settings.py` itself is not in the guardrail set, so a change that *empties* the list is single-reviewed, not council-gated. Guarding it would fire the panel on every unrelated settings edit; §G1 deliberately scopes to control-plane surfaces. Pinned instead by a **default-is-populated test** so an accidental revert to `[]` fails CI.

## Operational note

The council fails **closed** for guardrail PRs when a family is cooled (parks, auto-resumes) — bounded by the park-cap → operator escalation and degraded-quorum floor (F14). So control-plane changes may now wait on backend availability; that is the intended trade for keyless change control (spec C1.4 permits guardrail parks to wait).

## Tests

`tests/unit` full suite **8532 pass at 86.04%** (gate 85%); reviewer suite **166 pass**; settings **38 pass** incl. the new default-populated test; ruff + ty clean.

Completes the council: C1 + C2 + C3 + **activation**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)