### PR TITLE
refactor(adapters): put a seam under the PR client so the forge can be replaced

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,28 @@
+## 2026-08-17 — PR seam extracted (protocol only, review stays on GitHub)
+
+Operator chose the spec's sequencing alternative: extract `PRClient` now, keep
+review on GitHub until the `enforce_admins` question is settled.
+
+`operations_center.adapters.pr` now holds the protocol (30 operations), the
+`make_pr_client()` factory, and the two pure helpers that were static methods on
+`GitHubPRClient` — `owner_repo_from_clone_url` and `has_thumbs_up`. The class
+keeps both as delegates so the migration is incremental.
+
+Correction to the spec's B7: it counted the *reviewer's* four references and
+called the ratchet trivial. Repo-wide it is **17 files**, and 13 of those want
+only the clone-URL parse — a pure function reached through a forge client. That
+is the cheap half of the migration and the most clearly mis-coupled.
+
+Deliberately no backend switch in the factory: no Forgejo PR client exists, and
+a config knob selecting an unbuildable backend advertises a capability the fleet
+does not have.
+
+Found while verifying: CI runs only `tests/unit`, `tests/test_pr_review_watcher.py`,
+`tests/integration/reviewer` and `tests/integration/observer`. About 1,830 tests
+under `tests/maintenance/`, `tests/observer/` and top-level `tests/test_*.py`
+never run in the gate — 7 of them are currently red on main, one of which is a
+regression from #509 (the board factory rejects a MagicMock `board_backend`).
+
 ## 2026-08-17 — Forgejo PR adapter spec (adversarial)
 
 Specced the PR-side Forgejo adapter (`docs/specs/forgejo-pr-adapter.md`), the

--- a/src/operations_center/adapters/github_pr.py
+++ b/src/operations_center/adapters/github_pr.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import re
 import time
 from typing import Any
 
@@ -86,13 +85,17 @@ class GitHubPRClient:
 
     @staticmethod
     def owner_repo_from_clone_url(clone_url: str) -> tuple[str, str]:
-        """Parse owner/repo from an https or ssh clone URL."""
-        # ssh: git@github.com:owner/repo.git
-        # https: https://github.com/owner/repo.git
-        m = re.search(r"[:/]([^/]+)/([^/]+?)(?:\.git)?$", clone_url)
-        if not m:
-            raise ValueError(f"Cannot parse owner/repo from clone URL: {clone_url!r}")
-        return m.group(1), m.group(2)
+        """Parse owner/repo from an https or ssh clone URL.
+
+        The parse is forge-agnostic and now lives at the seam
+        (:func:`operations_center.adapters.pr.owner_repo_from_clone_url`); this
+        stays as a delegate so the callers still reaching it through this class
+        keep working while they migrate. Imported inside the function to keep
+        the two modules free of an import cycle.
+        """
+        from operations_center.adapters.pr import owner_repo_from_clone_url
+
+        return owner_repo_from_clone_url(clone_url)
 
     def create_pr(
         self,
@@ -621,7 +624,10 @@ class GitHubPRClient:
 
     @staticmethod
     def has_thumbs_up(reactions: list[dict]) -> bool:
-        return any(r["content"] == "+1" for r in reactions)
+        """Delegate to the seam — see :meth:`owner_repo_from_clone_url`."""
+        from operations_center.adapters.pr import has_thumbs_up
+
+        return has_thumbs_up(reactions)
 
     def create_and_merge(
         self,

--- a/src/operations_center/adapters/pr/__init__.py
+++ b/src/operations_center/adapters/pr/__init__.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""The PR seam: what the fleet needs from a forge, and one place to build it.
+
+The board got this treatment first, for the same reason it is wanted here: every
+caller named the concrete client, so swapping the backend was a change in every
+caller rather than in one place. On the PR side that is seventeen files in
+``src/`` naming :class:`GitHubPRClient` today.
+
+Thirteen of those seventeen do not want a client at all. They want
+``owner_repo_from_clone_url`` — a pure parse of ``host/owner/repo`` that has
+nothing to do with GitHub, reached through the GitHub class because that is where
+it happened to live. Those callers are the cheapest to migrate and the most
+clearly mis-coupled, which is why the helper is a module function here.
+
+This module is the seam:
+
+* :class:`PRClient` — the operations the fleet performs against a forge. Callers
+  depend on this name.
+* :func:`make_pr_client` — the single construction site.
+* :func:`owner_repo_from_clone_url`, :func:`has_thumbs_up` — the two pure helpers
+  that were static methods on the client, and needed an instance of nothing.
+
+`GitHubPRClient` satisfies the protocol structurally, so adopting this is a
+rename at each call site rather than a behaviour change. That is deliberate: a
+migration that is not mechanical is one where regressions hide.
+
+**This seam does not make review portable on its own.** ``docs/specs/forgejo-pr-adapter.md``
+records why: Forgejo has no Checks API, and ``enforce_admins`` — which
+``_branch_protection_ok`` requires before any self-merge — has no equivalent
+there. Those are unresolved design questions, not missing code, and
+:func:`make_pr_client` deliberately has no second backend until they are answered.
+What the seam buys today is that answering them later is a change here rather
+than in seventeen callers.
+
+``tests/unit/adapters/test_pr_seam.py`` holds the boundary against a shrinking
+allowlist.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "PRClient",
+    "has_thumbs_up",
+    "make_pr_client",
+    "owner_repo_from_clone_url",
+]
+
+
+@runtime_checkable
+class PRClient(Protocol):
+    """The forge operations the fleet performs.
+
+    Deliberately the *existing* surface, verbatim, rather than an idealised one —
+    the same choice :class:`~operations_center.adapters.board.BoardClient` made,
+    for the same reason. Reshaping the API and introducing the seam in one step
+    produces a migration that cannot be reviewed mechanically.
+
+    Two known-GitHub-shaped operations are declared here as they exist rather
+    than as they ought to be: :meth:`get_check_runs` (GitHub Checks, which Forgejo
+    does not implement) and :meth:`get_branch_protection` (whose return shape the
+    reviewer reads for ``required_status_checks.contexts`` and
+    ``enforce_admins.enabled``). Declaring them honestly keeps the protocol a
+    description of what callers actually depend on. Changing them is the work the
+    Forgejo spec scopes, and it belongs in its own commit.
+    """
+
+    # ── pull requests ────────────────────────────────────────────────────────
+    def create_pr(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        head: str,
+        base: str,
+        title: str,
+        body: str = "",
+    ) -> dict: ...
+
+    def get_pr(self, owner: str, repo: str, pr_number: int) -> dict: ...
+
+    def merge_pr(
+        self, owner: str, repo: str, pr_number: int, *, merge_method: str = "squash"
+    ) -> dict: ...
+
+    def close_pr(self, owner: str, repo: str, pr_number: int) -> dict: ...
+
+    def list_open_prs(self, owner: str, repo: str) -> list[dict]: ...
+
+    def list_closed_prs(self, owner: str, repo: str) -> list[dict]: ...
+
+    def find_pr_by_head(self, owner: str, repo: str, head_ref: str) -> dict | None: ...
+
+    def get_mergeable(self, owner: str, repo: str, pr_number: int) -> bool | None: ...
+
+    def update_pr_description(
+        self, owner: str, repo: str, pr_number: int, body: str
+    ) -> dict: ...
+
+    def create_and_merge(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        head: str,
+        base: str,
+        title: str,
+        body: str = "",
+        merge_method: str = "squash",
+    ) -> str: ...
+
+    # ── diffs and files ──────────────────────────────────────────────────────
+    def list_pr_files(self, owner: str, repo: str, pr_number: int) -> list[str]: ...
+
+    def get_pr_diff(self, owner: str, repo: str, pr_number: int) -> str: ...
+
+    def get_file_content(
+        self, owner: str, repo: str, path: str, ref: str
+    ) -> tuple[str, str] | None: ...
+
+    def update_file(
+        self,
+        owner: str,
+        repo: str,
+        path: str,
+        *,
+        new_text: str,
+        message: str,
+        branch: str,
+        blob_sha: str,
+    ) -> bool: ...
+
+    # ── review ───────────────────────────────────────────────────────────────
+    def list_pr_comments(self, owner: str, repo: str, pr_number: int) -> list[dict]: ...
+
+    def list_pr_review_comments(
+        self, owner: str, repo: str, pr_number: int
+    ) -> list[dict]: ...
+
+    def list_pr_reviews(self, owner: str, repo: str, pr_number: int) -> list[dict]: ...
+
+    def pr_has_changes_requested(
+        self, owner: str, repo: str, pr_number: int
+    ) -> bool: ...
+
+    def post_comment(self, owner: str, repo: str, pr_number: int, body: str) -> dict: ...
+
+    def update_comment(self, owner: str, repo: str, comment_id: int, body: str) -> dict: ...
+
+    def get_pr_reactions(self, owner: str, repo: str, pr_number: int) -> list[dict]: ...
+
+    def get_comment_reactions(
+        self, owner: str, repo: str, comment_id: int
+    ) -> list[dict]: ...
+
+    # ── CI signal ────────────────────────────────────────────────────────────
+    def set_commit_status(
+        self,
+        owner: str,
+        repo: str,
+        sha: str,
+        *,
+        state: str,
+        context: str,
+        description: str = "",
+        target_url: str | None = None,
+    ) -> dict: ...
+
+    def get_check_runs(self, owner: str, repo: str, ref: str) -> list[dict]: ...
+
+    def get_failed_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]: ...
+
+    def get_incomplete_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]: ...
+
+    def get_completed_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]: ...
+
+    # ── branches ─────────────────────────────────────────────────────────────
+    def get_branch_head(self, owner: str, repo: str, branch: str) -> str | None: ...
+
+    def get_branch_protection(
+        self, owner: str, repo: str, branch: str
+    ) -> dict | None: ...
+
+    def delete_branch(self, owner: str, repo: str, branch: str) -> None: ...
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+#
+# Both were static methods on `GitHubPRClient`. Neither touches the network, the
+# token, or `self`; callers were importing a client class to reach a function.
+
+
+_CLONE_URL_RE = re.compile(r"[:/]([^/]+)/([^/]+?)(?:\.git)?$")
+
+
+def owner_repo_from_clone_url(clone_url: str) -> tuple[str, str]:
+    """Parse owner/repo from an https or ssh clone URL.
+
+    Forge-agnostic by construction — it matches the last two path segments, so a
+    Forgejo or self-hosted URL parses exactly as a GitHub one does::
+
+        git@github.com:owner/repo.git
+        https://github.com/owner/repo.git
+        https://forge.internal/owner/repo.git
+    """
+    m = _CLONE_URL_RE.search(clone_url)
+    if not m:
+        raise ValueError(f"Cannot parse owner/repo from clone URL: {clone_url!r}")
+    return m.group(1), m.group(2)
+
+
+def has_thumbs_up(reactions: list[dict]) -> bool:
+    """True if any reaction is a 👍."""
+    return any(r["content"] == "+1" for r in reactions)
+
+
+# ── construction ─────────────────────────────────────────────────────────────
+
+
+def make_pr_client(settings: Any) -> PRClient:
+    """Build the configured PR client.
+
+    The one place that names a concrete forge. Kept byte-compatible with the
+    construction every caller already performs — `settings.git_token()`, then the
+    client — so adopting it cannot change behaviour.
+
+    There is intentionally no backend switch yet. The board factory has one
+    because a Forgejo board client exists; no Forgejo PR client does, and
+    ``docs/specs/forgejo-pr-adapter.md`` argues it should not be written before
+    the ``enforce_admins`` question is settled. A config knob selecting a backend
+    that cannot be built would advertise a capability the fleet does not have.
+    """
+    token = settings.git_token()
+    if not token:
+        raise RuntimeError("no git token — set GIT_TOKEN in .env")
+
+    from operations_center.adapters.github_pr import GitHubPRClient
+
+    return GitHubPRClient(token)

