### PR TITLE
feat(reviewer): seat an all-Opus council, and let members actually write their verdict

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,31 @@
+## 2026-08-13 — fix(reviewer): decouple the D1 fallback pairing from council seating
+
+Caught by rebasing the all-Opus council branch onto main after #486 landed, not
+by CI on the branch — the branch predated #486, so nothing had ever run the two
+together. #486's `_review_model_for_backend` derives the ordinary-review fallback
+model by scanning `_COUNCIL_PANEL` for a matching backend. The all-Opus panel has
+no codex seat, so that lookup returns `None`, and #486's own unit test
+(`assert _review_model_for_backend("codex_cli") == "codex"`, in `tests/unit/`,
+which CI DOES run) fails: `assert None == 'codex'`.
+
+The coupling is the actual defect, not the panel. The panel answers "who
+adjudicates guardrail PRs" — a review-policy choice the operator changes freely.
+`_review_model_for_backend` answers "which model reviews when claude is cooled" —
+a capacity fallback. Deriving the second from the first means reseating the
+council silently disables the fallback: on a host that DOES have codex, every
+claude-cooled ordinary review would park instead of diverting, with no error and
+no failing test to say so. This host has no codex, so the behavior change here is
+nil; the latent trap is what mattered.
+
+Fixed with an explicit `_REVIEW_FALLBACK_MODELS = {"codex_cli": "codex"}` — the
+same pairing D1 validated, now stated directly instead of inferred, so seating
+and fallback vary independently. Added a regression test that asserts the lookup
+still yields codex WHILE the live panel has no codex seat, which is precisely the
+combination that was broken.
+
+Full suite on the rebased branch: 10382 passed, 5 failed — the same 5
+pre-existing sandbox/custodian failures, zero new.
+
 ## 2026-07-17 — feat(reviewer): D1 — run ordinary reviews on codex when claude is cooled
 
 Built the validated follow-up the code itself flagged (self-review sweep defer

--- a/.console/log.md
+++ b/.console/log.md
@@ -83,6 +83,50 @@ Docs: rewrote `docs/operator/setup.md` "Executor Install Behavior" to describe
 the import-based flow, fixed the "install/verify `team-executor` CLI" bullet and
 the Advanced Mode pin description, and corrected the `docs/demo.md` prerequisite
 that told operators to put `team-executor` on PATH.
+## 2026-08-13 — feat(reviewer): all-Opus council (operator decision) — codex seat removed
+
+Operator directive: there is no codex subscription on this host, so the C1
+cross-family panel could never reach quorum — and an unrunnable seat parks every
+guardrail PR fail-closed (`min_council_members: 3`). The council was not weaker
+than designed, it was inert. `_COUNCIL_PANEL` is now three pinned Opus versions
+on `claude_code`: `claude-opus-5` (correctness), `claude-opus-4-8`
+(security/capability), `claude-opus-4-7` (convergence/operational). All four
+current Opus IDs were probed against the live CLI before pinning; all respond.
+
+Versions are pinned, not aliased. `opus` resolves to whatever the CLI calls
+latest, which would silently collapse two seats onto one model and reduce the
+panel to a duplicate vote — a rubber stamp that still reports 3/3.
+
+The seating change alone would have introduced a silent quota bug.
+`_member_on_cooldown` compared the seat's model string to the cooldown record's
+by equality, but the store only ever speaks the limit classifier's four-token
+vocabulary (sonnet/opus/haiku/codex — it is all `detect_model` can parse from a
+CLI limit message). A seat named `claude-opus-5` would therefore match no `opus`
+cooldown: a rate-limited council would report itself fully available and burn
+the quorum dispatching three doomed reviews. Both sides now normalize through
+`detect_model`, which is the identity for bare tokens, so alias-style seats keep
+their existing behavior. Regression test added.
+
+Two consequences are accepted, not fixed, and are recorded in
+`COUNCIL_VERDICT.md` rather than left to be rediscovered:
+
+1. Diversity is now version + lens, NOT family. The same-family
+   generator/evaluator gap C1 exists to close is no longer closed by panel
+   composition — three Opus versions share training lineage and can share a
+   blind spot. Restoring a real second family is the standing fix.
+2. Availability is all-or-nothing. Every seat draws on one subscription and
+   normalizes to one family token, so any claude cooldown — model-scoped,
+   account-wide, or the budget guard's synthetic `budget_reserve` — cools the
+   whole council. The `min_council_members: 2` degraded quorum is now
+   unreachable via the cooldown store; expect whole-council parks where the
+   codex seat used to carry the panel through a claude bucket exhaustion.
+
+Verification: `tests/test_pr_review_watcher.py` + `tests/unit/entrypoints/
+pr_review_watcher/` — 209 passed. Full suite 10347 passed, 5 failed; the same 5
+reproduce with the change stashed (sandbox file-deletion race guards +
+`test_custodian_sweep`), so zero new failures. `ruff check` / `ruff format
+--check` clean on all touched files.
+
 ## 2026-08-03 — fix(hooks): pre-push resolved the wrong workspace root inside a git worktree
 
 `.hooks/pre-push` locates the boundary disclosure artifact by globbing sibling

--- a/.console/log.md
+++ b/.console/log.md
@@ -83,6 +83,48 @@ Docs: rewrote `docs/operator/setup.md` "Executor Install Behavior" to describe
 the import-based flow, fixed the "install/verify `team-executor` CLI" bullet and
 the Advanced Mode pin description, and corrected the `docs/demo.md` prerequisite
 that told operators to put `team-executor` on PATH.
+## 2026-08-13 — fix(reviewer): members could not write verdict.json — every review scored CONCERNS
+
+Found by running the review watcher for real on this host, not by a test. Every
+council member returned `rc=0` with prose like "Wrote verdict.json with all four
+checks", and the reviewer logged `no verdict from member review`. The fail-safe
+turned that into CONCERNS, published a **failing** `reviewer-verdict` status, and
+consumed a fix-ladder attempt — on a PR nothing had actually reviewed. Left
+running it would have walked the whole backlog to `max_fix_attempts` and started
+CLOSING PRs.
+
+Cause: `build_member_argv` ran `claude --model M -p --effort low <prompt>` with
+no permission mode. Probed directly in an empty tmpdir:
+
+    (default mode)              -> "Write permission was denied,
+                                    so `verdict.json` was not created."   rc=0
+    --permission-mode acceptEdits -> "Written."  verdict.json present
+    --dangerously-skip-permissions -> "Written."  verdict.json present
+
+The old comment asserted the flagless form "matches the path that has run in
+production", so the previous host must have carried a permissive user-level
+Claude settings file that masked this. A fresh CLI install does not.
+
+Fixed with `--permission-mode acceptEdits`, deliberately NOT
+`--dangerously-skip-permissions`. A member reads attacker-influenceable text
+(the PR diff), so COUNCIL_VERDICT.md's injection threat is live and
+bypassPermissions would hand an injected instruction full Bash. Verified on this
+host that under acceptEdits a Bash escape is refused ("blocked by the sandbox")
+and writes stay confined to the member's temp cwd — the narrowing is real, not
+assumed. One fix covers both paths, since the ordinary single reviewer builds
+its argv through the same function.
+
+Blast radius of the bad run: nothing merged, nothing closed. `reviewer-verdict`
+failures landed only on #481 and #486, which already carried that identical
+status beforehand; each also got a review comment from the empty review. The six
+merge-ready PRs (#496 #495 #494 #490 #488 #487) were still queued at
+`self_review` when the watcher was stopped and carry no verdict.
+
+Separately visible in that run, not fixed here: red-audit PRs (#478/#483/#485)
+and every CONCERNS fix pass need SwitchBoard on `localhost:20401`, which is not
+deployed — the reviewer logs `planning failed … Connection refused` and records
+"pushed no changes". Reviews and merges do not depend on it; auto-fix does.
+
 ## 2026-08-13 — feat(reviewer): all-Opus council (operator decision) — codex seat removed
 
 Operator directive: there is no codex subscription on this host, so the C1

--- a/docs/design/COUNCIL_VERDICT.md
+++ b/docs/design/COUNCIL_VERDICT.md
@@ -40,6 +40,17 @@ would share training, failure modes, and any poisoned evidence identically.
 Cross-family members (Claude sonnet, Claude opus, Codex gpt-5) plus distinct
 review lenses give strictly stronger diversity than seeds would.
 
+> **SUPERSEDED IN PRACTICE — operator decision 2026-08-13.** The live panel is
+> three pinned Opus *versions* on one family (see C1 below). The reasoning above
+> still describes the strongest available design; it is not what runs. The
+> operator holds no codex subscription, and because an unrunnable seat parks
+> every guardrail PR fail-closed, the cross-family panel was inert rather than
+> merely weaker. Version diversity decorrelates more than seeds would but
+> strictly less than families: three Opus versions share training lineage, so
+> the same-family generator/evaluator gap this section argues against is
+> **accepted, not closed**. Restoring a genuine second family (codex, or any
+> non-Anthropic CLI on the ladder) is the standing fix.
+
 A council member is still an agent running on this infrastructure reading
 attacker-influenceable text (the diff). Mitigations: members receive the diff
 as data with injection-hardened prompts (INJ conventions), never execute PR
@@ -75,12 +86,19 @@ a follow-up PR that then rides through the council).
 
 For a guardrail PR:
 
-1. **Panel**: K=3 members, one per backend family rung — claude/sonnet,
-   claude/opus, codex/gpt-5 — reusing the existing worker-backend ladder and
+1. **Panel**: K=3 members reusing the existing worker-backend ladder and
    cooldown machinery. Each member gets an identical evidence bundle (diff,
    PR body, the guardrail file's role, last loop-cycle summary, heartbeats)
    and a distinct lens prompt: *correctness*, *security/capability-change*,
    *convergence/operational*.
+   - *Designed* seating: one member per backend family rung — claude/sonnet,
+     claude/opus, codex/gpt-5.
+   - *Live* seating (operator decision 2026-08-13): three pinned Opus versions
+     on the claude_code family — `claude-opus-5` (correctness),
+     `claude-opus-4-8` (security/capability), `claude-opus-4-7`
+     (convergence/operational). Versions are pinned, never aliased: `opus`
+     would drift onto whatever the CLI calls latest and silently collapse two
+     seats onto one model. See the superseded note under *Why cross-family*.
 2. **Verdict**: each member returns structured JSON
    `{"verdict": "LGTM"|"CONCERN", "reasons": [...]}` (same schema as the
    self-heal ladder's structured concerns).
@@ -94,6 +112,14 @@ For a guardrail PR:
    expiry path (#446). The gate fails CLOSED for guardrail changes; ordinary
    PRs are unaffected. Degrade-never-halt applies to the fleet's work, not to
    its own guardrail approvals.
+   Under the live all-Opus seating, availability is **all-or-nothing**: seats
+   are compared at family grain (`limit_classifier.detect_model`), so any
+   claude cooldown — model-scoped `opus`, account-wide `session_5h`, or the
+   budget guard's synthetic `budget_reserve` — cools all three at once. The
+   `min_council_members: 2` degraded quorum is therefore unreachable via the
+   cooldown store today; it survives only for a seat made unavailable some
+   other way. Expect whole-council parks where the codex seat used to carry
+   the panel through a claude bucket exhaustion.
 5. **Record**: verdicts land in `state/council/<repo>-<pr>.json` and a PR
    comment summarizing all three members' reasons; the `reviewer-verdict`
    status context is set only on quorum.

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -714,6 +714,16 @@ def _member_on_cooldown(usage_store, backend: str, model: str, *, now: datetime)
     (``session_5h`` / ``global_weekly`` / unattributed) cools every model of
     the backend, including this one.
 
+    Compared at FAMILY grain. A panel seat may name a pinned version
+    (``claude-opus-5``), but the usage store only ever records the limit
+    classifier's four-token vocabulary (sonnet/opus/haiku/codex — see
+    ``WORKER_BACKEND_MODELS``), because that is all ``detect_model`` can parse
+    out of a CLI limit message. Comparing raw strings would make an ``opus``
+    cooldown match NO Opus-version seat, so a rate-limited council would look
+    fully available and burn its quota dispatching three doomed reviews. Both
+    sides are normalized through ``detect_model`` instead; it is the identity
+    for bare tokens, so alias-style seats keep their existing behavior.
+
     Fails OPEN (not cooled) on a store-read error: a broken usage store must
     never itself deadlock the council quorum check (degrade-never-halt).
     """
@@ -728,11 +738,18 @@ def _member_on_cooldown(usage_store, backend: str, model: str, *, now: datetime)
             exc,
         )
         return False
-    from operations_center.backends.limit_classifier import MODEL_WEEKLY
+    from operations_center.backends.limit_classifier import MODEL_WEEKLY, detect_model
 
+    seat_family = detect_model(model, default=model)
     for entry in details:
         if entry.get("limit_kind") == MODEL_WEEKLY:
-            if entry.get("model") == model:
+            entry_model = entry.get("model")
+            entry_family = (
+                detect_model(entry_model, default=entry_model)
+                if isinstance(entry_model, str)
+                else entry_model
+            )
+            if entry_family == seat_family:
                 return True
             continue
         return True  # account-wide / unattributed — blocks every model of the backend
@@ -4115,12 +4132,16 @@ def _run_council(
     now = datetime.now(UTC)
 
     available = [
-        member for member in _COUNCIL_PANEL if not _member_on_cooldown(usage_store, *member[:2], now=now)
+        member
+        for member in _COUNCIL_PANEL
+        if not _member_on_cooldown(usage_store, *member[:2], now=now)
     ]
     min_members = getattr(council, "min_council_members", 3)
 
     if len(available) < min_members:
-        cooled = sorted(f"{b}/{m}" for (b, m, _lens) in _COUNCIL_PANEL if (b, m, _lens) not in available)
+        cooled = sorted(
+            f"{b}/{m}" for (b, m, _lens) in _COUNCIL_PANEL if (b, m, _lens) not in available
+        )
         detail = (
             f"Guardrail-surface PR requires a {min_members}-member cross-family council "
             f"(COUNCIL_VERDICT.md C1); only {len(available)}/{len(_COUNCIL_PANEL)} panel seats "
@@ -4531,7 +4552,7 @@ def main() -> int:
     # Containment self-check (audit Track A3): surface a broken posture at boot.
     for problem in verify_containment():
         logger.error(
-            'pr_review_watcher: containment self-check FAILED — %s '
+            "pr_review_watcher: containment self-check FAILED — %s "
             '{"event": "containment_selfcheck_failed", "problem": "%s"}',
             problem,
             problem,

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -687,21 +687,29 @@ def _run_direct_review(
     return _run_member_review(oc_root, goal_text, state_key, backend="claude_code", model="haiku")
 
 
+# Ordinary-review fallback pairings (D1), keyed by worker backend.
+#
+# Deliberately INDEPENDENT of ``verdict._COUNCIL_PANEL``. D1 originally derived
+# this by scanning the panel, to reuse a pairing already proven safe as a live
+# council seat. That coupling is subtly wrong: the panel answers "who adjudicates
+# guardrail PRs" (a review-policy choice), while this answers "which model
+# reviews when claude is cooled" (a capacity fallback). Deriving one from the
+# other means reseating the council SILENTLY disables the fallback — exactly what
+# the 2026-08-13 all-Opus panel did, since it carries no codex seat, turning
+# every claude-cooled ordinary review into a park on hosts that do have codex.
+# The ``codex_cli`` → ``codex`` pairing below is the same one D1 validated; it is
+# now stated directly instead of inferred, so the two can vary independently.
+_REVIEW_FALLBACK_MODELS: dict[str, str] = {"codex_cli": "codex"}
+
+
 def _review_model_for_backend(backend: str) -> str | None:
     """Model to pair with a fallback review backend for the ordinary review (D1).
 
-    Sourced from the validated council panel (``verdict._COUNCIL_PANEL``) so the
-    ordinary-review claude→codex fallback reuses the SAME ``(backend, model)``
-    pairing already proven safe as a live council seat (``codex_cli`` → ``codex``)
-    — no new, unvalidated pairing is introduced. Returns ``None`` when the
-    backend has no known review pairing (caller then parks rather than guess a
-    model). Not consulted for ``claude_code`` (that path keeps its own
-    ``_run_direct_review`` haiku default).
+    Returns ``None`` when the backend has no known review pairing (caller then
+    parks rather than guess a model). Not consulted for ``claude_code`` (that
+    path keeps its own ``_run_direct_review`` haiku default).
     """
-    for member_backend, model, _lens in _COUNCIL_PANEL:
-        if member_backend == backend:
-            return model
-    return None
+    return _REVIEW_FALLBACK_MODELS.get(backend)
 
 
 def _member_on_cooldown(usage_store, backend: str, model: str, *, now: datetime) -> bool:

--- a/src/operations_center/entrypoints/pr_review_watcher/member_runner.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/member_runner.py
@@ -23,10 +23,25 @@ def build_member_argv(backend: str, model: str, prompt: str) -> list[str] | None
     Returns ``None`` for an unsupported ``(backend, model)`` pair.
     """
     if backend == "claude_code":
-        # Preserve the live single-review invocation exactly (only the model
-        # varies per council seat): `--effort low` keeps reviews cheap+fast, and
-        # NOT passing --dangerously-skip-permissions matches the path that has
-        # run in production — a reviewer in an empty tmpdir needs neither.
+        # `--effort low` keeps reviews cheap+fast.
+        #
+        # `--permission-mode acceptEdits` is REQUIRED, not a convenience. The
+        # member's one required action is writing verdict.json to its cwd, and
+        # under the default permission mode a non-interactive `-p` run cannot
+        # write at all: the CLI denies the write, the model reports success in
+        # prose, and the process still exits rc=0. The reviewer then finds no
+        # verdict.json, records "no verdict", and the fail-safe scores the PR
+        # CONCERNS — publishing a FAILING reviewer-verdict status and burning a
+        # fix-ladder attempt on a PR nobody actually reviewed. Diagnosed live
+        # 2026-08-13 after a fresh CLI install; the previous host evidently
+        # carried a permissive user-level settings file that masked this.
+        #
+        # Deliberately NOT --dangerously-skip-permissions. A council member
+        # reads attacker-influenceable text (the PR diff), so the injection
+        # threat in COUNCIL_VERDICT.md is live: bypassPermissions would hand an
+        # injected instruction full Bash. acceptEdits grants file writes only —
+        # verified on this host that a Bash escape attempt under acceptEdits is
+        # refused and writes stay confined to the member's temp cwd.
         return [
             "claude",
             "--model",
@@ -34,6 +49,8 @@ def build_member_argv(backend: str, model: str, prompt: str) -> list[str] | None
             "-p",
             "--effort",
             "low",
+            "--permission-mode",
+            "acceptEdits",
             prompt,
         ]
     if backend == "codex_cli":

--- a/src/operations_center/entrypoints/pr_review_watcher/verdict.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/verdict.py
@@ -226,13 +226,33 @@ _LENS_FRAGMENTS: dict[str, str] = {
     "convergence-operational": LENS_CONVERGENCE_OPERATIONAL,
 }
 
-# The panel: one member per backend-family rung, each with a distinct lens. Each
-# entry is (worker_backend, model, lens). ``model`` is the CLI --model alias
-# (claude) / the codex model tag — main.py maps these to argv.
+# The panel: three seats, each with a distinct lens. Each entry is
+# (worker_backend, model, lens). ``model`` is passed straight to the CLI's
+# --model flag (member_runner.build_member_argv), so it may be an alias
+# ("opus") or a pinned version ID ("claude-opus-5").
+#
+# OPERATOR DECISION 2026-08-13: the panel is now three pinned Opus VERSIONS on
+# one family, replacing the cross-family (claude/sonnet, claude/opus, codex)
+# panel C1 originally specified. The operator runs no codex subscription, and
+# an unrunnable seat parks every guardrail PR fail-closed (min_council_members
+# defaults to 3), so the cross-family panel was not merely weaker here — it was
+# inert. Two consequences are accepted deliberately and must not be "fixed"
+# silently:
+#   1. Diversity is now version + lens, NOT family. The same-family
+#      generator/evaluator gap COUNCIL_VERDICT.md C1 was written to close is
+#      no longer closed by the panel composition; three Opus versions share
+#      training lineage and can share a blind spot.
+#   2. Every seat draws on ONE subscription. An account-wide claude cooldown
+#      (session_5h / global_weekly / the budget guard's synthetic
+#      budget_reserve) now cools the WHOLE council at once, where the codex
+#      seat used to survive it. Guardrail PRs park until the bucket resets.
+# Versions are pinned rather than aliased on purpose: "opus" would drift onto
+# whatever the CLI calls latest, silently collapsing two seats onto one model
+# and reducing the panel to a duplicate-vote rubber stamp.
 _COUNCIL_PANEL: tuple[tuple[str, str, str], ...] = (
-    ("claude_code", "sonnet", "correctness"),
-    ("claude_code", "opus", "security-capability"),
-    ("codex_cli", "codex", "convergence-operational"),
+    ("claude_code", "claude-opus-5", "correctness"),
+    ("claude_code", "claude-opus-4-8", "security-capability"),
+    ("claude_code", "claude-opus-4-7", "convergence-operational"),
 )
 
 

--- a/tests/test_pr_review_watcher.py
+++ b/tests/test_pr_review_watcher.py
@@ -579,7 +579,9 @@ def test_phase1_backend_unavailable_park_autoexpires(tmp_path: Path) -> None:
     must resume autonomous review without a human or a new push."""
     from datetime import UTC, datetime, timedelta
 
-    stale = (datetime.now(UTC) - timedelta(seconds=watcher._BACKEND_UNAVAILABLE_RESUME_S + 60)).isoformat()
+    stale = (
+        datetime.now(UTC) - timedelta(seconds=watcher._BACKEND_UNAVAILABLE_RESUME_S + 60)
+    ).isoformat()
     state, sp = _make_state(
         tmp_path,
         phase="self_review",
@@ -3476,9 +3478,7 @@ def test_branch_protection_gate_refuses_on_api_error() -> None:
 def _ladder_settings(dynamic: bool = True):
     from types import SimpleNamespace
 
-    return SimpleNamespace(
-        team_executor=SimpleNamespace(dynamic_worker_backend_selection=dynamic)
-    )
+    return SimpleNamespace(team_executor=SimpleNamespace(dynamic_worker_backend_selection=dynamic))
 
 
 def _cool_claude(store, now):
@@ -3491,6 +3491,38 @@ def _cool_claude(store, now):
         limit_kind="session_5h",  # account-wide → claude fully cooled
         model=None,
     )
+
+
+def test_member_on_cooldown_matches_pinned_version_against_family_token(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A ``model_weekly`` cooldown is recorded under the limit classifier's
+    family token ("opus"), never a pinned version ID — that vocabulary is all
+    ``detect_model`` can parse out of a CLI limit message. The council's seats
+    ARE pinned versions, so a raw string comparison would match none of them and
+    report a rate-limited council as fully available, burning the quorum on
+    three doomed reviews. Both sides normalize to the family instead."""
+    from datetime import datetime, timedelta, timezone
+
+    from operations_center.execution.usage_store import UsageStore
+
+    monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "u.json"))
+    now = datetime.now(timezone.utc)
+    store = UsageStore()
+    store.record_worker_backend_cooldown(
+        worker_backend="claude_code",
+        reset_at=now + timedelta(hours=2),
+        now=now,
+        limit_kind="model_weekly",
+        model="opus",
+    )
+
+    for seat in ("claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "opus"):
+        assert watcher._member_on_cooldown(store, "claude_code", seat, now=now) is True, seat
+    # A different family under the same backend stays runnable — the cooldown is
+    # model-scoped, not account-wide, so this must not over-block.
+    for seat in ("sonnet", "haiku"):
+        assert watcher._member_on_cooldown(store, "claude_code", seat, now=now) is False, seat
 
 
 def test_select_review_backend_available_when_no_cooldown(monkeypatch, tmp_path):
@@ -3528,7 +3560,9 @@ def test_select_review_backend_respects_dynamic_disabled(monkeypatch, tmp_path):
     now = datetime.now(timezone.utc)
     store = UsageStore()
     _cool_claude(store, now)
-    sel = watcher._select_review_backend(_ladder_settings(dynamic=False), usage_store=store, now=now)
+    sel = watcher._select_review_backend(
+        _ladder_settings(dynamic=False), usage_store=store, now=now
+    )
     # operator opted out of the ladder globally → always the preferred backend
     assert sel is not None and sel.selected_backend == "claude_code"
 
@@ -3704,7 +3738,15 @@ def test_phase1_guardrail_paths_empty_uses_single_review_no_fork(tmp_path: Path)
         ) as mock_direct,
     ):
         watcher._phase1(
-            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", SETTINGS
+            state,
+            sp,
+            _contributor_pr_data(),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            SETTINGS,
         )
 
     mock_council.assert_not_called()
@@ -3721,7 +3763,15 @@ def test_phase1_guardrail_hit_forks_to_council(tmp_path: Path) -> None:
         patch.object(watcher, "_run_direct_review") as mock_direct,
     ):
         watcher._phase1(
-            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+            state,
+            sp,
+            _contributor_pr_data(),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            settings,
         )
 
     mock_council.assert_called_once()
