### PR TITLE
fix(OperationsCenter): guard every execute backend in ensure_executor_backends

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-08-03 — fix(OperationsCenter): ensure_executor_backends must guard EVERY backend src/ imports
+
+The self-heal in `scripts/operations-center.sh` covered only two of the three
+execute backends. Its guard was `import team_executor, dag_executor` and its
+install loop `for _sib in TeamExecutor DAGExecutor` — but `src/` also imports
+`critique_executor` (`.executor`, `.models`, plus a full adapter at
+`backends/critique_executor/`). A dropped CritiqueExecutor therefore left the
+guard PASSING, so the self-heal never fired and the critique lane stalled with
+exactly the "no obvious cause" symptom the function's own comment warns about
+for its other two backends — the failure mode it exists to prevent, reproduced
+in the one case it didn't cover. Root cause is structural, not a typo: the guard
+enumerates backends independently of what `src/` actually imports, so the two
+drift silently. Fixed by adding `critique_executor` to the guard and
+`CritiqueExecutor` to the loop, and by stating the invariant in the comment
+(the guard must import every backend `src/` imports) so the next backend added
+doesn't repeat it. Verified end-to-end against a live venv: with all three
+present the guard short-circuits (no needless reinstall); after uninstalling
+critique-executor the OLD guard still passes — the bug, reproduced — while the
+new guard fires and restores all three; capabilities plane intact afterward
+(the sibling installs bypass the `[tool.uv]` override pin, so that was checked
+explicitly, not assumed). Also noted, NOT fixed here: `docs/operator/setup.md`
+says setup verifies via `team-executor --help`, but TeamExecutor declares no
+`[project.scripts]` — no such console script exists and OC consumes it purely
+as a library. That doc line is stale.
+
 ## 2026-07-15 — feat(reviewer): ACTIVATE the council — populate guardrail_paths (§G1)
 
 The council's go-live. C1/C2/C3 all merged; `reviewer.council.guardrail_paths`

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -69,22 +69,27 @@ ensure_venv() {
   ensure_executor_backends
 }
 
-# The execute backends (team_executor, dag_executor) are sibling CHECKOUTS, not
-# declared OC dependencies — `uv pip install -e .[dev]` never installs them and a
-# `uv sync` / venv-recreate actively DROPS them. When that happens the executor
+# The execute backends (team_executor, dag_executor, critique_executor) are sibling
+# CHECKOUTS, not declared OC dependencies — `uv pip install -e .[dev]` never installs
+# them and a `uv sync` / venv-recreate actively DROPS them. When that happens the executor
 # can't load its backend ("team_executor not installed: No module named
 # 'team_executor'") and EVERY goal task fails at execute → the whole lane stalls
 # with no obvious cause. Self-heal: whenever the backends aren't importable, (re)install
 # them editable. Runs every launch but the import check is ~free and the install only
 # fires when actually missing, so a mid-life drop recovers on the next fleet start
 # rather than blocking autonomy until a human notices.
+#
+# The guard must import EVERY backend src/ imports. It previously checked only
+# team_executor and dag_executor, so a missing critique_executor left the guard
+# passing, the self-heal never firing, and the critique lane stalling with exactly
+# the no-obvious-cause symptom described above.
 ensure_executor_backends() {
-  if "${VENV_DIR}/bin/python" -c "import team_executor, dag_executor" 2>/dev/null; then
+  if "${VENV_DIR}/bin/python" -c "import team_executor, dag_executor, critique_executor" 2>/dev/null; then
     return 0
   fi
   echo "operations-center.sh: executor backends missing — (re)installing siblings" >&2
   local _sib
-  for _sib in TeamExecutor DAGExecutor; do
+  for _sib in TeamExecutor DAGExecutor CritiqueExecutor; do
     if [[ -f "${ROOT_DIR}/../${_sib}/pyproject.toml" ]]; then
       uv pip install --python "${VENV_DIR}/bin/python" -e "${ROOT_DIR}/../${_sib}" \
         || echo "operations-center.sh: WARNING failed to install ${_sib} — execute backend unavailable" >&2


### PR DESCRIPTION
## Problem

`ensure_executor_backends()` self-heals missing execute backends by reinstalling them editable from sibling checkouts. It covered **two of the three** backends `src/` imports:

```bash
if "${VENV_DIR}/bin/python" -c "import team_executor, dag_executor" 2>/dev/null; then
  return 0
fi
...
for _sib in TeamExecutor DAGExecutor; do
```

But `src/` also imports `critique_executor` — `.executor`, `.models`, plus a full adapter at `src/operations_center/backends/critique_executor/`.

A dropped CritiqueExecutor therefore left the guard **passing**, so the self-heal never fired and the critique lane stalled with exactly the "no obvious cause" symptom the function's own comment warns about for its other two backends. It is the failure mode the function exists to prevent, reproduced in the one case it did not cover.

Root cause is structural rather than a typo: the guard enumerates backends independently of what `src/` actually imports, so the two drift silently.

## Change

- add `critique_executor` to the import guard
- add `CritiqueExecutor` to the reinstall loop
- state the invariant in the comment — *the guard must import every backend `src/` imports* — so the next backend added does not repeat the drift

## Verification

Tested end to end against a live venv:

| Step | Result |
|---|---|
| `bash -n` on the edited script | pass |
| Baseline, all three present | guard short-circuits — no needless reinstall |
| **Old guard** vs missing `critique_executor` | **passes despite the missing backend** — the bug, reproduced |
| New guard, same condition | fires, reinstalls all three siblings |
| After self-heal | `critique_executor` restored |
| Capabilities plane | intact |

That last row matters: sibling installs bypass the `[tool.uv] override-dependencies` pin, so a transitive dep could have regressed `repograph` to the planeless build and silently killed `CapabilityRegistry`. It did not, but it was checked rather than assumed.

Full unit suite green — 8530 passed, 0 failed. The count rose by one against baseline (8529, with skips 5 → 4): a previously-skipped test unlocks once the executor backends are importable. Custodian pre-push gate clean.

## Review note

`scripts/operations-center.sh` is on the council's `guardrail_paths` §G1 set, so this gets the K=3 cross-family panel rather than single self-review. Expected for this file — flagging it so the heavier review on a 15-line diff is not a surprise.

## Related

Independent of, but thematically adjacent to, `fix/executor-install-ref` and ProtocolWarden/TeamExecutor#19, which fix the *other* executor wiring defect (the `team-executor` CLI path). Kept on a separate branch so each is reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
