### PR TITLE
fix(watch): reconcile watcher pids via one supervisor tag, not per-role patterns

### DIFF
--- a/.console/backlog.md
+++ b/.console/backlog.md
@@ -4,6 +4,15 @@ _Durable work inventory. Update after each meaningful chunk of progress._
 
 ## Up Next
 
+### Migrate running watchers onto supervisor tags
+- Supervisors launched before `oc-watch-supervisor=<role>` existed carry no tag.
+  `reconcile_watch_pid_file` returns 3 for them and `start_watch_role` refuses, so
+  nothing double-runs — but those roles cannot be reconciled until restarted.
+- One-time migration: `scripts/operations-center.sh watch-all-stop` then
+  `watch-all`. Until then a stale pid file for an untagged role needs the manual
+  stop the error message prints.
+- No deadline; the guard is safe indefinitely. This is bookkeeping, not risk.
+
 ### Split extraction_health_history.py, or the C29 exclusion becomes permanent
 - The module was at exactly 500 lines; #478's `edge_cases` field pushed it to 506 and
   it is now on the C29 exclusion list as an explicit deferral, not an exemption.

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,38 @@
+## 2026-08-17 — fix(watch): re-cut pid reconcile on a single supervisor tag
+
+#481 is closed rather than patched. It recovered a drifted watcher pid by
+scanning `ps` against a hand-maintained dict of per-role command-line fragments —
+a second copy of what `start_watch_role` already knows, with nothing keeping them
+in sync. A quoting change in the launcher would make matching return nothing,
+every caller reads "not found" as "not running", and `start_watch_role` launches a
+duplicate supervisor: the pid-drift failure the PR set out to fix. The council
+raised `code_quality` on five successive heads and hardened 2:1 -> 3:3, and the
+self-heal ladder exhausted twice without changing the branch. That is a design
+signal, not a lint signal.
+
+**The re-cut.** Every supervisor is stamped `oc-watch-supervisor=<role>` in its
+command line by the launcher itself; discovery matches that and nothing else.
+There is no per-role launch knowledge left to drift.
+
+Three things fell out of doing it properly:
+
+1. **A pid-reuse hole on main.** The existing check is `kill -0` on the recorded
+   pid. A pid file surviving a reboot can name a pid the kernel has recycled for
+   an unrelated process; `kill -0` succeeds and the role silently never starts.
+   Validation now also requires the tag in `/proc/<pid>/cmdline`.
+2. **Ambiguous must not read as absent.** Reconcile returns 1 for none and 2 for
+   several. Collapsing them is exactly how a discovery miss becomes a duplicate.
+3. **The fix could have caused the bug on upgrade.** Watchers already running
+   carry no tag, so they would have read as absent and been double-started.
+   A live-but-untagged pid is now outcome 3 and the launcher refuses with the
+   stop command. Verified against the live review watcher: it refused, and the
+   process count did not change.
+
+**The drift guard is a test, not a convention.** `test_every_launch_branch_is_stamped`
+fails if any launch omits the stamp — and it earned its place immediately by
+catching two branches this change had missed, one of which (`start_watchdog`)
+was a real supervisor indented differently from the other five.
+
 ## 2026-08-17 — fix(console): restore the #498 entries this branch's rotation dropped
 
 Caught by a heading census, not by a gate. This branch carried its own log

--- a/.custodian/config.yaml
+++ b/.custodian/config.yaml
@@ -509,6 +509,11 @@ audit:
       # Architecture-guard + lock-store-concurrency tests don't import the
       # code under audit — they probe via subprocess + filesystem.
       - tests/test_architecture_cleanup_guards.py
+      # Same category: the watch-supervisor tag tests audit
+      # scripts/operations-center.sh as text and exercise its bash helpers via
+      # subprocess. There is no src package to import — the subject is a shell
+      # script.
+      - tests/unit/scripts/test_watch_supervisor_tag.py
       - tests/unit/audit_dispatch/test_lock_store_concurrency.py
       # Slow-test tracker tests exercise conftest.py hooks via subprocess — no src imports.
       - tests/test_slow_test_hooks_integration.py

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -360,6 +360,78 @@ watch_pid_file() {
   echo "${WATCH_DIR}/${role}.pid"
 }
 