@@ -3851,7 +3901,9 @@ def test_run_council_unanimous_lgtm_merges(tmp_path: Path) -> None:
         ) as mock_member,
         patch.object(watcher, "_merge_and_done") as mock_merge,
     ):
-        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings)
+        )
 
     assert mock_member.call_count == 3
     mock_merge.assert_called_once()
@@ -3867,7 +3919,7 @@ def test_run_council_any_concern_feeds_fix_ladder(tmp_path: Path) -> None:
     settings = _council_settings()
 
     def _member_side_effect(oc_root, goal_text, state_key, *, backend, model):
-        if backend == "claude_code" and model == "opus":
+        if backend == "claude_code" and model == "claude-opus-4-8":
             return _member_result("CONCERNS", failing=["code_quality"], summary="bug found")
         return _member_result("LGTM")
 
@@ -3877,7 +3929,9 @@ def test_run_council_any_concern_feeds_fix_ladder(tmp_path: Path) -> None:
         patch.object(watcher, "_merge_and_done") as mock_merge,
         patch.object(watcher, "_run_fix_pass", return_value=True) as mock_fix,
     ):
-        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings)
+        )
 
     mock_merge.assert_not_called()
     mock_fix.assert_called_once()
@@ -3895,14 +3949,16 @@ def test_run_council_records_state_and_posts_one_comment(tmp_path: Path) -> None
         patch.object(watcher, "_run_member_review", return_value=_member_result("LGTM")),
         patch.object(watcher, "_merge_and_done"),
     ):
