### PR TITLE
refactor(adapters): put a seam under the board so Plane can be replaced

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,37 @@
+## 2026-08-17 — refactor(adapters): put a seam under the board, so Plane can leave
+
+Operator pushback, fairly made: the point of this work is for the ecosystem to
+stop using Plane, and a day of PR-queue maintenance had not moved that at all.
+
+**What the survey found.** 97 files mention Plane, which is not a work estimate.
+Sorted by actual coupling: 37 import `PlaneClient` directly, 11 already take a
+client as a parameter (correct already), and 47 only mention it in a comment or
+an env-var name. The operation surface is eleven methods. And ten files had
+independently hand-rolled the identical `_make_plane_client()` — the clearest
+possible evidence the missing piece was a shared one.
+
+**The seam.** `adapters/board` holds a `BoardClient` protocol and one
+`make_board_client()` factory. The protocol is the existing surface verbatim, not
+an improved one: a protocol that reshapes the API at the same time cannot be
+adopted mechanically, and a non-mechanical migration is where regressions hide.
+Twelve files now go through it; twelve hand-rolled constructors are gone. The
+remainder is a ratchet list that may only shrink, so the boundary tightens rather
+than erodes.
+
+**Three corrections to my own work, worth recording.** My migration script
+skipped four files whose imports were indented inside `if TYPE_CHECKING:` — it
+reported them rather than half-migrating, which was the right call. Twice I
+guessed from a test's filename which module it covered and broke tests for
+`board_unblock.py`, which is *not* migrated; the fix was to revert every test
+edit, run the suite, and take the files that actually failed. And four failures
+that appeared at full-suite scope but vanished in isolation turned out to be
+stale bytecode from those reverted edits — verified by purging `__pycache__` and
+running twice, rather than accepting "it passes now".
+
+Plane is not running (localhost:8080 → 404) and `spec_hygiene` has been failing
+against it every cycle, so the fleet already depends on something absent. That
+makes the seam overdue rather than premature.
+
 ## 2026-08-17 — chore(console): the watcher tag migration is done
 
 Moved "Migrate running watchers onto supervisor tags" from Up Next to Done. It

