### PR TITLE
refactor(reviewer): move the last caller onto the PR seam — migration finished

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,21 @@
+## 2026-08-18 — PR seam: migration finished (17 -> 0)
+
+`pr_review_watcher/main.py` — the guardrail remainder — moved onto the seam.
+`_github_client` now delegates to `make_pr_client(settings)`, giving that
+factory the production caller it was written for; `_owner_repo` delegates to
+`owner_repo_from_clone_url`. Only observable change: the missing-token error is
+the seam's forge-neutral "no git token — set GIT_TOKEN in .env" (was "no GitHub
+token — ..."); no test asserts the old string.
+
+Ratchet allowlist is empty and `test_the_migration_is_finished` pins it — the
+board seam's end state, reached the same way. Nothing outside `adapters/`
+imports `GitHubPRClient`. Swapping the forge is now a one-module change on both
+the board and PR sides; the Forgejo PR client itself stays blocked on the B2
+enforce_admins decision (docs/specs/forgejo-pr-adapter.md).
+
+Noted in passing: `test_run_pipeline_updates_propose_heartbeat_during_execution`
+is timing-flaky (1-in-3 failure in isolation on unchanged code).
+
 ## 2026-08-17 — PR seam: 16 of 17 callers migrated
 
 The seam gained `pr_client_from_token()` alongside `make_pr_client(settings)`.

--- a/src/operations_center/entrypoints/pr_review_watcher/main.py
+++ b/src/operations_center/entrypoints/pr_review_watcher/main.py
@@ -380,12 +380,9 @@ def _load_settings(config_path: Path):
 
 
 def _github_client(settings):
-    from operations_center.adapters.github_pr import GitHubPRClient
+    from operations_center.adapters.pr import make_pr_client
 
-    token = settings.git_token()
-    if not token:
-        raise RuntimeError("no GitHub token — set GIT_TOKEN in .env")
-    return GitHubPRClient(token)
+    return make_pr_client(settings)
 
 
 def _plane_client(settings):
@@ -395,9 +392,9 @@ def _plane_client(settings):
 
 
 def _owner_repo(clone_url: str) -> tuple[str, str]:
-    from operations_center.adapters.github_pr import GitHubPRClient
+    from operations_center.adapters.pr import owner_repo_from_clone_url
 
-    return GitHubPRClient.owner_repo_from_clone_url(clone_url)
+    return owner_repo_from_clone_url(clone_url)
 
 
 def _venv_python(oc_root: Path) -> str:

--- a/tests/unit/adapters/test_pr_seam.py
+++ b/tests/unit/adapters/test_pr_seam.py
@@ -2,8 +2,8 @@
 # Copyright (C) 2026 ProtocolWarden
 """Hold the PR seam, and make the remaining coupling shrink rather than drift.
 
-Seventeen files in ``src/`` name :class:`GitHubPRClient` directly. Thirteen of
-them do so only to reach ``owner_repo_from_clone_url``, a pure URL parse that
+Seventeen files in ``src/`` named :class:`GitHubPRClient` directly. Thirteen of
+them only to reach ``owner_repo_from_clone_url``, a pure URL parse that
 never needed a client. That is the shape the board seam had before it was
 migrated, and the same ratchet applies:
 
@@ -15,9 +15,9 @@ migrated, and the same ratchet applies:
 
 Unlike the board, there is no second backend to migrate *to* yet, and
 ``docs/specs/forgejo-pr-adapter.md`` argues there should not be one until the
-``enforce_admins`` question is answered. So there is deliberately no
-``test_the_migration_is_finished`` here: finishing is not yet defined. What these
-tests protect is that the cost of finishing stays flat instead of growing.
+``enforce_admins`` question is answered. "Finished" therefore means what it meant
+for the board: every caller goes through the seam, so a future backend is a
+change in one module. ``test_the_migration_is_finished`` pins that state.
 """
 
 from __future__ import annotations
@@ -29,17 +29,12 @@ import pytest
 
 SRC = pathlib.Path(__file__).resolve().parents[3] / "src" / "operations_center"
 