-        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings)
+        )
 
     gh.post_comment.assert_called_once()
     body = gh.post_comment.call_args[0][3]
     assert "<!-- operations-center:bot -->" in body
-    assert "claude_code/sonnet" in body
-    assert "claude_code/opus" in body
-    assert "codex_cli/codex" in body
+    assert "claude_code/claude-opus-5" in body
+    assert "claude_code/claude-opus-4-8" in body
+    assert "claude_code/claude-opus-4-7" in body
 
     council_path = watcher._council_state_path(tmp_path, REPO_KEY, PR_NUMBER)
     assert council_path.exists()
@@ -3927,7 +3983,11 @@ def test_run_council_each_member_dispatched_on_its_own_family(tmp_path: Path, mo
                 {
                     "checks": [
                         {"check_id": "code_quality", "status": "pass", "evidence_span": "x"},
-                        {"check_id": "no_tooling_artifacts", "status": "pass", "evidence_span": "x"},
+                        {
+                            "check_id": "no_tooling_artifacts",
+                            "status": "pass",
+                            "evidence_span": "x",
+                        },
                     ],
                     "summary": "ok",
                 }
@@ -3945,21 +4005,25 @@ def test_run_council_each_member_dispatched_on_its_own_family(tmp_path: Path, mo
         ),
         patch.object(watcher, "_merge_and_done"),
     ):