+# Every supervisor carries this tag verbatim in its command line. It is the ONE
+# string discovery matches on, so there is no per-role launch knowledge that can
+# drift out of sync with start_watch_role. tests/unit/scripts/
+# test_watch_supervisor_tag.py fails if any launch branch omits it.
+watch_supervisor_tag() {
+  printf 'oc-watch-supervisor=%s' "$1"
+}
+
+# True when ${pid} is alive AND its command line carries ${role}'s tag.
+#
+# `kill -0` alone is not sufficient and is a live bug on main: a pid file left
+# behind by a previous boot can name a pid the kernel has since recycled for an
+# unrelated process. `kill -0` then succeeds, the launcher concludes the watcher
+# is already running, and the role silently never starts.
+watch_pid_is_supervisor() {
+  local pid="$1"
+  local role="$2"
+  local cmdline
+  [[ -n "${pid}" ]] || return 1
+  [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "${pid}" 2>/dev/null || return 1
+  cmdline="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null)" || return 1
+  [[ "${cmdline}" == *"$(watch_supervisor_tag "${role}")"* ]]
+}
+
+# Resolve the live supervisor pid for a role, repairing a stale pid file.
+#
+#   0 + pid on stdout : exactly one supervisor found (pid file refreshed if stale)
+#   1                 : none running
+#   2                 : the tag matches MORE than one process
+#   3                 : pid file names a live but UNTAGGED process
+#                       (pre-upgrade supervisor, or a recycled pid)
+#
+# 2 is deliberately distinct from 1. Collapsing them is what makes a discovery
+# miss turn into a duplicate supervisor: callers must be able to tell "nothing is
+# running, start one" from "something is ambiguous, do not touch it".
+reconcile_watch_pid_file() {
+  local role="$1"
+  local pid_file
+  local pid
+  local matches
+  local count
+  pid_file="$(watch_pid_file "${role}")"
+  if [[ -f "${pid_file}" ]]; then
+    pid="$(cat "${pid_file}" 2>/dev/null)"
+    if watch_pid_is_supervisor "${pid}" "${role}"; then
+      printf '%s\n' "${pid}"
+      return 0
+    fi
+    # Alive, but not carrying our tag. Either a supervisor started before this
+    # tagging existed, or an unrelated process on a recycled pid. Both must
+    # refuse: treating it as "not running" is how an upgrade ends up running two
+    # supervisors for the same role.
+    if [[ -n "${pid}" ]] && [[ "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+      return 3
+    fi
+  fi
+  matches="$(pgrep -f "$(watch_supervisor_tag "${role}")" 2>/dev/null || true)"
+  count="$(printf '%s' "${matches}" | grep -c . || true)"
+  if [[ "${count}" -eq 1 ]]; then
+    mkdir -p "$(dirname "${pid_file}")"
+    printf '%s\n' "${matches}" > "${pid_file}"
+    printf '%s\n' "${matches}"
+    return 0
+  fi
+  if [[ "${count}" -gt 1 ]]; then
+    echo "watch-${role}: ${count} processes carry $(watch_supervisor_tag "${role}") — refusing to guess" >&2
+    return 2
+  fi
+  return 1
+}
+
 watch_log_file() {
   local role="$1"
   echo "${WATCH_DIR}/$(timestamp)_${role}.log"
@@ -388,9 +460,27 @@ start_watch_role() {
   esac
   local pid_file
   pid_file="$(watch_pid_file "${role}")"
-  if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" >/dev/null 2>&1; then
-    echo "watch-${role} already running with PID $(cat "${pid_file}")"
+  local live_pid=""
+  local rc=0
+  live_pid="$(reconcile_watch_pid_file "${role}")" || rc=$?
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "watch-${role} already running with PID ${live_pid}"
     return 0
+  fi
+  if [[ "${rc}" -eq 2 ]]; then
+    # Ambiguous, not absent. Starting another here is precisely how duplicate
+    # supervisors accumulate, so stop rather than guess.
+    echo "watch-${role}: multiple supervisors already match the tag — not starting another." >&2
+    echo "  resolve with: scripts/operations-center.sh watch-stop --role ${role}" >&2
+    return 1
+  fi
+  if [[ "${rc}" -eq 3 ]]; then
+    # A live process holds this role's pid file but predates supervisor tagging
+    # (or the pid was recycled). Starting another would double-run the role.
+    echo "watch-${role}: pid file names live PID $(cat "${pid_file}" 2>/dev/null) which carries no supervisor tag." >&2
+    echo "  It predates tagging, or the pid was reused. Stop it before starting:" >&2
+    echo "  scripts/operations-center.sh watch-stop --role ${role}" >&2
+    return 1
   fi
   rm -f "${pid_file}"
   mkdir -p "${WATCH_DIR}"
@@ -403,6 +493,7 @@ start_watch_role() {
   # a crash and triggers a restart with a 30-second backoff.
   if [[ "${role}" == "intake" ]]; then
     setsid /bin/bash -lc "
+      # oc-watch-supervisor=${role}
       cd '${ROOT_DIR}'
       set -a
       source '${ENV_PATH}'
@@ -426,6 +517,7 @@ start_watch_role() {
     " >>"${log_file}" 2>&1 < /dev/null &
   elif [[ "${role}" == "review" ]]; then
     setsid /bin/bash -lc "
+      # oc-watch-supervisor=${role}
       cd '${ROOT_DIR}'
       set -a
       source '${ENV_PATH}'
@@ -457,6 +549,7 @@ start_watch_role() {
     # role (executes spec-author tasks through the backend pipeline). See
     # docs/architecture/adr/0007-spec-director-refactor.md.
     setsid /bin/bash -lc "
+      # oc-watch-supervisor=${role}
       cd '${ROOT_DIR}'
       set -a
       source '${ENV_PATH}'
@@ -497,6 +590,7 @@ start_watch_role() {
     " >>"${log_file}" 2>&1 < /dev/null &
   elif [[ "${role}" == "propose" ]]; then
     setsid /bin/bash -lc "
+      # oc-watch-supervisor=${role}
       cd '${ROOT_DIR}'
       set -a
       source '${ENV_PATH}'
@@ -522,6 +616,7 @@ start_watch_role() {
   else
     # goal, test, improve — Plane-polling board workers
     setsid /bin/bash -lc "
+      # oc-watch-supervisor=${role}
       cd '${ROOT_DIR}'
       set -a
       source '${ENV_PATH}'
@@ -607,6 +702,7 @@ start_watchdog() {
   # Runs every hour; revives any watcher whose PID file exists but PID is dead.
   # Exits when its own PID file is removed (by stop_watchdog / dev-down).
   setsid /bin/bash -lc "
+    # oc-watch-supervisor=watchdog
     cd '${ROOT_DIR}'
     set -a
     source '${ENV_PATH}'
@@ -697,12 +793,12 @@ status_watch_role() {
   local status_file
   pid_file="$(watch_pid_file "${role}")"
   status_file="$(watch_status_file "${role}")"
-  if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" >/dev/null 2>&1; then
+  local live_pid
+  if live_pid="$(reconcile_watch_pid_file "${role}")"; then
     if [[ -f "${status_file}" ]]; then
-      python3 - "${role}" "${pid_file}" "${status_file}" <<'PY'
+      python3 - "${role}" "${live_pid}" "${status_file}" <<'PY'
 import json, sys
-role, pid_file, status_file = sys.argv[1:]
-pid = open(pid_file).read().strip()
+role, pid, status_file = sys.argv[1:]
 data = json.load(open(status_file))
 counters = data.get("counters", {})
 print(
@@ -714,7 +810,7 @@ print(
 )
 PY
     else
-      echo "watch-${role}: running (pid $(cat "${pid_file}"))"
+      echo "watch-${role}: running (pid ${live_pid})"
     fi
   else
     if [[ -f "${status_file}" ]]; then

--- a/tests/unit/scripts/test_watch_supervisor_tag.py
+++ b/tests/unit/scripts/test_watch_supervisor_tag.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Pin the watch-supervisor tag contract in scripts/operations-center.sh.
+
+PR #481 tried to recover a drifted watcher pid by scanning `ps` for a
+hand-maintained dict of per-role command-line fragments. That dict duplicated
+knowledge that already lived in `start_watch_role`, and nothing kept the two in
+sync. A quoting or argument change in the launcher would make matching silently
+return nothing, every caller reads "not found" as "not running", and
+`start_watch_role` then launches a DUPLICATE supervisor — the exact pid-drift
+failure the change set out to fix. The council raised it on five heads running.
+
+The replacement stamps one uniform tag into every supervisor's command line and
+matches only that. These tests exist so the single-source property is enforced
+rather than merely intended: if someone adds a sixth launch branch and forgets
+the stamp, `test_every_launch_branch_is_stamped` fails here instead of silently
+degrading in production.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "operations-center.sh"
+
+pytestmark = pytest.mark.skipif(
+    not SCRIPT.exists(), reason="launcher script not present in this checkout"
+)
+
+
+def _script() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+# ── the invariant that #481 lacked ───────────────────────────────────────────
+
+
+def test_every_launch_branch_is_stamped():
+    """Every `setsid /bin/bash -lc` supervisor must carry the tag.
+
+    This is the drift guard. Discovery matches the tag and nothing else, so an
+    unstamped branch is invisible to reconciliation — and an invisible watcher
+    reads as "not running", which is what produces duplicate supervisors.
+    """
+    text = _script()
+    launches = []
+    for m in re.finditer(r"setsid /bin/bash -lc \"", text):
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        # Prose describing the launch pattern is not a launch. stop_watch_role's
+        # comment quotes it verbatim, and matching that would be a false alarm.
+        if text[line_start : m.start()].lstrip().startswith("#"):
+            continue
+        launches.append(m.start())
+    assert launches, "no supervisor launches found — has the launcher been restructured?"
+
+    unstamped = []
+    for pos in launches:
+        # The stamp is the first line inside the command string. The watch roles
+        # interpolate ${role}; the watchdog is its own fixed role name.
+        window = text[pos : pos + 200]
+        if "oc-watch-supervisor=" not in window:
+            line_no = text.count("\n", 0, pos) + 1
+            unstamped.append(line_no)
+
+    assert not unstamped, (
+        f"{len(unstamped)} launch branch(es) at line(s) {unstamped} do not stamp "
+        "oc-watch-supervisor=${role} as their first line. Discovery matches only "
+        "that tag, so an unstamped supervisor cannot be reconciled and a duplicate "
+        "will be started."
+    )
+
+
+def test_tag_has_exactly_one_definition():
+    """One producer of the tag string. Two would be the drift #481 died of."""
+    text = _script()
+    assert text.count("watch_supervisor_tag() {") == 1
+    # The literal may appear only in the helper and in the launch stamps; every
+    # other consumer must go through watch_supervisor_tag().
+    literal_uses = re.findall(r"oc-watch-supervisor=", text)
+    stamps = re.findall(r"# oc-watch-supervisor=", text)
+    assert len(literal_uses) == len(stamps) + 1, (
+        f"oc-watch-supervisor= appears {len(literal_uses)}x but only "
+        f"{len(stamps)} stamps + 1 helper are allowed; a second producer of the "
+        "tag string is exactly the drift that sank #481"
+    )
+
+
+def test_no_per_role_command_line_patterns_reintroduced():
+    """Guard against the #481 shape coming back.
+
+    A dict keyed by role holding command-line fragments is the specific design
+    the council rejected three-to-nil.
+    """
+    text = _script()
+    assert "find_watch_supervisor_pid" not in text, (
+        "find_watch_supervisor_pid is back — it matched per-role command-line "
+        "fragments that duplicate start_watch_role and drift silently"
+    )
+
+
+def test_ambiguous_is_distinct_from_absent():
+    """reconcile must not collapse 'many' into 'none'.
+
+    Returning the same code for both is how a discovery miss becomes a duplicate
+    supervisor: the caller starts one because it believes nothing is running.
+    """
+    text = _script()
+    body = re.search(
+        r"reconcile_watch_pid_file\(\) \{(.*?)\n\}", text, re.S
+    )
+    assert body, "reconcile_watch_pid_file not found"
+    assert "return 2" in body.group(1), "no distinct exit code for the ambiguous case"
+    assert "return 1" in body.group(1), "no distinct exit code for the absent case"
+
+
+def test_start_refuses_to_start_when_ambiguous():
+    """start_watch_role must bail on rc=2 rather than launch another."""
+    text = _script()
+    body = re.search(r"start_watch_role\(\) \{(.*?)\n  local log_file", text, re.S)
+    assert body, "start_watch_role not found"
+    assert 'rc}" -eq 2' in body.group(1).replace("${", "{"), (
+        "start_watch_role does not handle the ambiguous exit code"
+    )
+
+
+# ── behaviour, exercised against real processes ──────────────────────────────
+
+_FUNCS = ("watch_supervisor_tag", "watch_pid_is_supervisor", "reconcile_watch_pid_file")
+
+
+def _bash_prelude(watch_dir: Path) -> str:
+    """Extract the helpers so they can run without executing the script's dispatch."""
+    text = _script()
+    out = [f'WATCH_DIR="{watch_dir}"', 'watch_pid_file() { echo "${WATCH_DIR}/${1}.pid"; }']
+    for name in _FUNCS:
+        m = re.search(rf"^{name}\(\) \{{.*?^\}}", text, re.S | re.M)
+        assert m, f"could not extract {name}"
+        out.append(m.group(0))
+    return "\n".join(out) + "\n"
+
+
+def _run(prelude: str, snippet: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", prelude + snippet],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="needs /proc")
+@pytest.mark.skipif(shutil.which("pgrep") is None, reason="needs pgrep")
+def test_live_tagged_process_is_recognised(tmp_path):
+    """A process carrying the tag validates; the same pid without it does not."""
+    prelude = _bash_prelude(tmp_path)
+    tag = "oc-watch-supervisor=pytestrole"
+    # The trailing `:` matters. With a single simple command, bash exec-replaces
+    # itself with `sleep`, which discards the script text — and the tag with it —
+    # from the process command line. A second command forces bash to stay alive
+    # as the parent, which is also how the real supervisors behave.
+    proc = subprocess.Popen(
+        ["bash", "-c", f"# {tag}\nsleep 30\n:"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.3)
+        r = _run(prelude, f'watch_pid_is_supervisor {proc.pid} pytestrole && echo YES || echo NO')
+        assert r.stdout.strip() == "YES", r.stderr
+
+        # Same live pid, different role — must NOT validate. This is the
+        # pid-reuse hole: kill -0 alone would say "running".
+        r2 = _run(prelude, f'watch_pid_is_supervisor {proc.pid} otherrole && echo YES || echo NO')
+        assert r2.stdout.strip() == "NO", r2.stderr
+    finally:
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="needs /proc")
+def test_stale_pid_file_is_not_trusted(tmp_path):
+    """A pid file naming a live but unrelated process must not read as running.
+
+    This is the bug on main today: `kill -0` succeeds on a recycled pid, so the
+    role silently never starts.
+    """
+    prelude = _bash_prelude(tmp_path)
+    # Point the pid file at a process that is definitely alive and definitely
+    # not a watcher: this test's own interpreter.
+    (tmp_path / "ghost.pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+    r = _run(prelude, 'watch_pid_is_supervisor "$(cat "${WATCH_DIR}/ghost.pid")" ghost && echo YES || echo NO')
+    assert r.stdout.strip() == "NO", r.stderr
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="needs /proc")
+def test_reconcile_reports_absent_with_code_1(tmp_path):
+    prelude = _bash_prelude(tmp_path)
+    r = _run(prelude, 'reconcile_watch_pid_file nosuchrole_xyz; echo "rc=$?"')
+    assert "rc=1" in r.stdout, r.stdout + r.stderr
+
+
+@pytest.mark.skipif(not Path("/proc").is_dir(), reason="needs /proc")
+def test_untagged_live_pid_is_not_reported_as_absent(tmp_path):
+    """The upgrade case: a live supervisor started before tagging existed.
+
+    Reporting it as absent (rc=1) would make start_watch_role launch a SECOND
+    supervisor for a role that is already running — the duplicate-supervisor
+    failure this whole change exists to prevent, caused by the fix itself. It
+    must be its own outcome so the launcher can refuse.
+    """
+    prelude = _bash_prelude(tmp_path)
+    (tmp_path / "legacy.pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+    r = _run(prelude, 'reconcile_watch_pid_file legacy; echo "rc=$?"')
+    assert "rc=3" in r.stdout, (
+        "a live but untagged pid must not read as absent; got: "
+        + r.stdout + r.stderr
+    )
+
+
+def test_start_refuses_on_untagged_live_pid():
+    """start_watch_role must handle rc=3, not fall through to launching."""
+    text = _script()
+    body = re.search(r"start_watch_role\(\) \{(.*?)\n  local log_file", text, re.S)
+    assert body, "start_watch_role not found"
+    assert 'rc}" -eq 3' in body.group(1).replace("${", "{"), (
+        "start_watch_role does not handle the untagged-live-pid case, so an "
+        "upgrade would double-run every already-running watcher"
+    )


### PR DESCRIPTION
Re-cut of #481, which is closed. Same problem — watcher pid-file drift — with a
design that answers the council's objection instead of working around it.

## Why #481 was closed

It recovered a drifted pid by scanning `ps` against a hand-maintained dict of
per-role command-line fragments. That dict duplicated what `start_watch_role`
already knows, matched by exact substrings including shell quoting
(`--role 'goal'`), and nothing kept the two in sync.

When they drift, matching silently returns nothing. Every caller reads "not
found" as "not running", so `start_watch_role` launches a **duplicate
supervisor** — the pid-drift failure the change set out to prevent. Multiple
matches exited 3 and were treated identically, with the same result.

The council raised `code_quality` on five successive heads and hardened from 2:1
to unanimous 3/3; the Self-Heal Ladder exhausted twice without changing the
branch. That is a design signal, not a lint signal.

## What this does instead

The launcher stamps `oc-watch-supervisor=<role>` into every supervisor's command
line, and discovery matches that and nothing else. There is no per-role launch
detail left to drift.

Three things fell out of doing it properly:

**A pid-reuse hole that exists on `main` today.** Validation was `kill -0` on the
recorded pid. A pid file surviving a reboot can name a pid the kernel has since
recycled for an unrelated process — `kill -0` succeeds, the launcher concludes
the watcher is running, and the role silently never starts. Validation now also
requires the tag in `/proc/<pid>/cmdline`.

**Ambiguous is not absent.** Reconcile returns 1 for none and 2 for several.
Collapsing them is precisely how a discovery miss becomes a duplicate.

**The fix could have caused the bug on upgrade.** Supervisors already running
carry no tag, so they would have read as absent and been double-started on the
first restart after merge. A live-but-untagged pid is its own outcome (3) and the
launcher refuses, printing the stop command. Verified against the live review
watcher: it refused, and the process count did not change.

```
watch-review: pid file names live PID 3611963 which carries no supervisor tag.
  It predates tagging, or the pid was reused. Stop it before starting:
  scripts/operations-center.sh watch-stop --role review
```

## The invariant is a test, not a convention

`test_every_launch_branch_is_stamped` fails if any launch omits the stamp. It
earned its place immediately: on the first pass it caught two branches this
change had missed, one of them a real supervisor (`start_watchdog`) indented
differently from the other five. Without it, that supervisor would have been
permanently invisible to reconciliation.

Also pinned: exactly one producer of the tag string, no reintroduction of
per-role command-line patterns, and the distinct exit codes.

## Verification

- 10 new tests, including behavioural ones against real tagged processes
- Full unit suite: 8596 passed, 4 skipped
- ruff clean; audit clean; D12/DC10 ratchet clean
- Live migration behaviour confirmed on the running review watcher

## Follow-up

Running watchers stay unreconcilable until restarted once (`watch-all-stop` then
`watch-all`). They cannot double-run in the meantime — the guard refuses. Filed
in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
