### PR TITLE
feat(detectors): warn at 80% of the .console/ budget

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-08-17 — feat(detectors): warn at 80% of the .console/ budget
+
+The budget is a cliff. Fine at 99%, and at 101% every open PR fails the gate at
+once — which is what happened today, blocking five until the log was rotated by
+hand. Nothing warned beforehand.
+
+OC2 now writes an advisory to stderr between 80% and 100%. Deliberately **not** a
+finding: findings fail the audit at every severity, so raising one at 80% would
+move the cliff earlier rather than remove it. The advisory reaches pre-push and CI
+output while the push still succeeds.
+
+Verified at four sizes — 75% silent, 80% and 95% advise without a finding, 105%
+fails as before. The repo today is at 75%, so nothing fires.
+
+**Correcting an earlier estimate of mine.** I said log.md grows ~15KB per PR and
+had ~9 PRs of headroom. That was measured across a day dominated by seven stale
+PRs each carrying months of accumulated July entries (+60KB, +17KB, +10KB).
+Ordinary PRs add ~1.8KB: the last five were +2127, +1982, +886, +2067, +2106. At
+384,352 of 512,000 the real headroom is ~70 PRs, not 9. The budget did not need
+raising; it needed a warning.
+
+Why the file grows at all: the fleet merged 191 of 200 PRs (95.5%), and the
+pre-commit hook requires a log entry on every one. ~200 PRs x ~1.8KB is roughly
+the whole file. It grows because the fleet ships, not because anything is wrong.
+
 ## 2026-08-17 — fix(adapters): repair the board seam, and the gap that let it merge red
 
 #503 merged with CI red. Worth being precise about how, because two separate

--- a/.custodian/detectors.py
+++ b/.custodian/detectors.py
@@ -33,6 +33,8 @@ Superseded and removed (native Custodian covers them):
 
 from __future__ import annotations
 
+import sys as _sys
+
 import ast
 import re
 from pathlib import Path
@@ -69,6 +71,10 @@ def _detect_r1_console_presence(ctx: AuditContext) -> DetectorResult:
 
 _TASK_SIZE_LIMIT = 100 * 1024  # 100 KB (task.md should remain concise)
 _CONSOLE_SIZE_LIMIT = 500 * 1024  # 500 KB (log.md grows through legitimate operational history)
+# Warn while there is still room to act. The budget is otherwise a cliff: fine at
+# 99%, and at 101% every open PR fails the gate at once — which is exactly what
+# happened on 2026-08-17, blocking five of them until the log was rotated by hand.
+_CONSOLE_WARN_RATIO = 0.80
 _TASK_REQUIRED_SECTIONS = ["## Objective", "## Overall Plan", "## Current Stage"]
 _BACKLOG_STANDARD_SECTIONS = ["## In Progress", "## Up Next", "## Done"]
 
@@ -241,6 +247,18 @@ def _detect_r2_console_budget(ctx: AuditContext) -> DetectorResult:
             limit_kb = size_limit // 1024
             if size > size_limit:
                 samples.append(f".console/{filename} exceeds {limit_kb}KB budget ({size} bytes)")
+            elif size >= size_limit * _CONSOLE_WARN_RATIO:
+                # Advisory, NOT a finding. Findings fail the audit at every
+                # severity, so reporting this as one would just move the cliff
+                # from 100% to 80%. stderr reaches pre-push and CI output while
+                # the push still succeeds.
+                pct = 100.0 * size / size_limit
+                _sys.stderr.write(
+                    f"[OC2] .console/{filename} is at {pct:.0f}% of its {limit_kb}KB "
+                    f"budget ({size:,} bytes, {size_limit - size:,} to spare) — "
+                    f"rotate older entries to docs/history/ before it blocks every "
+                    f"open PR at once\n"
+                )
         except OSError:
             samples.append(f".console/{filename} cannot be read (permission denied)")
 


### PR DESCRIPTION
The budget is a cliff: fine at 99%, and at 101% **every open PR fails the gate at once**. That happened today and blocked five PRs until the log was rotated by hand. Nothing warned beforehand.

OC2 now writes an advisory to stderr between 80% and 100%.

**Deliberately not a finding.** Findings fail the audit at every severity — LOW included — so raising one at 80% would move the cliff earlier rather than remove it. stderr reaches pre-push and CI output while the push still succeeds. A nudge, not a gate.

## Verified at four sizes

| size | finding | advisory |
|---|---|---|
| 75% | no | no |
| 80% | no | **yes** |
| 95% | no | **yes** |
| 105% | **yes** | no |

The repo is at 75% today, so nothing fires. The detector's 14 existing tests still pass.

Uses `_sys.stderr.write` rather than `print`, since T201 forbids print here — avoiding the lint rather than suppressing it.

## A correction worth recording

I previously estimated ~15KB growth per PR and ~9 PRs of headroom. That was measured across a day dominated by seven stale PRs each carrying months of accumulated log entries (+60KB, +17KB, +10KB). Ordinary PRs add ~1.8KB — the last five were +2127, +1982, +886, +2067, +2106. Real headroom is **~70 PRs**, not 9. The budget did not need raising; it needed a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)