-        watcher._run_council(**_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings))
+        watcher._run_council(
+            **_run_council_args(tmp_path, state, sp, _contributor_pr_data(), gh, settings)
+        )
 
     assert len(argvs) == 3
-    sonnet_calls = [a for a in argvs if "--model" in a and a[a.index("--model") + 1] == "sonnet"]
-    opus_calls = [a for a in argvs if "--model" in a and a[a.index("--model") + 1] == "opus"]
-    codex_calls = [a for a in argvs if a[:2] == ["codex", "exec"]]
-    assert len(sonnet_calls) == 1
-    assert len(opus_calls) == 1
-    assert len(codex_calls) == 1
+    models = [a[a.index("--model") + 1] for a in argvs if "--model" in a]
+    # One dispatch per pinned Opus version — no seat collapsed onto another,
+    # which is the failure mode an alias-based panel would produce silently.
+    assert sorted(models) == ["claude-opus-4-7", "claude-opus-4-8", "claude-opus-5"]
+    assert all(a[0] == "claude" for a in argvs)
 
 
 def test_run_council_quorum_unmet_parks(tmp_path: Path, monkeypatch) -> None:
-    """Both claude_code seats cooled (session_5h, account-wide) leaves only
-    codex — 1 < min_council_members(3) — parks instead of burning cooled
-    backends or silently downgrading to a lesser quorum."""
+    """An account-wide claude cooldown (session_5h) now cools EVERY seat, since
+    the panel is three Opus versions on one family — 0 < min_council_members(3)
+    — so it parks instead of burning cooled backends or silently downgrading to
+    a lesser quorum. Before the 2026-08-13 all-Opus panel this left the codex
+    seat runnable (1 available); the whole-council park is the accepted cost of
+    dropping the cross-family seat."""
     from datetime import datetime, timezone
 
     from operations_center.execution.usage_store import UsageStore