--- a/src/operations_center/adapters/board/__init__.py
+++ b/src/operations_center/adapters/board/__init__.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""The board seam: what the fleet needs from a task board, and one place to build it.
+
+OC's board is Plane today and will not be. Replacing it is currently a 37-file
+change, not because the surface is large — it is eleven operations — but because
+every one of those files imports `PlaneClient` by name, constructs it from the
+same four settings fields, and type-hints against the concrete class. Ten of them
+have independently hand-rolled the identical `_make_plane_client()` helper, which
+is the clearest possible evidence that the missing piece is a shared one.
+
+This module is that piece:
+
+* :class:`BoardClient` — the operations the fleet actually performs, named in
+  board terms rather than Plane's. Callers depend on this.
+* :func:`make_board_client` — the single construction site. Swapping backends
+  changes this function, not every caller.
+
+`PlaneClient` already satisfies the protocol structurally, so adopting this is a
+rename at each call site, not a behavioural change. That is deliberate: the
+migration should be boring and reviewable, and any behaviour change should be its
+own commit.
+
+Nothing outside ``adapters/`` should import `PlaneClient` directly.
+``tests/unit/adapters/test_board_seam.py`` enforces that against a shrinking
+allowlist, so the boundary tightens instead of eroding.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover
+    from operations_center.domain.models import BoardTask
+
+__all__ = ["BoardClient", "make_board_client"]
+
+
+@runtime_checkable
+class BoardClient(Protocol):
+    """The board operations the fleet performs.
+
+    Deliberately the *existing* surface, verbatim, rather than an idealised one.
+    A protocol that reshapes the API at the same time as introducing the seam
+    cannot be adopted mechanically, and a migration that is not mechanical is one
+    where regressions hide. Reshaping (for instance, `list_issues` growing a
+    filter so backends need not return the whole board) belongs in later commits,
+    once callers depend on this name instead of `PlaneClient`.
+    """
+
+    # ── reads ────────────────────────────────────────────────────────────────
+    def fetch_issue(self, task_id: str) -> dict[str, Any]: ...
+
+    def fetch_project(self) -> dict[str, Any]: ...
+
+    def list_issues(self) -> list[dict[str, Any]]: ...
+
+    def list_states(self) -> list[dict[str, Any]]: ...
+
+    def list_labels(self, *, force_refresh: bool = False) -> list[dict[str, Any]]: ...
+
+    def list_comments(self, task_id: str) -> list[dict[str, Any]]: ...
+
+    # ── translation into the domain ──────────────────────────────────────────
+    def to_board_task(self, issue: dict[str, Any]) -> BoardTask: ...
+
+    # ── writes ───────────────────────────────────────────────────────────────
+    def transition_issue(self, task_id: str, state: str) -> None: ...
+
+    def create_issue(
+        self,
+        *,
+        name: str,
+        description: str,
+        state: str | None = None,
+        label_names: list[str] | None = None,
+    ) -> dict[str, Any]: ...
+
+    def update_issue_description(self, task_id: str, description: str) -> None: ...
+
+    def update_issue_labels(self, task_id: str, label_names: list[str]) -> None: ...
+
+    def comment_issue(self, task_id: str, comment_markdown: str) -> None: ...
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def close(self) -> None: ...
+
+
+def make_board_client(settings: Any) -> BoardClient:
+    """Build the configured board client.
+
+    The one place that names a concrete backend. Every caller that used to
+    construct `PlaneClient` from `settings.plane.*` calls this instead, so
+    pointing the fleet at a different board is a change here and nowhere else.
+
+    Kept byte-compatible with the ten hand-rolled `_make_plane_client()` helpers
+    it replaces — same four fields, same token accessor — so adopting it cannot
+    change behaviour.
+    """
+    from operations_center.adapters.plane import PlaneClient
+
+    board = settings.plane
+    return PlaneClient(
+        base_url=board.base_url,
+        api_token=settings.plane_token(),
+        workspace_slug=board.workspace_slug,
+        project_id=board.project_id,
+    )

--- a/src/operations_center/entrypoints/board_worker/main.py
+++ b/src/operations_center/entrypoints/board_worker/main.py
@@ -56,14 +56,9 @@ def _load_settings(config_path: Path):
 
 
 def _plane_client(settings):
-    from operations_center.adapters.plane import PlaneClient
+    from operations_center.adapters.board import make_board_client
 
-    return PlaneClient(
-        base_url=settings.plane.base_url,
-        api_token=settings.plane_token(),
-        workspace_slug=settings.plane.workspace_slug,
-        project_id=settings.plane.project_id,
-    )
+    return make_board_client(settings)
 
 
 # ── Heartbeat ─────────────────────────────────────────────────────────────────

--- a/src/operations_center/entrypoints/maintenance/board_unblock_task.py
+++ b/src/operations_center/entrypoints/maintenance/board_unblock_task.py
@@ -30,7 +30,7 @@ import time
 from datetime import UTC, datetime
 
 from operations_center.adapters.github_pr import GitHubPRClient
-from operations_center.adapters.plane import PlaneClient
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.capability_ownership import verify_owner_or_degrade
 from operations_center.config.settings import Settings
 from operations_center.in_flight_reconcile import state_name as _state_name
@@ -148,7 +148,7 @@ def reconcile_merged_pr_tasks(
     return actions
 
 
-def apply_board_actions(client: PlaneClient, actions: list[dict], *, apply: bool) -> list[dict]:
+def apply_board_actions(client: BoardClient, actions: list[dict], *, apply: bool) -> list[dict]:
     """Apply transition actions to Plane (or annotate as dry-run). Mirrors the
     standalone CLI's apply loop so behaviour is identical in both call paths."""
     results: list[dict] = []
@@ -202,7 +202,7 @@ class BoardUnblockTask:
         stale_blocked_hours: int = 4,
         stale_running_hours: int = 2,
         clean_blocked_min_minutes: int = 5,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
         gh_client: GitHubPRClient | None = None,
     ) -> None:
         self._settings = settings
