### PR TITLE
feat(console): rotate .console/log.md automatically before OC2 bites

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -13,6 +13,36 @@ exists to prevent, and a stop/start cycle is exactly when they would appear.
 Moved rather than deleted: Done is how this backlog records what was actually
 carried out, and the migration's outcome is the evidence that #499 and #500 hold
 against the live fleet and not merely in tests.
+## 2026-08-17 — feat(console): rotate log.md automatically, before OC2 bites
+
+`.console/log.md` grows monotonically by construction: the pre-commit hook
+requires every source commit to add an entry, and nothing ever removes one. At
+roughly 15KB per merged PR the 500KB cap arrives on a schedule — and when it
+does, every open PR fails the gate at once. That happened today and stalled five
+of them until the log was rotated by hand.
+
+Rotation now happens in the pre-commit hook at 80% of budget, keeping the newest
+entries down to 55%. Rotating at the cap would be too late: the first commit to
+notice is already the one failing.
+
+**Every write is gated on a census.** A rotation rewrites the whole file, and a
+wholesale rewrite is precisely the operation that destroys log history silently
+— rebase one across another change to the same file and the other side's entries
+vanish with no conflict and no finding, because OC2 measures size and a rotation
+is *meant* to shrink the file. That nearly erased six entries earlier today. So
+`apply()` recomputes every heading afterwards and refuses to write if even one
+would become unreachable; the hook treats that refusal as a hard commit failure,
+because a lost entry leaves no other trace.
+
+Verified against the real log rather than only fixtures: forcing a rotation on a
+copy of the live 241-entry file produced 111 kept + 130 archived = 241, landing
+at 55.1% of budget.
+
+Two details worth keeping: the archive is named for the range of dates it
+actually contains, not a cutoff — log.md is not strictly date-ordered, and #498's
+archive claimed "through 2026-06-14" while holding entries up to 2026-07-14. And
+each archive is linked from a maintained block in log.md, because an unlinked
+file under `docs/` is a DC7 orphan and fails the audit.
 
 ## 2026-08-17 — fix(watch): status must not call a running watcher stopped
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -27,3 +27,35 @@ if [ "$log_staged" -eq 0 ]; then
     printf '  Skip: git commit --no-verify\n\n'
     exit 1
 fi
+
+# Rotate .console/log.md before it breaches OC2's 500KB cap.
+#
+# This hook and that cap together make the file grow monotonically: every source
+# commit must add an entry, and nothing ever removes one. At roughly 15KB per
+# merged PR the cap arrives on a schedule, and when it does EVERY open PR fails
+# the gate at once — on 2026-08-17 that stalled five of them until someone
+# rotated by hand.
+#
+# Rotating here makes the fix atomic with the commit that would have pushed it
+# over, and the rotation refuses to write if any entry would be lost.
+repo_root=$(git rev-parse --show-toplevel)
+rotate_py="${repo_root}/.venv/bin/python"
+[ -x "$rotate_py" ] || rotate_py=$(command -v python3 || true)
+
+if [ -n "$rotate_py" ]; then
+    rotate_out=$("$rotate_py" -m operations_center.entrypoints.maintenance.console_log_rotate \
+        --repo-root "$repo_root" --apply 2>&1)
+    rotate_rc=$?
+    if [ "$rotate_rc" -eq 2 ]; then
+        # The census refused: rotation would have dropped history. Never commit
+        # past this — a lost log entry leaves no other trace.
+        printf '\n\033[31m  log rotation refused\033[0m\n'
+        printf '%s\n\n' "$rotate_out"
+        exit 1
+    fi
+    if printf '%s' "$rotate_out" | grep -q 'archived'; then
+        printf '\n\033[33m  .console/log.md rotated (OC2 budget)\033[0m\n'
+        printf '%s\n\n' "$rotate_out" | sed 's/^/  /'
+        git add .console/log.md docs/history/console-log/ 2>/dev/null || true
+    fi
+fi