@@ -3983,7 +4047,7 @@ def test_run_council_quorum_unmet_parks(tmp_path: Path, monkeypatch) -> None:
     assert state["escalated_needs_human"] is True
     assert state["escalated_reason"] == "reviewer_backend_unavailable"
     assert state["council_park"] is True
-    assert state["council_available_members"] == 1
+    assert state["council_available_members"] == 0
 
 
 def test_phase1_council_park_within_cap_still_auto_resumes(tmp_path: Path) -> None:
@@ -4016,7 +4080,15 @@ def test_phase1_council_park_within_cap_still_auto_resumes(tmp_path: Path) -> No
 
     with patch.object(watcher, "_run_direct_review", return_value=None) as mock_direct:
         watcher._phase1(
-            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+            state,
+            sp,
+            _contributor_pr_data(),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            settings,
         )
 
     assert state["escalated_needs_human"] is False
@@ -4048,7 +4120,15 @@ def test_phase1_council_park_cap_escalates_distinctly(tmp_path: Path) -> None:
 
     with patch.object(watcher, "_run_council") as mock_council:
         watcher._phase1(
-            state, sp, _contributor_pr_data(), gh, "owner", "repo", tmp_path, tmp_path / "cfg.yaml", settings
+            state,
+            sp,
+            _contributor_pr_data(),
+            gh,
+            "owner",
+            "repo",
+            tmp_path,
+            tmp_path / "cfg.yaml",
+            settings,
         )
 
     mock_council.assert_not_called()  # capped hold — never even reaches the fork this poll