@@ -215,16 +215,10 @@ class BoardUnblockTask:
         self._plane_client = plane_client
         self._gh_client = gh_client
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def _make_gh_client(self) -> GitHubPRClient | None:
         if self._gh_client is not None:

--- a/src/operations_center/entrypoints/maintenance/detect_convergence_stall.py
+++ b/src/operations_center/entrypoints/maintenance/detect_convergence_stall.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from operations_center.adapters.board import make_board_client
 from operations_center.config import load_settings
 from operations_center.proposer.rejection_store import ProposalRejectionStore
 
@@ -188,14 +189,8 @@ def apply_breaker(
 
 
 def _plane_client(settings: Any):
-    from operations_center.adapters.plane import PlaneClient
 
-    return PlaneClient(
-        base_url=settings.plane.base_url,
-        api_token=settings.plane_token(),
-        workspace_slug=settings.plane.workspace_slug,
-        project_id=settings.plane.project_id,
-    )
+    return make_board_client(settings)
 
 
 def scan(settings: Any, *, threshold: int = DEFAULT_THRESHOLD) -> list[StalledFamily]:

--- a/src/operations_center/entrypoints/maintenance/drift_monitor_task.py
+++ b/src/operations_center/entrypoints/maintenance/drift_monitor_task.py
@@ -36,6 +36,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Mapping, cast
 
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.eval.corpus import load_ledger
 from operations_center.eval.critic import (
     EXTRACTION_KIND,
@@ -47,7 +48,6 @@ from operations_center.eval.panel_critic import run_panel_drift_monitor
 from operations_center.maintenance.contracts import MaintenanceResult
 
 if TYPE_CHECKING:
-    from operations_center.adapters.plane.client import PlaneClient
     from operations_center.maintenance.contracts import MaintenanceContext
 
 DEFAULT_INTERVAL_SECONDS = 21600  # 6h — drift is slow; model calls are not free
@@ -72,7 +72,7 @@ class DriftMonitorTask:
         corpus_path: Path = DEFAULT_CORPUS,
         extractor: CheckExtractor | None = None,
         votes: int = 3,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
         panel_families: list[str] | None = None,
         family_extractors: Mapping[str, CheckExtractor] | None = None,
         panel_enabled: bool | None = None,
@@ -105,18 +105,11 @@ class DriftMonitorTask:
             else bool(getattr(eval_panel, "enabled", False))
         )
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        from operations_center.adapters.plane.client import PlaneClient
 
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
         started = time.monotonic()
@@ -214,7 +207,7 @@ class DriftMonitorTask:
         return results
 
     @staticmethod
-    def _open_ticket_titles(client: PlaneClient) -> set[str]:
+    def _open_ticket_titles(client: BoardClient) -> set[str]:
         titles: set[str] = set()
         for issue in client.list_issues():
             name = str(issue.get("name", ""))

--- a/src/operations_center/entrypoints/maintenance/egress_probe.py
+++ b/src/operations_center/entrypoints/maintenance/egress_probe.py
@@ -33,10 +33,10 @@ import os
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.maintenance.contracts import MaintenanceResult
 
 if TYPE_CHECKING:
-    from operations_center.adapters.plane.client import PlaneClient
     from operations_center.maintenance.contracts import MaintenanceContext
 
 DEFAULT_INTERVAL_SECONDS = 300
@@ -92,7 +92,7 @@ class EgressProbeTask:
         allow_host: str = _ALLOW_HOST,
         deny_host: str = _DENY_HOST,
         probe_fn: Any = None,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
     ) -> None:
         self._settings = settings
         self.interval_seconds = interval_seconds
@@ -102,18 +102,11 @@ class EgressProbeTask:
         self._probe = probe_fn or _http_probe
         self._plane_client = plane_client
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        from operations_center.adapters.plane.client import PlaneClient
 
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
         started = time.monotonic()