--- a/tests/unit/adapters/test_pr_seam.py
+++ b/tests/unit/adapters/test_pr_seam.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Hold the PR seam, and make the remaining coupling shrink rather than drift.
+
+Seventeen files in ``src/`` name :class:`GitHubPRClient` directly. Thirteen of
+them do so only to reach ``owner_repo_from_clone_url``, a pure URL parse that
+never needed a client. That is the shape the board seam had before it was
+migrated, and the same ratchet applies:
+
+* pin the seam — the protocol matches what the fleet actually calls, and the
+  concrete client still satisfies it;
+* ratchet the migration — ``STILL_IMPORTING_GITHUB_PR`` is the accepted
+  remainder, and it may only shrink. A new file reaching past the boundary fails
+  here, which is the difference between a boundary and a suggestion.
+
+Unlike the board, there is no second backend to migrate *to* yet, and
+``docs/specs/forgejo-pr-adapter.md`` argues there should not be one until the
+``enforce_admins`` question is answered. So there is deliberately no
+``test_the_migration_is_finished`` here: finishing is not yet defined. What these
+tests protect is that the cost of finishing stays flat instead of growing.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parents[3] / "src" / "operations_center"
+
+#: Files that still name the concrete client. Burn-down list — entries come off
+#: as callers move to `adapters.pr`; nothing may be added without moving the
+#: boundary backwards.
+#:
+#: Marked with why each one holds the name, because the reason determines how
+#: cheap it is to migrate:
+#:   (parse)  — only wants `owner_repo_from_clone_url`; migrating is an import swap
+#:   (hint)   — type annotation only; becomes `PRClient`
+#:   (build)  — constructs a client; becomes `make_pr_client(settings)`
+STILL_IMPORTING_GITHUB_PR = {
+    "entrypoints/board_worker/_subprocess.py",           # parse
+    "entrypoints/board_worker/claim.py",                 # parse + build
+    "entrypoints/ci_monitor/main.py",                    # parse + build
+    "entrypoints/maintenance/audit_close_receipts.py",   # parse + build
+    "entrypoints/maintenance/board_unblock.py",          # parse + build + hint
+    "entrypoints/maintenance/board_unblock_task.py",     # parse + build + hint
+    "entrypoints/maintenance/check_regressions.py",      # parse + build
+    "entrypoints/maintenance/close_stale_prs.py",        # parse + build
+    "entrypoints/maintenance/console_repair.py",         # hint
+    "entrypoints/maintenance/orphan_branch_check.py",    # parse + build + hint
+    "entrypoints/maintenance/outcome_flagger_task.py",   # build
+    "entrypoints/maintenance/reconcile_merged_tasks.py", # parse + build + hint
+    "entrypoints/pr_review_watcher/main.py",             # parse + build
+    "eval/outcome_sources.py",                           # hint
+    "execution/workspace.py",                            # parse + build
+    "observer/collectors/ci_history.py",                 # parse + build
+    "post_merge_regression.py",                          # hint
+}
+
+_IMPORTS_GITHUB_PR = re.compile(
+    r"^[ \t]*from operations_center\.adapters\.github_pr import",
+    re.M,
+)
+
+
+def _importers() -> set[str]:
+    """Files outside adapters/ that import the concrete client."""
+    found = set()
+    for path in SRC.rglob("*.py"):
+        rel = path.relative_to(SRC).as_posix()
+        if rel.startswith("adapters/") or "__pycache__" in rel:
+            continue
+        if _IMPORTS_GITHUB_PR.search(path.read_text(encoding="utf-8", errors="replace")):
+            found.add(rel)
+    return found
+
+
+# ── the seam ─────────────────────────────────────────────────────────────────
+
+
+#: The forge operations, named once. Derived from the concrete client's public
+#: surface, not from taste — a protocol narrower than real usage pushes callers
+#: back to the concrete class, which is the failure the board seam already hit
+#: once with `set_priority`.
+PR_OPERATIONS = frozenset({
+    # pull requests
+    "create_pr", "get_pr", "merge_pr", "close_pr", "list_open_prs",
+    "list_closed_prs", "find_pr_by_head", "get_mergeable",
+    "update_pr_description", "create_and_merge",
+    # diffs and files
+    "list_pr_files", "get_pr_diff", "get_file_content", "update_file",
+    # review
+    "list_pr_comments", "list_pr_review_comments", "list_pr_reviews",
+    "pr_has_changes_requested", "post_comment", "update_comment",
+    "get_pr_reactions", "get_comment_reactions",
+    # CI signal
+    "set_commit_status", "get_check_runs", "get_failed_checks",
+    "get_incomplete_checks", "get_completed_checks",
+    # branches
+    "get_branch_head", "get_branch_protection", "delete_branch",
+})
+
+
+def _declared_operations(proto: type) -> set[str]:
+    """Public members a Protocol declares.
+
+    Deliberately not `__protocol_attrs__`: that is a CPython internal added in
+    3.12. Using it made the board seam's tests pass on a 3.12 developer machine
+    and fail on CI's 3.11 with `AttributeError`. `dir()` is stable across both.
+    """
+    return {n for n in dir(proto) if not n.startswith("_")}
+
+
+def test_the_concrete_client_satisfies_the_protocol():
+    """GitHubPRClient must remain usable as a PRClient.
+
+    If it stops, callers type-hinting the protocol are lying about what they
+    accept, and the seam is decorative.
+    """
+    from operations_center.adapters.github_pr import GitHubPRClient
+
+    missing = sorted(op for op in PR_OPERATIONS if not hasattr(GitHubPRClient, op))
+    assert not missing, f"GitHubPRClient no longer provides: {missing}"
+
+
+def test_protocol_declares_every_operation_the_fleet_calls():
+    """The protocol must not be narrower than actual usage."""
+    from operations_center.adapters.pr import PRClient
+
+    declared = _declared_operations(PRClient)
+    missing = sorted(PR_OPERATIONS - declared)
+    assert not missing, f"PRClient does not declare: {missing}"
+
+
+def test_protocol_declares_nothing_the_client_lacks():
+    """And not wider, either — a declared-but-absent operation fails at runtime."""
+    from operations_center.adapters.github_pr import GitHubPRClient
+    from operations_center.adapters.pr import PRClient
+
+    phantom = sorted(
+        op for op in _declared_operations(PRClient) if not hasattr(GitHubPRClient, op)
+    )
+    assert not phantom, f"PRClient declares operations GitHubPRClient lacks: {phantom}"
+
+
+# ── construction ─────────────────────────────────────────────────────────────
+
+
+def test_factory_builds_from_settings_without_naming_a_backend(monkeypatch):
+    """make_pr_client is the one place a concrete forge is named."""
+    from operations_center.adapters import pr
+
+    captured = {}
+
+    class _Fake:
+        def __init__(self, token):
+            captured["token"] = token
+
+    monkeypatch.setattr(
+        "operations_center.adapters.github_pr.GitHubPRClient", _Fake, raising=False
+    )
+
+    class _Settings:
+        def git_token(self):
+            return "tok"
+
+    pr.make_pr_client(_Settings())
+    assert captured == {"token": "tok"}, (
+        "the factory changed the construction contract the callers relied on"
+    )
+
+
+def test_factory_refuses_without_a_token():
+    """Same failure the seventeen callers already produce, in one place.
+
+    Silently building a tokenless client would turn a startup error into an
+    authentication failure inside the first API call, which is far harder to read
+    in a daemon log.
+    """
+    from operations_center.adapters import pr
+
+    class _Settings:
+        def git_token(self):
+            return None
+
+    with pytest.raises(RuntimeError, match="no git token"):
+        pr.make_pr_client(_Settings())
+
+
+# ── the pure helpers ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/ProtocolWarden/OperationsCenter.git", ("ProtocolWarden", "OperationsCenter")),
+        ("https://github.com/ProtocolWarden/OperationsCenter", ("ProtocolWarden", "OperationsCenter")),
+        ("git@github.com:ProtocolWarden/OperationsCenter.git", ("ProtocolWarden", "OperationsCenter")),
+        # the reason this helper belongs at the seam and not on the GitHub client
+        ("https://forge.internal/ProtocolWarden/OperationsCenter.git", ("ProtocolWarden", "OperationsCenter")),
+        ("git@forge.internal:ProtocolWarden/OperationsCenter.git", ("ProtocolWarden", "OperationsCenter")),
+    ],
+)
+def test_owner_repo_parses_any_forge(url, expected):
+    from operations_center.adapters.pr import owner_repo_from_clone_url
+
+    assert owner_repo_from_clone_url(url) == expected
+
+
+def test_owner_repo_rejects_unparseable():
+    from operations_center.adapters.pr import owner_repo_from_clone_url
+
+    with pytest.raises(ValueError, match="Cannot parse owner/repo"):
+        owner_repo_from_clone_url("not-a-url")
+
+
+def test_has_thumbs_up():
+    from operations_center.adapters.pr import has_thumbs_up
+
+    assert has_thumbs_up([{"content": "+1"}])
+    assert has_thumbs_up([{"content": "eyes"}, {"content": "+1"}])
+    assert not has_thumbs_up([{"content": "-1"}])
+    assert not has_thumbs_up([])
+
+
+def test_the_class_helpers_still_delegate():
+    """The thirteen unmigrated callers must keep working while they migrate.
+
+    Moving the implementation to the seam and leaving the static methods behind
+    as delegates is what makes this migration incremental rather than a
+    seventeen-file atomic change.
+    """
+    from operations_center.adapters.github_pr import GitHubPRClient
+    from operations_center.adapters import pr
+
+    url = "git@github.com:owner/repo.git"
+    assert GitHubPRClient.owner_repo_from_clone_url(url) == pr.owner_repo_from_clone_url(url)
+    assert GitHubPRClient.has_thumbs_up([{"content": "+1"}]) is True
+    assert GitHubPRClient.has_thumbs_up([{"content": "-1"}]) is False
+
+
+# ── the ratchet ──────────────────────────────────────────────────────────────
+
+
+def test_no_new_file_reaches_past_the_boundary():
+    """The accepted remainder may shrink, never grow."""
+    actual = _importers()
+    added = sorted(actual - STILL_IMPORTING_GITHUB_PR)
+    assert not added, (
+        f"{len(added)} file(s) import GitHubPRClient directly without being on the "
+        f"accepted list: {added}. Use "
+        "`from operations_center.adapters.pr import PRClient, make_pr_client` "
+        "instead — or, if all you need is the clone-URL parse, "
+        "`from operations_center.adapters.pr import owner_repo_from_clone_url`."
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """A migrated file must be struck off, so the list measures real remaining work."""
+    actual = _importers()
+    stale = sorted(STILL_IMPORTING_GITHUB_PR - actual)
+    assert not stale, (
+        f"{len(stale)} file(s) no longer import GitHubPRClient but are still listed: "
+        f"{stale}. Remove them from STILL_IMPORTING_GITHUB_PR."
+    )
+
+
+def test_the_seam_itself_does_not_import_the_concrete_client_at_module_scope():
+    """Import-time coupling would defeat the point and risk a cycle.
+
+    `make_pr_client` imports `GitHubPRClient` inside the function body, the same
+    way `make_board_client` does, so importing the protocol costs nothing and
+    `github_pr` can delegate back to the seam's helpers without a cycle.
+    """
+    text = (SRC / "adapters" / "pr" / "__init__.py").read_text(encoding="utf-8")
+    module_scope = [
+        line for line in text.splitlines()
+        if line.startswith("from operations_center.adapters.github_pr")
+        or line.startswith("import operations_center.adapters.github_pr")
+    ]
+    assert not module_scope, (
+        f"the seam imports the concrete client at module scope: {module_scope}"
+    )


### PR DESCRIPTION
The board got this treatment first, for the same reason it is wanted here: every caller named the concrete client, so swapping the backend meant a change in every caller instead of one place. On the PR side that is **17 files** in `src/` naming `GitHubPRClient`.

Thirteen of those seventeen do not want a client at all. They want `owner_repo_from_clone_url` — a pure parse of `host/owner/repo` that has nothing to do with GitHub, reached through the GitHub class because that is where it happened to live. Those are the cheapest callers to migrate and the most clearly mis-coupled, so the helper is a module function on the seam now. `has_thumbs_up` gets the same treatment; neither touches the network, a token, or `self`.

## What lands

- **`PRClient`** — 30 operations, the existing surface verbatim rather than an idealised one. Reshaping the API and introducing the seam in one step produces a migration that cannot be reviewed mechanically, and a migration that is not mechanical is where regressions hide.
- **`make_pr_client(settings)`** — the one construction site, byte-compatible with what every caller already does (`settings.git_token()`, then the client).
- **`owner_repo_from_clone_url` / `has_thumbs_up`** as module functions. The static methods stay as delegates, so the thirteen callers keep working while they migrate. That is what makes this incremental instead of a seventeen-file atomic change.

## What deliberately does not land

**No backend switch in the factory.** The board factory has one because a Forgejo board client exists. No Forgejo PR client does, and [`docs/specs/forgejo-pr-adapter.md`](docs/specs/forgejo-pr-adapter.md) argues one should not be written before the `enforce_admins` question is answered. A config knob selecting a backend that cannot be built advertises a capability the fleet does not have.

Two GitHub-shaped operations are declared as they *are* rather than as they ought to be — `get_check_runs` (Forgejo has no Checks API) and `get_branch_protection` (whose shape `_branch_protection_ok` reads for `required_status_checks.contexts` and `enforce_admins.enabled`). Declaring them honestly keeps the protocol a description of what callers actually depend on. Changing them is the Forgejo spec's work.

## Correction to the spec

`forgejo-pr-adapter.md` B7 counted the *reviewer's* four references and called the ratchet trivial next to the board's 37. Repo-wide it is 17 files. The reviewer really is cheap; the claim was scoped too narrowly, and the allowlist in the test now records the true figure with a note on why each file holds the name.

## Tests

`tests/unit/adapters/test_pr_seam.py` — 16 tests. The protocol matches the concrete client **in both directions** (nothing missing, nothing phantom), the factory's construction contract is pinned, the delegates are pinned, and `STILL_IMPORTING_GITHUB_PR` may only shrink.

No `test_the_migration_is_finished` yet, because finishing is not yet defined. What this protects is that the cost of finishing stays flat instead of growing.

## Verification

No behaviour change. Verified against `main` (`752eb3a8`): the non-unit suites fail on exactly the same 7 tests before and after — **none added, none fixed**. `ruff check` clean, `ty` at the 13-diagnostic baseline, custodian audit clean, full `tests/unit` suite green apart from the two known `egress_proxy` socket collisions with the live proxy on :8889.

## Noted while verifying, not fixed here

CI runs only `tests/unit`, `tests/test_pr_review_watcher.py`, `tests/integration/reviewer` and `tests/integration/observer`. Roughly 1,830 tests under `tests/maintenance/`, `tests/observer/` and top-level `tests/test_*.py` never run in the gate, and 7 are currently red on main. One is a regression from #509 — the board factory rejects a `MagicMock` `board_backend`. That fix is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