@@ -4058,32 +4138,34 @@ def test_phase1_council_park_cap_escalates_distinctly(tmp_path: Path) -> None:
     assert "council_unavailable_capped" in gh.post_comment.call_args[0][3]
 
 
-def test_run_council_degraded_quorum_two_of_three_merges_on_unanimity(tmp_path: Path, monkeypatch) -> None:
-    """F14 degraded quorum: with min_council_members=2, one cooled seat still
-    allows the other two to proceed — unanimity among the AVAILABLE members
-    merges, and the state/comment record the degraded flag."""
-    from datetime import datetime, timezone
+def test_run_council_degraded_quorum_two_of_three_merges_on_unanimity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F14 degraded quorum: with min_council_members=2, one unavailable seat
+    still allows the other two to proceed — unanimity among the AVAILABLE
+    members merges, and the state/comment record the degraded flag.
 
+    NOTE: since the 2026-08-13 all-Opus panel, a single seat can no longer be
+    made unavailable through the usage store. Every seat normalizes to the same
+    ``opus`` family token, so a model_weekly cooldown cools all three and an
+    account-wide one cools all three — availability is 3 or 0, never 2. This
+    test therefore drives the seat-level predicate directly to keep the
+    degraded-quorum BRANCH covered; it no longer describes a state the cooldown
+    store can actually produce."""
     from operations_center.execution.usage_store import UsageStore
 
     monkeypatch.setenv("OPERATIONS_CENTER_EXECUTION_USAGE_PATH", str(tmp_path / "u.json"))
-    now = datetime.now(timezone.utc)
     store = UsageStore()
-    from datetime import timedelta
-
-    store.record_worker_backend_cooldown(
-        worker_backend="codex_cli",
-        reset_at=now + timedelta(hours=2),
-        now=now,
-        limit_kind="session_5h",
-        model=None,
-    )
 
     state, sp = _make_state(tmp_path, phase="self_review")
     gh = _guardrail_gh()
     settings = _council_settings(min_council_members=2)
 
+    def _one_seat_cooled(_store, _backend, model, *, now):
+        return model == "claude-opus-4-7"
+
     with (
+        patch.object(watcher, "_member_on_cooldown", side_effect=_one_seat_cooled),
         patch.object(
             watcher, "_run_member_review", return_value=_member_result("LGTM")
         ) as mock_member,
@@ -4094,7 +4176,7 @@ def test_run_council_degraded_quorum_two_of_three_merges_on_unanimity(tmp_path: 
             usage_store=store,
         )
 
-    assert mock_member.call_count == 2  # codex skipped — cooled
+    assert mock_member.call_count == 2  # claude-opus-4-7 seat skipped
     mock_merge.assert_called_once()
 
     council_path = watcher._council_state_path(tmp_path, REPO_KEY, PR_NUMBER)

--- a/tests/unit/reviewer/test_d1_codex_fallback.py
+++ b/tests/unit/reviewer/test_d1_codex_fallback.py
@@ -16,9 +16,21 @@ from unittest.mock import patch
 from operations_center.entrypoints.pr_review_watcher import main as watcher
 
 
-def test_review_model_for_backend_codex_matches_council_pairing() -> None:
-    # The fallback reuses the validated council seat pairing (codex_cli→codex),
-    # not a fresh, unvalidated model choice.
+def test_review_model_for_backend_codex_pairing() -> None:
+    # The D1-validated pairing (codex_cli→codex), not a fresh unvalidated choice.
+    assert watcher._review_model_for_backend("codex_cli") == "codex"
+
+
+def test_review_model_for_backend_is_independent_of_council_seating() -> None:
+    # Regression: D1 originally derived this pairing by scanning _COUNCIL_PANEL,
+    # so reseating the council SILENTLY killed the ordinary-review fallback — the
+    # 2026-08-13 all-Opus panel (no codex seat) turned every claude-cooled review
+    # into a park. The lookup must not consult the panel at all.
+    from operations_center.entrypoints.pr_review_watcher import verdict
+
+    assert not any(backend == "codex_cli" for backend, _m, _l in verdict._COUNCIL_PANEL), (
+        "precondition: the live panel has no codex seat"
+    )
     assert watcher._review_model_for_backend("codex_cli") == "codex"
 
 


### PR DESCRIPTION
Two commits, both required to make the reviewer function on this host. Operator-directed.

## 1. Seat an all-Opus council

`_COUNCIL_PANEL` becomes three pinned Opus versions on `claude_code`, keeping the three distinct lenses:

| Seat | Lens |
|---|---|
| `claude-opus-5` | correctness |
| `claude-opus-4-8` | security / capability-change |
| `claude-opus-4-7` | convergence / operational |

**Why.** The operator holds no codex subscription. Because an unrunnable seat parks every guardrail PR fail-closed (`min_council_members: 3`), the cross-family panel was not merely weaker here — it was **inert**. No guardrail PR could ever merge.

Versions are pinned rather than aliased on purpose: `opus` resolves to whatever the CLI calls latest, which would silently collapse two seats onto one model and reduce the panel to a duplicate vote that still reports 3/3. All four current Opus IDs were probed against the live CLI before pinning.

### The reseating alone would have introduced a silent quota bug

`_member_on_cooldown` compared a seat's model string to the cooldown record's by equality. But the usage store only ever speaks the limit classifier's four-token vocabulary (`sonnet`/`opus`/`haiku`/`codex`) — that is all `detect_model` can parse out of a CLI limit message. A seat named `claude-opus-5` therefore matches **no** `opus` cooldown, so a rate-limited council would report itself fully available and burn the quorum dispatching three doomed reviews.

Both sides now normalize through `detect_model`, which is the identity for bare tokens, so alias-style seats keep their existing behavior. Regression test covers version seats cooling on a family-token cooldown while `sonnet`/`haiku` stay runnable.

### Two consequences accepted, not fixed

Recorded in `COUNCIL_VERDICT.md` rather than left to be rediscovered:

1. **Diversity is now version + lens, NOT family.** The same-family generator/evaluator gap C1 exists to close is no longer closed by panel composition — three Opus versions share training lineage and can share a blind spot. Restoring a genuine second family is the standing fix.
2. **Availability is all-or-nothing.** Every seat draws on one subscription and normalizes to one family token, so any claude cooldown — model-scoped, account-wide, or the budget guard's synthetic `budget_reserve` — cools the whole council. `min_council_members: 2` is now unreachable via the cooldown store; the degraded-quorum test drives the seat predicate directly and says so.

## 2. Grant council members write access

Found by running the review watcher for real, not by a test.

Every member exited `rc=0` saying it had written `verdict.json`; the reviewer found none, logged `no verdict from member review`, and the fail-safe scored the PR CONCERNS — publishing a **failing** `reviewer-verdict` status and burning a fix-ladder attempt on a PR nothing had actually reviewed. Left running, it would have walked the backlog to `max_fix_attempts` and begun **closing** PRs.

`build_member_argv` passed no permission mode, so a non-interactive `-p` run cannot write at all. Probed in an empty tmpdir:

```
(default)                      -> "Write permission was denied, so
                                   `verdict.json` was not created."   rc=0
--permission-mode acceptEdits  -> "Written."   verdict.json present
--dangerously-skip-permissions -> "Written."   verdict.json present
```

The removed comment claimed the flagless form matched production, so the previous host must have carried a permissive user-level Claude settings file masking this. A fresh install does not.

Uses `acceptEdits`, **deliberately not** `--dangerously-skip-permissions`: a member reads attacker-influenceable text (the PR diff), so `COUNCIL_VERDICT.md`'s injection threat is live and `bypassPermissions` would hand an injected instruction full Bash. Verified on this host that a Bash escape under `acceptEdits` is refused ("blocked by the sandbox") and writes stay confined to the member's temp cwd. One fix covers the ordinary single reviewer too — same argv builder.

## Verification

- Reviewer + verdict suites: **209 passed**.
- Full suite: **10347 passed, 5 failed** — the identical 5 reproduce with these changes stashed (sandbox file-deletion race guards + `test_custodian_sweep`), so **zero new failures**.
- `ruff check` / `ruff format --check` clean on every touched file.
- **Live end-to-end**: with these commits running, guardrail PR #490 was adjudicated by the council — `available: 3, panel: 3, degraded_quorum: false`, unanimous LGTM across all three Opus seats — and merged. #487 and #494 also merged on ordinary LGTM reviews.

## Note for reviewers

This PR touches `pr_review_watcher/**` and `COUNCIL_VERDICT.md`, so it is itself a guardrail change and will be adjudicated by the very council it reseats — running the new panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