--- a/src/operations_center/entrypoints/maintenance/heartbeat_stall.py
+++ b/src/operations_center/entrypoints/maintenance/heartbeat_stall.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.entrypoints.heartbeat import (
     is_live,
     read_heartbeat,
@@ -34,7 +35,6 @@ from operations_center.entrypoints.heartbeat import (
 from operations_center.maintenance.contracts import MaintenanceResult
 
 if TYPE_CHECKING:
-    from operations_center.adapters.plane.client import PlaneClient
     from operations_center.maintenance.contracts import MaintenanceContext
 
 DEFAULT_INTERVAL_SECONDS = 300
@@ -70,7 +70,7 @@ class HeartbeatStallTask:
         max_liveness_seconds: float = DEFAULT_MAX_LIVENESS_SECONDS,
         max_success_age_seconds: float = DEFAULT_MAX_SUCCESS_AGE_SECONDS,
         min_consecutive_failures: int = DEFAULT_MIN_CONSECUTIVE_FAILURES,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
     ) -> None:
         self._settings = settings
         self._status_dir = status_dir
@@ -133,18 +133,11 @@ class HeartbeatStallTask:
             "failed", started, details, error=f"watcher(s) live but stalled: {roles_str}"
         )
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        from operations_center.adapters.plane.client import PlaneClient
 
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def _open_fix_task(
         self, ctx: MaintenanceContext, stalled: list[dict[str, object]]

--- a/src/operations_center/entrypoints/maintenance/outcome_flagger_task.py
+++ b/src/operations_center/entrypoints/maintenance/outcome_flagger_task.py
@@ -18,6 +18,7 @@ import os
 import time
 from typing import TYPE_CHECKING, Any, Literal
 
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.eval.outcome_flagger import (
     Disagreement,
     OutcomeSource,
@@ -27,7 +28,6 @@ from operations_center.maintenance.contracts import MaintenanceResult
 
 if TYPE_CHECKING:
     from operations_center.adapters.github_pr import GitHubPRClient
-    from operations_center.adapters.plane.client import PlaneClient
     from operations_center.maintenance.contracts import MaintenanceContext
 
 DEFAULT_INTERVAL_SECONDS = 3600
@@ -51,7 +51,7 @@ class OutcomeFlaggerTask:
         interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
         enabled: bool = True,
         outcome_source: OutcomeSource | None = None,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
     ) -> None:
         self._settings = settings
         self.interval_seconds = interval_seconds
@@ -59,18 +59,11 @@ class OutcomeFlaggerTask:
         self._outcome_source = outcome_source
         self._plane_client = plane_client
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        from operations_center.adapters.plane.client import PlaneClient
 
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def _make_gh_client(self) -> GitHubPRClient | None:
         from operations_center.adapters.github_pr import GitHubPRClient
@@ -159,7 +152,7 @@ class OutcomeFlaggerTask:
         return results
 
     @staticmethod
-    def _open_ticket_titles(client: PlaneClient) -> set[str]:
+    def _open_ticket_titles(client: BoardClient) -> set[str]:
         titles: set[str] = set()
         for issue in client.list_issues():
             name = str(issue.get("name", ""))

--- a/src/operations_center/entrypoints/maintenance/parked_unpark_task.py
+++ b/src/operations_center/entrypoints/maintenance/parked_unpark_task.py
@@ -39,7 +39,7 @@ import logging
 import time
 from pathlib import Path
 
-from operations_center.adapters.plane import PlaneClient
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.config.settings import Settings
 from operations_center.evidence_fingerprints import evidence_fingerprint
 from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceResult
@@ -86,7 +86,7 @@ class ParkedUnparkTask:
         interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
         enabled: bool | None = None,
         store_path: Path | None = None,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
     ) -> None:
         self._settings = settings
         self.interval_seconds = interval_seconds
@@ -99,16 +99,10 @@ class ParkedUnparkTask:
         self._store_path = store_path or DEFAULT_PARKED_STORE_PATH
         self._plane_client = plane_client
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
         started = time.monotonic()

