### PR TITLE
fix(watch): status must not report a running watcher as stopped

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,41 @@
+## 2026-08-17 — fix(watch): status must not call a running watcher stopped
+
+Follow-up to #499, fixing a regression that change introduced and I did not
+catch before merge.
+
+#499 routed `status_watch_role` through `reconcile_watch_pid_file` but its
+else-branch treats every non-zero code as stopped — including 3, which means
+"alive, but launched before supervisor tagging existed". So `watch-all-status`
+printed `watch-review: stopped` for a watcher that was running, heartbeating,
+and had just merged #499 itself.
+
+I had documented the migration as "untagged watchers cannot be reconciled until
+restarted". That was true and insufficient: the observable effect is a
+monitoring surface asserting a live service is down. An operator acting on that
+reading is the real hazard, not the missing reconciliation.
+
+rc=3 now prints `running (pid N, untagged — restart to reconcile)` — the state
+that is actually true, plus the one-line remedy.
+
+`status_watchdog` was also brought onto the same path. #499 left it on a bare
+`kill -0`, which reports "running" for a pid the kernel has recycled — the same
+hole #499 closed everywhere else.
+
+Two tests pin both: status must distinguish the untagged case, and the watchdog
+must not trust `kill -0` alone.
+
+Nearly shipped a worse bug than the one being fixed: editing the script through
+the `\\wsl.localhost` UNC path stripped its executable bit, and git records mode,
+so the commit carried `old mode 100755 / new mode 100644`. A non-executable
+`scripts/operations-center.sh` breaks every fleet operation with Permission
+denied. Caught because a verification step printed nothing where it had printed
+status lines a moment earlier — the empty output was the tell, not an error
+message. Restored with `chmod +x` before pushing.
+
+Worth remembering: edits made through the Windows UNC path lose the mode bit;
+edits made by a script running inside WSL do not. #499 escaped this only because
+its edits went through Python running in WSL.
+
 ## 2026-08-17 — fix(watch): re-cut pid reconcile on a single supervisor tag
 
 #481 is closed rather than patched. It recovered a drifted watcher pid by

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -780,8 +780,16 @@ stop_watchdog() {
 
 status_watchdog() {
   local pid_file="${WATCH_DIR}/watchdog.pid"
-  if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" >/dev/null 2>&1; then
-    echo "watchdog: running (pid $(cat "${pid_file}"))"
+  # Was a bare `kill -0`, which #499 left behind: that reports "running" for a
+  # pid the kernel has recycled onto an unrelated process. Same three outcomes
+  # as the watch roles, so the watchdog cannot claim to be up when it is not.
+  local live_pid=""
+  local rc=0
+  live_pid="$(reconcile_watch_pid_file watchdog)" || rc=$?
+  if [[ "${rc}" -eq 0 ]]; then
+    echo "watchdog: running (pid ${live_pid})"
+  elif [[ "${rc}" -eq 3 ]]; then
+    echo "watchdog: running (pid $(cat "${pid_file}" 2>/dev/null), untagged — restart to reconcile)"
   else
     echo "watchdog: stopped"
   fi
@@ -793,8 +801,17 @@ status_watch_role() {
   local status_file
   pid_file="$(watch_pid_file "${role}")"
   status_file="$(watch_status_file "${role}")"
-  local live_pid
-  if live_pid="$(reconcile_watch_pid_file "${role}")"; then
+  local live_pid=""
+  local rc=0
+  live_pid="$(reconcile_watch_pid_file "${role}")" || rc=$?
+  if [[ "${rc}" -eq 3 ]]; then
+    # Alive, but launched before supervisor tagging existed. Printing "stopped"
+    # here would be a lie about a running service — and an operator acting on it
+    # is the actual hazard. Report what is true: running, not yet reconcilable.
+    echo "watch-${role}: running (pid $(cat "${pid_file}" 2>/dev/null), untagged — restart to reconcile)"
+    return 0
+  fi
+  if [[ "${rc}" -eq 0 ]]; then
     if [[ -f "${status_file}" ]]; then
       python3 - "${role}" "${live_pid}" "${status_file}" <<'PY'
 import json, sys

--- a/tests/unit/scripts/test_watch_supervisor_tag.py
+++ b/tests/unit/scripts/test_watch_supervisor_tag.py
@@ -224,6 +224,39 @@ def test_untagged_live_pid_is_not_reported_as_absent(tmp_path):
     )
 
 
+def test_status_does_not_report_a_live_supervisor_as_stopped():
+    """A running-but-untagged supervisor must not be reported as stopped.
+
+    #499 routed status through reconcile but collapsed every non-zero code into
+    "stopped", so `watch-all-status` printed `watch-review: stopped` for a watcher
+    that was running, heartbeating and merging PRs. A monitoring surface that
+    reports a live service as down is worse than the drift it replaced, because
+    an operator acting on it is the actual hazard.
+    """
+    text = _script()
+    for func in ("status_watch_role", "status_watchdog"):
+        body = re.search(rf"^{func}\(\) \{{.*?^\}}", text, re.S | re.M)
+        assert body, f"{func} not found"
+        src = body.group(0)
+        assert 'rc}" -eq 3' in src.replace("${", "{"), (
+            f"{func} does not distinguish the untagged-but-alive case, so it "
+            "will report a running supervisor as stopped"
+        )
+        assert "untagged" in src, f"{func} does not surface the untagged state to the operator"
+
+
+def test_status_watchdog_does_not_trust_bare_kill_0():
+    """The watchdog must validate like the roles do, not with `kill -0` alone."""
+    text = _script()
+    body = re.search(r"^status_watchdog\(\) \{.*?^\}", text, re.S | re.M)
+    assert body
+    src = body.group(0)
+    assert "reconcile_watch_pid_file watchdog" in src, (
+        "status_watchdog still trusts a bare kill -0, which reports 'running' "
+        "for a recycled pid"
+    )
+
+
 def test_start_refuses_on_untagged_live_pid():
     """start_watch_role must handle rc=3, not fall through to launching."""
     text = _script()


### PR DESCRIPTION
Follow-up to #499, fixing a regression that change introduced.

## The problem

#499 routed `status_watch_role` through `reconcile_watch_pid_file`, but its
else-branch treats every non-zero exit as stopped — including `3`, which means
*alive, but launched before supervisor tagging existed*.

So `watch-all-status` printed:

```
watch-review: stopped
```

for a watcher that was running, heartbeating, and had just merged #499 itself.

I documented the migration as "untagged watchers cannot be reconciled until
restarted". That was true and not enough: the effect an operator actually sees is
a monitoring surface asserting a live service is down, and acting on that reading
is the real hazard.

## The fix

`rc=3` now reports what is true, with the remedy attached:

```
watch-review: running (pid 3611963, untagged — restart to reconcile)
```

`status_watchdog` is brought onto the same path. #499 left it on a bare
`kill -0`, which reports "running" for a pid the kernel has recycled onto an
unrelated process — the hole #499 closed everywhere else.

## Verification

Checked against the live fleet, where the two cases exist side by side right now:
the running-but-untagged `review` watcher reports running, and the genuinely
stopped `watchdog` still reports stopped.

Two tests pin it: status must distinguish the untagged case (both functions), and
the watchdog must not trust `kill -0` alone. 12 tests total, ruff/audit/ratchet
clean.

## One more thing this nearly shipped

Editing the script through the `\\wsl.localhost` UNC path stripped its executable
bit, and git records mode — the first commit carried `old mode 100755 / new mode
100644`. A non-executable `scripts/operations-center.sh` breaks every fleet
operation with Permission denied. Caught because a verification step printed
nothing where it had printed status lines moments earlier; the empty output was
the tell. Restored before pushing, and the diff against main now shows no mode
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