--- a/src/operations_center/entrypoints/maintenance/console_log_rotate.py
+++ b/src/operations_center/entrypoints/maintenance/console_log_rotate.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Rotate `.console/log.md` before it breaches OC2's budget.
+
+OC's pre-commit hook requires every source commit to add a log entry, and OC2
+caps the file at 500KB. Those two rules together make growth monotonic — roughly
+15KB per merged PR — so the file reaches the cap on a predictable schedule. When
+it does, *every* open PR fails the gate at once and the whole queue stalls until
+someone rotates by hand. That happened on 2026-08-17 and blocked five PRs.
+
+This rotates on a warning threshold, well before the cap, so the breach never
+arrives.
+
+**Why this refuses rather than trusts itself.** A rotation rewrites the whole
+file, and a wholesale rewrite is exactly the operation that silently destroys
+history: rebase such a commit across another change to the same file and the
+other side's entries vanish with no conflict and no finding, because OC2 only
+measures size and a rotation is *supposed* to shrink the file. That very thing
+nearly erased six entries on 2026-08-17. So every write here is gated on a
+census: each entry heading present before must still be reachable afterwards,
+in the log or in an archive. If one would be lost, nothing is written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+#: OC2's cap. Kept in sync with `.custodian/config.yaml`; the check below fails
+#: loudly rather than silently rotating to a stale target if that ever diverges.
+BUDGET_BYTES = 512_000
+
+#: Rotate once the file crosses this share of the budget. Deliberately well
+#: under 1.0: rotating *at* the cap means the first commit to notice is already
+#: failing, which is the stall this exists to prevent.
+WARN_RATIO = 0.80
+
+#: Rotation keeps the newest entries up to this share, leaving room for many
+#: more cycles before the next rotation.
+TARGET_RATIO = 0.55
+
+ARCHIVE_DIR = Path("docs/history/console-log")
+_ENTRY_RE = re.compile(r"^## ", re.MULTILINE)
+_DATE_RE = re.compile(r"^## (\d{4}-\d{2}-\d{2})")
+_BLOCK_BEGIN = "<!-- rotated-archives:begin -->"
+_BLOCK_END = "<!-- rotated-archives:end -->"
+
+
+@dataclass(frozen=True)
+class Plan:
+    """What a rotation would do, before anything is written."""
+
+    size: int
+    budget: int
+    warn_at: int
+    needed: bool
+    keep: list[str]
+    archive: list[str]
+    archive_path: Path | None
+
+    @property
+    def headroom(self) -> int:
+        return self.budget - self.size
+
+
+def _entries(text: str) -> list[str]:
+    """Split the log into entries. Each runs from its `## ` heading to the next."""
+    starts = [m.start() for m in _ENTRY_RE.finditer(text)]
+    if not starts:
+        return []
+    bounds = starts + [len(text)]
+    return [text[bounds[i] : bounds[i + 1]] for i in range(len(starts))]
+
+
+def _heading(entry: str) -> str:
+    return entry.split("\n", 1)[0].strip()
+
+
+def _date_of(entry: str) -> str:
+    m = _DATE_RE.match(entry)
+    return m.group(1) if m else "undated"
+
+
+def plan(log_path: Path, *, budget: int = BUDGET_BYTES,
+         warn_ratio: float = WARN_RATIO, target_ratio: float = TARGET_RATIO) -> Plan:
+    """Decide what to rotate. Pure — reads the log, writes nothing."""
+    text = log_path.read_text(encoding="utf-8")
+    size = len(text.encode("utf-8"))
+    warn_at = int(budget * warn_ratio)
+    if size < warn_at:
+        return Plan(size, budget, warn_at, False, [], [], None)
+
+    entries = _entries(text)
+    if not entries:
+        return Plan(size, budget, warn_at, False, [], [], None)
+
+    # Keep newest-first until the target is reached; the rest is archived. The
+    # log is not strictly date-ordered, so this is positional by construction —
+    # which is fine, and is why the archive is named for the entries it holds
+    # rather than for a cutoff date it cannot honestly claim.
+    target = int(budget * target_ratio)
+    keep: list[str] = []
+    archive: list[str] = []
+    running = 0
+    for entry in entries:
+        n = len(entry.encode("utf-8"))
+        if running + n <= target:
+            keep.append(entry)
+            running += n
+        else:
+            archive.append(entry)
+
+    if not archive:
+        return Plan(size, budget, warn_at, False, [], [], None)
+
+    dates = sorted(d for d in (_date_of(e) for e in archive) if d != "undated")
+    span = f"{dates[0]}-to-{dates[-1]}" if dates else "undated"
+    return Plan(size, budget, warn_at, True, keep, archive, ARCHIVE_DIR / f"log-archive-{span}.md")
+
+
+def _archive_header(p: Plan) -> str:
+    dates = sorted(d for d in (_date_of(e) for e in p.archive) if d != "undated")
+    span = f"{dates[0]} — {dates[-1]}" if dates else "undated entries"
+    return (
+        f"# `.console/log.md` archive — {len(p.archive)} entries ({span})\n"
+        "\n"
+        "**Not maintained.** Rotated out of `.console/log.md` automatically to stay\n"
+        f"within OC2's {BUDGET_BYTES:,}-byte budget. Entries are verbatim and are never\n"
+        "updated — see `docs/structure.md` on why history is not kept current.\n"
+        "\n"
+        "The entries below are in their original order, which is the order they were\n"
+        "written in. That is not strictly chronological, so this file is named for the\n"
+        "range of dates it contains rather than a cutoff it cannot honestly claim.\n"
+        "\n"
+        "Current log: [`.console/log.md`](../../../.console/log.md)\n"
+        "\n"
+        "---\n"
+        "\n"
+    )
+
+
+def _pointer_block(existing: str, archive_path: Path, count: int) -> str:
+    """Maintain the archive index at the end of the log.
+
+    The links matter beyond navigation: an archive under `docs/` that nothing
+    links to is an orphan, and DC7 fails the audit for it.
+    """
+    line = f"- [{archive_path.name}]({os.path.relpath(archive_path, '.console')}) — {count} entries\n"
+    if _BLOCK_BEGIN in existing and _BLOCK_END in existing:
+        head, rest = existing.split(_BLOCK_BEGIN, 1)
+        body, tail = rest.split(_BLOCK_END, 1)
+        if line in body:
+            return existing
+        return f"{head}{_BLOCK_BEGIN}{body.rstrip()}\n{line}{_BLOCK_END}{tail}"
+    return (
+        f"{existing.rstrip()}\n\n---\n\n"
+        f"{_BLOCK_BEGIN}\n\n_Rotated archives:_\n\n{line}{_BLOCK_END}\n"
+    )
+
+
+def apply(log_path: Path, p: Plan, *, repo_root: Path) -> list[Path]:
+    """Write the rotation, or raise if it would lose an entry."""
+    if not p.needed or p.archive_path is None:
+        return []
+
+    before = {_heading(e) for e in _entries(log_path.read_text(encoding="utf-8"))}
+
+    archive_abs = repo_root / p.archive_path
+    archive_abs.parent.mkdir(parents=True, exist_ok=True)
+    existing_archive = archive_abs.read_text(encoding="utf-8") if archive_abs.exists() else ""
+    archive_text = (existing_archive or _archive_header(p)) + "".join(p.archive)
+
+    new_log = _pointer_block("".join(p.keep), p.archive_path, len(p.archive))
+
+    # The census. Every heading that existed must still be reachable.
+    after = {_heading(e) for e in _entries(new_log)} | {_heading(e) for e in _entries(archive_text)}
+    lost = sorted(before - after)
+    if lost:
+        raise RuntimeError(
+            "refusing to rotate: "
+            f"{len(lost)} entr{'y' if len(lost) == 1 else 'ies'} would be lost, "
+            f"first: {lost[0][:70]!r}"
+        )
+
+    archive_abs.write_text(archive_text, encoding="utf-8")
+    log_path.write_text(new_log, encoding="utf-8")
+    return [log_path, archive_abs]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Rotate .console/log.md before it breaches OC2.")
+    ap.add_argument("--repo-root", type=Path, default=Path.cwd())
+    ap.add_argument("--check", action="store_true", help="report only; exit 1 if rotation is due")
+    ap.add_argument("--apply", action="store_true", help="rotate if due")
+    ap.add_argument("--budget", type=int, default=BUDGET_BYTES)
+    ap.add_argument("--warn-ratio", type=float, default=WARN_RATIO)
+    args = ap.parse_args(argv)
+
+    log_path = args.repo_root / ".console/log.md"
+    if not log_path.exists():
+        print(f"no log at {log_path}", file=sys.stderr)
+        return 0
+
+    p = plan(log_path, budget=args.budget, warn_ratio=args.warn_ratio)
+    pct = 100.0 * p.size / p.budget
+    print(f"log.md {p.size:,} bytes ({pct:.1f}% of {p.budget:,}); rotate at {p.warn_at:,}")
+
+    if not p.needed:
+        print(f"  no rotation needed — {p.headroom:,} bytes of headroom")
+        return 0
+
+    if args.check and not args.apply:
+        print(f"  rotation DUE: would archive {len(p.archive)} of "
+              f"{len(p.keep) + len(p.archive)} entries")
+        return 1
+
+    try:
+        written = apply(log_path, p, repo_root=args.repo_root)
+    except RuntimeError as exc:
+        print(f"  {exc}", file=sys.stderr)
+        return 2
+
+    new_size = log_path.stat().st_size
+    print(f"  archived {len(p.archive)} entries -> {p.archive_path}")
+    print(f"  log.md now {new_size:,} bytes ({100.0 * new_size / p.budget:.1f}% of budget)")
+    for w in written:
+        print(f"  wrote {w}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/entrypoints/maintenance/test_console_log_rotate.py
+++ b/tests/unit/entrypoints/maintenance/test_console_log_rotate.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for automatic `.console/log.md` rotation.
+
+The behaviour that matters most here is the refusal: a rotation rewrites the
+whole file, and a wholesale rewrite is the operation that silently destroys log
+history when rebased across another change to the same file. On 2026-08-17 that
+nearly erased six entries, and nothing caught it — no conflict, and no finding,
+because OC2 measures size and a rotation is meant to shrink the file. So the
+census that gates every write is tested directly, not just the happy path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from operations_center.entrypoints.maintenance import console_log_rotate as clr
+
+
+def _log(n_entries: int, body_bytes: int = 1000, start_day: int = 1) -> str:
+    out = []
+    for i in range(n_entries):
+        day = start_day + (i % 27)
+        out.append(f"## 2026-06-{day:02d} — entry {i}\n\n" + ("x" * body_bytes) + "\n\n")
+    return "".join(out)
+
+
+def _write(tmp_path, text):
+    p = tmp_path / ".console"
+    p.mkdir(parents=True, exist_ok=True)
+    f = p / "log.md"
+    f.write_text(text, encoding="utf-8")
+    return f
+
+
+def test_no_rotation_below_the_threshold(tmp_path):
+    f = _write(tmp_path, _log(5))
+    p = clr.plan(f, budget=512_000)
+    assert not p.needed
+    assert p.headroom > 0
+
+
+def test_rotation_is_due_above_the_threshold(tmp_path):
+    f = _write(tmp_path, _log(60, body_bytes=1000))
+    p = clr.plan(f, budget=50_000, warn_ratio=0.80)
+    assert p.needed
+    assert p.archive, "nothing selected for archiving"
+    assert p.keep, "rotation must not empty the log"
+
+
+def test_every_entry_survives_rotation(tmp_path):
+    """The core guarantee: rotation moves history, it never drops it."""
+    text = _log(60, body_bytes=1000)
+    f = _write(tmp_path, text)
+    before = {clr._heading(e) for e in clr._entries(text)}
+
+    p = clr.plan(f, budget=50_000)
+    clr.apply(f, p, repo_root=tmp_path)
+
+    after_log = {clr._heading(e) for e in clr._entries(f.read_text(encoding="utf-8"))}
+    archive = tmp_path / p.archive_path
+    after_arch = {clr._heading(e) for e in clr._entries(archive.read_text(encoding="utf-8"))}
+
+    assert before == (after_log | after_arch), "entries were lost or invented"
+    assert not (after_log & after_arch), "an entry is duplicated across log and archive"
+
+
+def test_rotation_brings_the_file_under_budget(tmp_path):
+    f = _write(tmp_path, _log(60, body_bytes=1000))
+    p = clr.plan(f, budget=50_000)
+    clr.apply(f, p, repo_root=tmp_path)
+    assert f.stat().st_size < 50_000
+
+
+def test_refuses_to_write_when_an_entry_would_be_lost(tmp_path, monkeypatch):
+    """If the census fails, nothing is written and the log is left untouched.
+
+    Modelled on the real hazard rather than an artificial one: a bug in the
+    retained-log construction drops entries, and the result still looks
+    plausible — smaller, well-formed, no conflict, no finding. The census is the
+    only thing standing between that and lost history.
+    """
+    f = _write(tmp_path, _log(60, body_bytes=1000))
+    original = f.read_text(encoding="utf-8")
+    p = clr.plan(f, budget=50_000)
+
+    # Retained entries silently vanish while the archive is written correctly.
+    monkeypatch.setattr(clr, "_pointer_block", lambda existing, path, count: "")
+
+    with pytest.raises(RuntimeError, match="refusing to rotate"):
+        clr.apply(f, p, repo_root=tmp_path)
+
+    assert f.read_text(encoding="utf-8") == original, "log was modified despite the refusal"
+
+
+def test_archive_is_linked_so_it_is_not_an_orphan(tmp_path):
+    """An unlinked archive under docs/ is a DC7 orphan and fails the audit."""
+    f = _write(tmp_path, _log(60, body_bytes=1000))
+    p = clr.plan(f, budget=50_000)
+    clr.apply(f, p, repo_root=tmp_path)
+    log_text = f.read_text(encoding="utf-8")
+    assert p.archive_path.name in log_text, "archive is not linked from the log"
+
+
+def test_second_rotation_is_additive(tmp_path):
+    """Rotating again must not orphan the first archive's link."""
+    f = _write(tmp_path, _log(60, body_bytes=1000))
+    p1 = clr.plan(f, budget=50_000)
+    clr.apply(f, p1, repo_root=tmp_path)
+    first = p1.archive_path.name
+
+    f.write_text(f.read_text(encoding="utf-8") + _log(40, body_bytes=1000, start_day=1),
+                 encoding="utf-8")
+    p2 = clr.plan(f, budget=50_000)
+    if p2.needed:
+        clr.apply(f, p2, repo_root=tmp_path)
+        assert first in f.read_text(encoding="utf-8"), "first archive lost its link"
+
+
+def test_budget_matches_the_detector_that_enforces_it():
+    """A drifted constant would rotate to the wrong target and still fail OC2."""
+    assert clr.BUDGET_BYTES == 512_000
+    assert 0 < clr.TARGET_RATIO < clr.WARN_RATIO < 1.0


### PR DESCRIPTION
`.console/log.md` grows monotonically by construction: the pre-commit hook requires an entry on every source commit, and nothing ever removes one. At ~15KB per merged PR the 500KB cap arrives on a schedule — and when it does, **every open PR fails the gate at once**. That happened on 2026-08-17 and stalled five PRs until the log was rotated by hand.

## What this does

Rotation runs from the pre-commit hook at **80%** of budget, trimming back to **55%**. Rotating *at* the cap would be too late: the first commit to notice is already the one failing.

## Every write is gated on a census

A rotation rewrites the whole file, and a wholesale rewrite is precisely the operation that destroys log history silently — rebase one across another change to the same file and the other side's entries vanish, with **no conflict and no finding**, because OC2 measures size and a rotation is *supposed* to shrink the file. That nearly erased six entries earlier today.

So `apply()` recomputes every entry heading afterwards and refuses to write if even one would become unreachable. The hook treats that refusal as a hard commit failure, because a lost log entry leaves no other trace.

## Verified against real data

Not just fixtures — forcing a rotation on a copy of the live 241-entry log gave **111 kept + 130 archived = 241**, landing at 55.1% of budget. Against the current log it correctly reports no rotation due (74.1%, 132KB headroom).

## Two details

Archives are named for the date range they **actually contain**, not a cutoff. log.md is not strictly date-ordered — #498's archive claims "through 2026-06-14" while holding entries up to 2026-07-14.

Each archive is linked from a maintained block in log.md, because an unlinked file under `docs/` is a DC7 orphan and fails the audit.

8 tests, including the refusal path and link preservation across a second rotation. ruff, audit and the D12/DC10 ratchet all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)