--- a/src/operations_center/entrypoints/maintenance/queue_healing_task.py
+++ b/src/operations_center/entrypoints/maintenance/queue_healing_task.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 import time
 
-from operations_center.adapters.plane import PlaneClient
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.config.settings import Settings
 from operations_center.maintenance.contracts import MaintenanceContext, MaintenanceResult
 
@@ -54,7 +54,7 @@ class QueueHealingTask:
         interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
         enabled: bool | None = None,
         apply: bool = True,
-        plane_client: PlaneClient | None = None,
+        plane_client: BoardClient | None = None,
     ) -> None:
         self._settings = settings
         self.interval_seconds = interval_seconds
@@ -67,16 +67,10 @@ class QueueHealingTask:
         self._apply = apply
         self._plane_client = plane_client
 
-    def _make_plane_client(self) -> PlaneClient:
+    def _make_plane_client(self) -> BoardClient:
         if self._plane_client is not None:
             return self._plane_client
-        p = self._settings.plane
-        return PlaneClient(
-            base_url=p.base_url,
-            api_token=self._settings.plane_token(),
-            workspace_slug=p.workspace_slug,
-            project_id=p.project_id,
-        )
+        return make_board_client(self._settings)
 
     def run_once(self, ctx: MaintenanceContext) -> MaintenanceResult:
         started = time.monotonic()

--- a/src/operations_center/entrypoints/maintenance/reconcile_merged_tasks.py
+++ b/src/operations_center/entrypoints/maintenance/reconcile_merged_tasks.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from operations_center.adapters.board import make_board_client
 from operations_center.adapters.github_pr import GitHubPRClient
 from operations_center.config import load_settings
 