-#: Files that still name the concrete client.
-#:
-#: This began as a burn-down list of 17. Sixteen are migrated; the one that
-#: remains is a guardrail path (`pr_review_watcher/**`), so it moves under K=3
-#: council review in its own change rather than riding along with a sixteen-file
-#: mechanical sweep.
-#:
-#: Adding to this set is not a way to avoid migrating.
-STILL_IMPORTING_GITHUB_PR = {
-    "entrypoints/pr_review_watcher/main.py",
-}
+#: Files that still name the concrete client. Empty — the burn-down list of 17
+#: reached zero when `pr_review_watcher/main.py` moved (last, and under K=3
+#: council review, because it is a guardrail path). The set stays so the ratchet
+#: keeps holding: unlike the board's `PLANE_SPECIFIC_BY_DESIGN`, there is no
+#: file with a design reason to name a forge client directly.
+STILL_IMPORTING_GITHUB_PR: set[str] = set()
 
 #: Migrated in the sweep. Pinned so the boundary cannot quietly erode back.
 MIGRATED = [
@@ -55,6 +50,7 @@ MIGRATED = [
     "entrypoints/maintenance/orphan_branch_check.py",
     "entrypoints/maintenance/outcome_flagger_task.py",
     "entrypoints/maintenance/reconcile_merged_tasks.py",
+    "entrypoints/pr_review_watcher/main.py",
     "eval/outcome_sources.py",
     "execution/workspace.py",
     "observer/collectors/ci_history.py",
@@ -290,15 +286,17 @@ def test_migrated_files_stay_migrated(migrated):
     assert "adapters.pr" in text, f"{migrated} no longer uses the seam"
 
 
-def test_only_the_guardrail_file_is_left():
-    """The remainder is one file, and it is the one that needs council review.
+def test_the_migration_is_finished():
+    """No caller is left to migrate.
 
-    When `pr_review_watcher/main.py` moves, this test and the allowlist go with
-    it, and the migration is finished.
+    The seam existed to make swapping the forge a one-place change. That is only
+    true once every caller goes through it — a seam with stragglers still forces
+    a per-caller change at cutover, which is the cost it was built to remove.
+    Same end state the board seam reached.
     """
-    assert STILL_IMPORTING_GITHUB_PR == {"entrypoints/pr_review_watcher/main.py"}, (
-        "the accepted remainder changed — if a file was migrated, strike it off; "
-        "if one was added, it needs a reason"
+    actual = _importers()
+    assert not actual, (
+        f"{len(actual)} caller(s) import GitHubPRClient again: {sorted(actual)}"
     )
 
 


### PR DESCRIPTION
The last of the 17. `pr_review_watcher/main.py` was deliberately held out of #514's sixteen-file sweep because it is a **guardrail path** — this PR exists so the K=3 council reviews it on its own, with nothing else in the diff.

## The change

Two function bodies:

- `_github_client(settings)` → delegates to `make_pr_client(settings)`. That factory was written for exactly this caller (holds `Settings`, treats a missing token as fatal) and since #514 it had **no production caller at all** — a dead capability the seam's own docstring argued against. It now has its intended one.
- `_owner_repo(clone_url)` → delegates to the seam's `owner_repo_from_clone_url`.

Names and lazy-import style are unchanged, so the three tests that patch `watcher._github_client` by object are unaffected.

## The one observable change

The missing-token error becomes the seam's forge-neutral `no git token — set GIT_TOKEN in .env` (was `no GitHub token — …`). No test asserts the old string — the heartbeat tests that mention "no GitHub token" construct their own records and never read this message. This is a startup-failure message; the reviewer refuses to start either way.

## The ratchet finishes

`STILL_IMPORTING_GITHUB_PR` empties, `pr_review_watcher/main.py` joins `MIGRATED` (17 entries pinned), and `test_the_migration_is_finished` locks the end state — the same shape the board seam finished in (#510). **Nothing outside `adapters/` imports `GitHubPRClient`.** Swapping the forge is now a one-module change on both the board and PR sides; the Forgejo PR client itself remains blocked on the B2 `enforce_admins` decision per [the spec](docs/specs/forgejo-pr-adapter.md).

## Verification

- Seam ratchet: 36 passed
- Reviewer suites, CI-exact: `test_pr_review_watcher.py` 170 passed, `integration/reviewer` 101 passed
- Full suite: the same 8 pre-existing failures as main (2 egress-proxy socket collisions with the live proxy on :8889 + 6 in the un-gated suites), none added
- `ruff` clean, `ty` at the 13-diagnostic baseline (real venv), custodian audit clean, census OK, no mode changes

Noted in passing, not addressed here: `test_run_pipeline_updates_propose_heartbeat_during_execution` is timing-flaky — it fails ~1-in-3 **in isolation on unchanged code**. Recorded in `.console/log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
