### PR TITLE
fix(adapters): the board factory rejected a settings double

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -22,6 +22,14 @@ Found while verifying: CI runs only `tests/unit`, `tests/test_pr_review_watcher.
 under `tests/maintenance/`, `tests/observer/` and top-level `tests/test_*.py`
 never run in the gate — 7 of them are currently red on main, one of which is a
 regression from #509 (the board factory rejects a MagicMock `board_backend`).
+## 2026-08-17 — board factory rejected a settings double (regression from #509)
+
+`make_board_client` read `getattr(settings, "board_backend", "plane")`. A
+`MagicMock()` answers every attribute, so the default was unreachable and the
+factory raised "unknown board_backend <MagicMock ...>". Broken on main since
+#509; invisible because the test it breaks is in `tests/maintenance/`, which no
+CI job runs. Non-string now means "unconfigured", not "chosen"; a real typo is
+still a hard error. 7 red -> 6 in the non-unit suites.
 
 ## 2026-08-17 — Forgejo PR adapter spec (adversarial)
 

--- a/src/operations_center/adapters/board/__init__.py
+++ b/src/operations_center/adapters/board/__init__.py
@@ -100,6 +100,14 @@ def make_board_client(settings: Any) -> BoardClient:
     change behaviour.
     """
     backend = getattr(settings, "board_backend", "plane")
+    if not isinstance(backend, str):
+        # A test double (`MagicMock()`) answers every attribute with a child
+        # mock, so `getattr` never reaches its default and `backend` becomes a
+        # Mock — which matches neither "plane" nor "forgejo" and raised
+        # "unknown board_backend <MagicMock ...>" from deep inside the factory.
+        # Real Settings validates this field as a str, so a non-string here means
+        # "nothing configured this", not "someone chose backend 42".
+        backend = "plane"
 
     if backend == "forgejo":
         from operations_center.adapters.forgejo import ForgejoClient

--- a/tests/unit/adapters/test_board_seam.py
+++ b/tests/unit/adapters/test_board_seam.py
@@ -151,6 +151,46 @@ def test_factory_builds_from_settings_without_naming_a_backend(monkeypatch):
     }, "the factory changed the construction contract the callers relied on"
 
 
+def test_factory_tolerates_a_settings_double(monkeypatch):
+    """A MagicMock settings object must still build the default backend.
+
+    `getattr(settings, "board_backend", "plane")` looks like it defaults, but a
+    MagicMock answers every attribute, so the default is unreachable and the
+    factory raised "unknown board_backend <MagicMock ...>". That is not a
+    hypothetical: it broke
+    `tests/maintenance/test_orphan_branch_check.py::test_emit_plane_task_updates_existing_issue`
+    from #509 until now, and went unnoticed because CI runs `tests/unit` and
+    never `tests/maintenance/`.
+    """
+    from unittest.mock import MagicMock
+
+    from operations_center.adapters import board
+
+    built = {}
+
+    class _Fake:
+        def __init__(self, **kw):
+            built.update(kw)
+
+    monkeypatch.setattr(
+        "operations_center.adapters.plane.PlaneClient", _Fake, raising=False
+    )
+
+    board.make_board_client(MagicMock())
+    assert built, "a settings double no longer builds the default backend"
+
+
+def test_factory_still_rejects_a_real_unknown_backend():
+    """Tolerating a mock must not tolerate a typo in the config."""
+    from operations_center.adapters import board
+
+    class _Settings:
+        board_backend = "gitlab"
+
+    with pytest.raises(RuntimeError, match="unknown board_backend"):
+        board.make_board_client(_Settings())
+
+
 # ── the ratchet ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
#509 gave `make_board_client` a backend switch:

```python
backend = getattr(settings, "board_backend", "plane")
```

That reads as "default to plane", but a `MagicMock()` settings object answers every attribute with a child mock, so the default is **unreachable**. `backend` becomes a Mock, matches neither `"plane"` nor `"forgejo"`, and the factory raises `unknown board_backend <MagicMock name='mock.board_backend' ...>` from three frames down.

It has been broken on `main` since #509 merged.

## Why nobody noticed

CI runs `tests/unit`, `tests/test_pr_review_watcher.py`, `tests/integration/reviewer`, and `tests/integration/observer`. The test this breaks lives in `tests/maintenance/`, which **no CI job runs**. Roughly 1,830 tests sit outside the gate; 7 were red on main, and this was one of them.

## The fix

Treat a non-string as "nothing configured this" rather than as a chosen backend. Real `Settings` validates the field as a `str`, so the only way to reach a non-string here is a test double.

A typo in real config is still a hard error — `test_factory_still_rejects_a_real_unknown_backend` pins that, so tolerating a mock does not quietly become tolerating `board_backend: gitlab`.

## Verification

- `tests/maintenance/test_orphan_branch_check.py` — 1 failed, 19 passed → **20 passed**
- Non-unit suites: **7 red → 6**; the remaining 6 are unrelated and pre-date this
- `tests/unit` unchanged apart from the two known `egress_proxy` socket collisions with the live proxy on :8889
- `ruff` clean, `ty` at the 13-diagnostic baseline, custodian audit clean

Touches `.console/log.md` only because the pre-commit hook requires an entry; it will conflict trivially with #512, and both sides should be kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