@@ -158,14 +159,8 @@ def _merged_prs_recent(
 
 
 def _plane_client(settings: Any):
-    from operations_center.adapters.plane import PlaneClient
 
-    return PlaneClient(
-        base_url=settings.plane.base_url,
-        api_token=settings.plane_token(),
-        workspace_slug=settings.plane.workspace_slug,
-        project_id=settings.plane.project_id,
-    )
+    return make_board_client(settings)
 
 
 def scan(

--- a/src/operations_center/entrypoints/maintenance/triage_scan.py
+++ b/src/operations_center/entrypoints/maintenance/triage_scan.py
@@ -26,7 +26,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from operations_center.adapters.plane import PlaneClient
+from operations_center.adapters.board import BoardClient, make_board_client
 from operations_center.config import load_settings
 from operations_center.priority_scans import (
     handle_awaiting_input_scan,
@@ -48,12 +48,7 @@ def main() -> int:
     args = parser.parse_args()
 
     settings = load_settings(args.config)
-    client = PlaneClient(
-        base_url=settings.plane.base_url,
-        api_token=settings.plane_token(),
-        workspace_slug=settings.plane.workspace_slug,
-        project_id=settings.plane.project_id,
-    )
+    client = make_board_client(settings)
     try:
         items = client.list_issues()
     except Exception as exc:
@@ -265,7 +260,7 @@ def _queue_healing_actions(
 
 
 def apply_queue_healing_actions(
-    client: PlaneClient,
+    client: BoardClient,
     decisions: list[tuple["QueueHealingTask", "QueueHealingDecision"]],
     *,
     apply: bool,

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -389,14 +389,9 @@ def _github_client(settings):
 
 
 def _plane_client(settings):
-    from operations_center.adapters.plane import PlaneClient
+    from operations_center.adapters.board import make_board_client
 
-    return PlaneClient(
-        base_url=settings.plane.base_url,
-        api_token=settings.plane_token(),
-        workspace_slug=settings.plane.workspace_slug,
-        project_id=settings.plane.project_id,
-    )
+    return make_board_client(settings)
 
 
 def _owner_repo(clone_url: str) -> tuple[str, str]:

--- a/tests/unit/adapters/test_board_seam.py
+++ b/tests/unit/adapters/test_board_seam.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Hold the board seam, and make the remaining coupling shrink rather than drift.
+
+OC's board is Plane today and will not be. What makes replacing it expensive is
+not the surface — eleven operations — but that callers name `PlaneClient`
+directly, construct it from the same four settings fields, and type-hint against
+the concrete class. Ten of them had independently hand-rolled the identical
+`_make_plane_client()` helper.
+
+`operations_center.adapters.board` is the seam: a `BoardClient` protocol and one
+`make_board_client()` factory. These tests do two jobs:
+
+* pin the seam itself — the protocol matches what the fleet actually calls, and
+  the concrete client still satisfies it;
+* ratchet the migration — `STILL_IMPORTING_PLANE` is the accepted remainder, and
+  it may only shrink. A new file reaching past the boundary fails here, which is
+  the difference between a boundary and a suggestion.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parents[3] / "src" / "operations_center"
+
+#: Files that still import PlaneClient directly. This list may only get shorter.
+#: Deleting an entry as you migrate a file is the point; adding one is not
+#: allowed — route the new caller through `make_board_client` instead.
+STILL_IMPORTING_PLANE = {
+    "entrypoints/autonomy_cycle/main.py",
+    "entrypoints/ci_monitor/main.py",
+    "entrypoints/custodian_sweep/main.py",
+    "entrypoints/error_ingest/main.py",
+    "entrypoints/flow_audit/main.py",
+    "entrypoints/ghost_audit/main.py",
+    "entrypoints/maintenance/board_unblock.py",
+    "entrypoints/maintenance/cleanup_stale_backlog.py",
+    "entrypoints/maintenance/cleanup_state.py",
+    "entrypoints/maintenance/dependency_check.py",
+    "entrypoints/maintenance/orphan_branch_check.py",
+    "entrypoints/maintenance/recover_stale.py",
+    "entrypoints/promote_backlog/main.py",
+    "entrypoints/propagate/main.py",
+    "entrypoints/proposer/main.py",
+    "entrypoints/setup/main.py",
+    "entrypoints/smoke/plane.py",
+    "entrypoints/spec_hygiene/main.py",
+    "entrypoints/spec_trigger/main.py",
+    "priority_scans.py",
+    "propagation/plane_adapter.py",
+    "proposer/candidate_integration.py",
+    "proposer/guardrail_adapter.py",
+    "scheduled_tasks/runner.py",
+    "spec_author/spec_author_task.py",
+}
+
+_IMPORTS_PLANE = re.compile(
+    r"^[ \t]*from operations_center\.adapters\.plane(?:\.client)? import PlaneClient",
+    re.M,
+)
+
+
+def _importers() -> set[str]:
+    """Files outside adapters/ that import the concrete client."""
+    found = set()
+    for path in SRC.rglob("*.py"):
+        rel = path.relative_to(SRC).as_posix()
+        if rel.startswith("adapters/") or "__pycache__" in rel:
+            continue
+        if _IMPORTS_PLANE.search(path.read_text(encoding="utf-8", errors="replace")):
+            found.add(rel)
+    return found
+
+
+# ── the seam ─────────────────────────────────────────────────────────────────
+
+
+def test_the_concrete_client_satisfies_the_protocol():
+    """PlaneClient must remain usable as a BoardClient.
+
+    If it stops, callers type-hinting the protocol are lying about what they
+    accept, and the seam is decorative.
+    """
+    from operations_center.adapters.board import BoardClient
+    from operations_center.adapters.plane import PlaneClient
+
+    missing = [
+        name
+        for name in BoardClient.__protocol_attrs__
+        if not hasattr(PlaneClient, name)
+    ]
+    assert not missing, f"PlaneClient no longer provides: {missing}"
+
+
+def test_protocol_covers_every_operation_the_fleet_calls():
+    """The protocol is derived from real call sites, not from taste.
+
+    A protocol narrower than actual usage pushes callers back to the concrete
+    class, which is how the old boundary eroded.
+    """
+    from operations_center.adapters.board import BoardClient
+
+    required = {
+        "fetch_issue", "fetch_project", "list_issues", "list_states",
+        "list_labels", "list_comments", "to_board_task", "transition_issue",
+        "create_issue", "update_issue_description", "update_issue_labels",
+        "comment_issue", "close",
+    }
+    assert required <= set(BoardClient.__protocol_attrs__)
+
+
+def test_factory_builds_from_settings_without_naming_a_backend(monkeypatch):
+    """make_board_client is the one place a concrete backend is named."""
+    from operations_center.adapters import board
+
+    captured = {}
+
+    class _Fake:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.PlaneClient", _Fake, raising=False
+    )
+
+    class _Board:
+        base_url = "http://board.local"
+        workspace_slug = "ws"
+        project_id = "proj"
+
+    class _Settings:
+        plane = _Board()
+
+        def plane_token(self):
+            return "tok"
+
+    board.make_board_client(_Settings())
+    assert captured == {
+        "base_url": "http://board.local",
+        "api_token": "tok",
+        "workspace_slug": "ws",
+        "project_id": "proj",
+    }, "the factory changed the construction contract the callers relied on"
+
+
+# ── the ratchet ──────────────────────────────────────────────────────────────
+
+
+def test_no_new_file_reaches_past_the_boundary():
+    """The accepted remainder may shrink, never grow."""
+    actual = _importers()
+    added = sorted(actual - STILL_IMPORTING_PLANE)
+    assert not added, (
+        f"{len(added)} file(s) import PlaneClient directly without being on the "
+        f"accepted list: {added}. Use "
+        "`from operations_center.adapters.board import BoardClient, make_board_client` "
+        "instead — the point of the seam is that swapping the board is one change, "
+        "not one per caller."
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """A migrated file must be struck off, so the list measures real remaining work."""
+    actual = _importers()
+    stale = sorted(STILL_IMPORTING_PLANE - actual)
+    assert not stale, (
+        f"{len(stale)} file(s) no longer import PlaneClient but are still listed: "
+        f"{stale}. Remove them from STILL_IMPORTING_PLANE."
+    )
+
+
+@pytest.mark.parametrize("migrated", [
+    "entrypoints/maintenance/board_unblock_task.py",
+    "entrypoints/maintenance/detect_convergence_stall.py",
+    "entrypoints/maintenance/drift_monitor_task.py",
+    "entrypoints/maintenance/egress_probe.py",
+    "entrypoints/maintenance/heartbeat_stall.py",
+    "entrypoints/maintenance/outcome_flagger_task.py",
+    "entrypoints/maintenance/parked_unpark_task.py",
+    "entrypoints/maintenance/queue_healing_task.py",
+    "entrypoints/maintenance/reconcile_merged_tasks.py",
+    "entrypoints/maintenance/triage_scan.py",
+])
+def test_migrated_files_stay_migrated(migrated):
+    """Pin this slice so it cannot quietly regress."""
+    text = (SRC / migrated).read_text(encoding="utf-8")
+    assert "PlaneClient" not in text, f"{migrated} names PlaneClient again"
+    assert "adapters.board" in text, f"{migrated} no longer uses the seam"
+
+
+def test_the_hand_rolled_factories_are_gone():
+    """Ten copies of the same constructor was the evidence the seam was missing."""
+    remaining = [
+        p.relative_to(SRC).as_posix()
+        for p in SRC.rglob("*.py")
+        if "__pycache__" not in p.as_posix()
+        and re.search(r"def _(?:make_)?plane_client\b", p.read_text(encoding="utf-8", errors="replace"))
+        and re.search(r"PlaneClient\(", p.read_text(encoding="utf-8", errors="replace"))
+    ]
+    assert not remaining, (
+        f"{len(remaining)} file(s) still hand-roll the client constructor: {remaining}"
+    )

--- a/tests/unit/entrypoints/maintenance/test_board_unblock_task.py
+++ b/tests/unit/entrypoints/maintenance/test_board_unblock_task.py
@@ -6,7 +6,7 @@ These pin both halves of the fix for the unwired board-unblock engine:
   - reconcile_merged_pr_tasks turns a Blocked/In-Review task whose PR MERGED into
     a Done transition (the #267/#341 fixture), and does NOT touch open/no-PR tasks.
   - BoardUnblockTask satisfies the MaintenanceTask contract and applies actions
-    via an injected PlaneClient, so registering it in the live loop makes the
+    via an injected board client, so registering it in the live loop makes the
     controller self-heal the board.
 """
 
@@ -221,7 +221,7 @@ class TestBoardUnblockTask:
         ]
         with (
             mock.patch(
-                "operations_center.entrypoints.maintenance.board_unblock_task.PlaneClient",
+                "operations_center.entrypoints.maintenance.board_unblock_task.make_board_client",
                 return_value=mock_client_instance,
             ),
             mock.patch(

--- a/tests/unit/entrypoints/maintenance/test_triage_scan_cov.py
+++ b/tests/unit/entrypoints/maintenance/test_triage_scan_cov.py
@@ -258,7 +258,7 @@ def patched(monkeypatch):
     """Patch all main() collaborators; return a control namespace."""
     client = _make_client()
     monkeypatch.setattr(mod, "load_settings", lambda cfg: _settings())
-    monkeypatch.setattr(mod, "PlaneClient", lambda **kw: client)
+    monkeypatch.setattr(mod, "make_board_client", lambda *a, **k: client)
     monkeypatch.setattr(mod, "handle_priority_rescore_scan", lambda items, now: [])
     monkeypatch.setattr(mod, "handle_awaiting_input_scan", lambda items, c, state_name: [])
     monkeypatch.setattr(mod, "_queue_healing_actions", lambda items, now: [])


### PR DESCRIPTION
Step one of getting the ecosystem off Plane. Not a swap — the seam that makes a
swap a contained change instead of a 37-file rewrite.

## What the survey actually found

"97 files reference Plane" is not a work estimate. Sorted by real coupling:

| | files | |
|---|---|---|
| imports `PlaneClient` directly | **37** | the actual job |
| calls methods on an injected client | 11 | already decoupled |
| mentions it in a comment or env-var name | 47 | no work for a swap |

The operation surface is **eleven methods**. And ten files had independently
hand-rolled the identical `_make_plane_client()` helper — the clearest possible
evidence that the missing piece was a shared one.

## The seam

`adapters/board` adds a `BoardClient` protocol and one `make_board_client()`
factory — the single place a concrete backend is named.

The protocol is the **existing surface verbatim**, not an improved one. A
protocol that reshapes the API while introducing the seam cannot be adopted
mechanically, and a non-mechanical migration is where regressions hide.
Reshaping (say, `list_issues` growing a filter so a backend needn't return the
whole board) belongs in later commits, once callers depend on this name.

**12 files migrated. All 12 hand-rolled constructors gone.** The remaining 25 sit
in a ratchet list that may only shrink — a new file reaching past the boundary
fails CI, which is the difference between a boundary and a suggestion.

## Three corrections to my own work

The migration script **skipped four files** whose imports were indented inside
`if TYPE_CHECKING:`, reporting them rather than half-migrating. That was the
right call and I fixed them in a second pass.

Twice I guessed from a test's filename which module it covered, and broke tests
for `board_unblock.py` — which is *not* migrated. The fix was to revert every
test edit, run the suite, and take the files that genuinely failed: exactly two.

Four failures appeared at full-suite scope but passed in isolation. They were
**stale bytecode** from those reverted edits, confirmed by purging `__pycache__`
and running twice — not accepted as "it passes now".

## Verification

- Full unit suite: **8614 passed**, from purged bytecode, twice
- Every migrated module imports cleanly
- ruff, audit, D12/DC10 ratchet: clean
- No file-mode changes

## Context

Plane is not running (`localhost:8080` → 404) and `spec_hygiene` fails against it
every cycle, so the fleet already depends on something absent. The seam is overdue
rather than premature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
