### PR TITLE
feat(adapters): Forgejo PR client — B2 dissolved by the live instance

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-08-18 — Forgejo PR client implemented; B2 dissolved by a live probe
+
+Probing the live instance rewrote the spec's hardest finding: Forgejo 13 has
+`apply_to_admins` — `enforce_admins` under another name — so the fail-closed
+gate's two required paths map 1:1. `ForgejoPRClient` now fills the PRClient
+protocol: statuses→check-runs under an explicit translation (warning→neutral,
+error→failure keeping its own name, pending→in_progress; history deduped
+latest-per-context), branch protection translated to exactly what
+`_branch_protection_ok` reads with the raw rule under `_forgejo`, pagination to
+exhaustion everywhere. `make_pr_client` gained the `pr_backend` switch
+(default github). Review stays on GitHub: flipping `pr_backend` is the cutover
+act, gated on `audit` existing on Forgejo Actions.
+
 ## 2026-08-18 — the board is live on Forgejo; Plane retired
 
 Cutover complete. Forgejo 13 runs in WSL docker (localhost:3000, registration

--- a/docs/specs/forgejo-pr-adapter.md
+++ b/docs/specs/forgejo-pr-adapter.md
@@ -198,6 +198,32 @@ mechanical.
 
 ---
 
+## Live findings — Forgejo 13, 2026-08-18
+
+Probed against the running instance (scratch repo `bp-probe`, kept for
+negative-case verification). Three findings revise the adversarial sections:
+
+1. **B2 mostly dissolves: `apply_to_admins` exists.** The branch-protection
+   rule carries a first-class `apply_to_admins` field — GitHub's
+   `enforce_admins` under Forgejo's name: the rule binds repository admins
+   too. With `enable_status_check` + `status_check_contexts` (which accepted
+   `["audit", "reviewer-verdict"]` verbatim), both paths the fail-closed gate
+   reads map 1:1 and truthfully. What remains of B2 is a cutover checklist
+   item, not a design question: **set `apply_to_admins: true` when protecting
+   the Forgejo repos.** Option (c)'s push-allowlist reconstruction is not
+   needed.
+2. **The status model, precisely.** A status carries its value in a field
+   named `status` (not `state`), and there are **five** values:
+   `pending / success / failure / error / warning` — `warning` has no GitHub
+   equivalent. The adapter's translation (`STATUS_TO_CHECK`): `pending` →
+   in_progress, `success` → success, `failure` and `error` → failure (the
+   original word survives in `output.title`), `warning` → **neutral** —
+   completed, not passed, not failed, which is Forgejo's own semantics. The
+   statuses endpoint returns full posting *history*; ids increase
+   monotonically, so the GitHub-style latest-per-context dedupe carries over.
+3. **`check-runs` is a confirmed 404**, and `GET /pulls/{index}.diff` serves
+   the raw diff.
+
 ## Correctness criteria
 
 1. Status→check translation is explicit about what it loses. A test asserts a
@@ -218,10 +244,10 @@ mechanical.
 
 ## Completion criteria
 
-- [ ] **B2 decided by the operator** — what replaces `enforce_admins`
-- [ ] `PRClient` protocol extracted; reviewer migrated onto it; ratchet test added
-- [ ] `ForgejoPRClient` implementing the protocol
-- [ ] Status→check translation with the losses tested, not papered over
+- [x] **B2 decided** — `apply_to_admins` IS `enforce_admins` (live finding 1); the operator flips it on at cutover
+- [x] `PRClient` protocol extracted; all 17 callers migrated (#512–#515)
+- [x] `ForgejoPRClient` implementing the protocol (`adapters/forgejo/pr_client.py`)
+- [x] Status→check translation with the losses tested (`STATUS_TO_CHECK`; warning→neutral, error→failure with its own name)
 - [ ] `audit` (or its replacement) produced on Forgejo under an identical name
 - [ ] Live verification against a real instance, **negative cases first**
 - [ ] Cutover, GitHub demoted to read-only mirror

--- a/src/operations_center/adapters/forgejo/pr_client.py
+++ b/src/operations_center/adapters/forgejo/pr_client.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Forgejo implementation of the PR seam.
+
+Fills the :class:`~operations_center.adapters.pr.PRClient` protocol against a
+Forgejo/Gitea instance. Written from the live findings recorded in
+``docs/specs/forgejo-pr-adapter.md`` (2026-08-18, Forgejo 13):
+
+* **No Checks API** — ``/commits/{sha}/check-runs`` is a 404. Forgejo has
+  commit *statuses* only, so :meth:`get_check_runs` synthesizes check-run-shaped
+  dicts from statuses under an explicit, lossy-but-documented translation (see
+  :data:`STATUS_TO_CHECK`). The three gate helpers reproduce the GitHub
+  client's semantics — latest-per-name dedupe, ``"name: summary"`` failure
+  strings, completed-must-be-non-empty green contract — on top of it.
+* **Branch protection has a first-class admin bit.** ``apply_to_admins`` is
+  GitHub's ``enforce_admins`` in Forgejo terms, and ``status_check_contexts``
+  carries required contexts verbatim. :meth:`get_branch_protection` translates
+  to the exact two paths the reviewer's fail-closed gate reads
+  (``required_status_checks.contexts``, ``enforce_admins.enabled``), keeping
+  the raw rule under ``_forgejo`` so nothing is asserted that the instance did
+  not say.
+
+The board adapter's conventions carry over: pagination reads to exhaustion
+(a short read is not an error, it is a confident wrong decision), and the
+constructor accepts a ``transport`` for tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 50
+_MAX_PAGES = 200
+
+#: How a Forgejo commit status becomes a GitHub-shaped check run. Two fields
+#: (status, conclusion) from one (status) — the losses are chosen, not implied:
+#:
+#: * ``error`` collapses into conclusion ``failure``: both block a merge. The
+#:   original word survives in ``output.title``, so failure strings still read
+#:   ``"ctx: error"``.
+#: * ``warning`` becomes ``neutral`` — completed, **not** a success and **not**
+#:   a failure, which is precisely Forgejo's non-blocking semantics. A naive
+#:   translation folding it into ``success`` would let "completed with
+#:   warnings" masquerade as "passed".
+#: * ``pending`` is ``in_progress`` with no conclusion, so the incomplete/
+#:   failed distinction the merge gate depends on survives.
+STATUS_TO_CHECK: dict[str, tuple[str, str | None]] = {
+    "pending": ("in_progress", None),
+    "success": ("completed", "success"),
+    "failure": ("completed", "failure"),
+    "error": ("completed", "failure"),
+    "warning": ("completed", "neutral"),
+}
+
+
+class ForgejoPRClient:
+    """PR operations against one Forgejo instance.
+
+    ``owner``/``repo`` travel per call, exactly as on ``GitHubPRClient`` — the
+    protocol was extracted verbatim, so a caller cannot tell which forge it
+    holds.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_token: str,
+        *,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._client = httpx.Client(
+            base_url=f"{base_url.rstrip('/')}/api/v1",
+            headers={"Authorization": f"token {api_token}"},
+            timeout=30.0,
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    # ── plumbing ─────────────────────────────────────────────────────────────
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        resp = self._client.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def _paginate(self, url: str, params: dict[str, Any] | None = None) -> list[dict]:
+        """Read every page. A page-one-only read of a 90-item list is not an
+        error anyone sees — it is 40 items silently missing from a decision."""
+        out: list[dict] = []
+        for page in range(1, _MAX_PAGES + 1):
+            resp = self._request(
+                "GET", url, params={**(params or {}), "page": page, "limit": _PAGE_SIZE}
+            )
+            batch = resp.json()
+            if not isinstance(batch, list):
+                raise RuntimeError(f"expected a list from {url}, got {type(batch).__name__}")
+            out.extend(batch)
+            if len(batch) < _PAGE_SIZE:
+                return out
+        raise RuntimeError(f"{url}: still returning full pages after {_MAX_PAGES} pages")
+
+    # ── pull requests ────────────────────────────────────────────────────────
+
+    def create_pr(
+        self, owner: str, repo: str, *, head: str, base: str, title: str, body: str = ""
+    ) -> dict:
+        resp = self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls",
+            json={"head": head, "base": base, "title": title, "body": body},
+        )
+        return resp.json()
+
+    def get_pr(self, owner: str, repo: str, pr_number: int) -> dict:
+        return self._request("GET", f"/repos/{owner}/{repo}/pulls/{pr_number}").json()
+
+    def merge_pr(
+        self, owner: str, repo: str, pr_number: int, *, merge_method: str = "squash"
+    ) -> dict:
+        self._request(
+            "POST",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/merge",
+            json={"Do": merge_method},
+        )
+        # Forgejo answers 200 with an empty body; report what happened in the
+        # key GitHub callers look at.
+        return {"merged": True}
+
+    def close_pr(self, owner: str, repo: str, pr_number: int) -> dict:
+        return self._request(
+            "PATCH", f"/repos/{owner}/{repo}/pulls/{pr_number}", json={"state": "closed"}
+        ).json()
+
+    def list_open_prs(self, owner: str, repo: str) -> list[dict]:
+        return self._paginate(f"/repos/{owner}/{repo}/pulls", {"state": "open"})
+
+    def list_closed_prs(self, owner: str, repo: str) -> list[dict]:
+        return self._paginate(f"/repos/{owner}/{repo}/pulls", {"state": "closed"})
+
+    def find_pr_by_head(self, owner: str, repo: str, head_ref: str) -> dict | None:
+        # Forgejo's list endpoint has no `head=` filter; filter client-side over
+        # the exhaustive read.
+        for pr in self._paginate(f"/repos/{owner}/{repo}/pulls", {"state": "open"}):
+            if ((pr.get("head") or {}).get("ref")) == head_ref:
+                return pr
+        return None
+
+    def get_mergeable(self, owner: str, repo: str, pr_number: int) -> bool | None:
+        return self.get_pr(owner, repo, pr_number).get("mergeable")
+
+    def update_pr_description(self, owner: str, repo: str, pr_number: int, body: str) -> dict:
+        return self._request(
+            "PATCH", f"/repos/{owner}/{repo}/pulls/{pr_number}", json={"body": body}
+        ).json()
+
+    def create_and_merge(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        head: str,
+        base: str,
+        title: str,
+        body: str = "",
+        merge_method: str = "squash",
+    ) -> str:
+        """Create a PR, merge it, then delete the head branch. Returns the PR html_url."""
+        pr = self.create_pr(owner, repo, head=head, base=base, title=title, body=body)
+        pr_number = pr["number"]
+        pr_url = pr["html_url"]
+        self.merge_pr(owner, repo, pr_number, merge_method=merge_method)
+        try:
+            self.delete_branch(owner, repo, head)
+        except httpx.HTTPStatusError:
+            _logger.warning("create_and_merge: could not delete branch %r", head)
+        return pr_url
+
+    # ── diffs and files ──────────────────────────────────────────────────────
+
+    def list_pr_files(self, owner: str, repo: str, pr_number: int) -> list[str]:
+        files = self._paginate(f"/repos/{owner}/{repo}/pulls/{pr_number}/files")
+        return [f.get("filename", "") for f in files if f.get("filename")]
+
+    def get_pr_diff(self, owner: str, repo: str, pr_number: int) -> str:
+        return self._request("GET", f"/repos/{owner}/{repo}/pulls/{pr_number}.diff").text
+
+    def get_file_content(
+        self, owner: str, repo: str, path: str, ref: str
+    ) -> tuple[str, str] | None:
+        try:
+            resp = self._request(
+                "GET", f"/repos/{owner}/{repo}/contents/{path}", params={"ref": ref}
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        data = resp.json()
+        text = base64.b64decode(data.get("content", "") or "").decode("utf-8")
+        return text, data.get("sha", "")
+
+    def update_file(
+        self,
+        owner: str,
+        repo: str,
+        path: str,
+        *,
+        new_text: str,
+        message: str,
+        branch: str,
+        blob_sha: str,
+    ) -> bool:
+        resp = self._request(
+            "PUT",
+            f"/repos/{owner}/{repo}/contents/{path}",
+            json={
+                "content": base64.b64encode(new_text.encode("utf-8")).decode("ascii"),
+                "message": message,
+                "branch": branch,
+                "sha": blob_sha,
+            },
+        )
+        return resp.status_code in (200, 201)
+
+    # ── review ───────────────────────────────────────────────────────────────
+
+    def list_pr_comments(self, owner: str, repo: str, pr_number: int) -> list[dict]:
+        # Issues and PRs share a number space, so PR discussion comments live on
+        # the issue endpoint — same as GitHub.
+        return self._paginate(f"/repos/{owner}/{repo}/issues/{pr_number}/comments")
+
+    def list_pr_review_comments(self, owner: str, repo: str, pr_number: int) -> list[dict]:
+        # No flat review-comments endpoint; flatten across reviews.
+        out: list[dict] = []
+        for review in self.list_pr_reviews(owner, repo, pr_number):
+            rid = review.get("id")
+            if rid is None:
+                continue
+            out.extend(
+                self._paginate(
+                    f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{rid}/comments"
+                )
+            )
+        return out
+
+    def list_pr_reviews(self, owner: str, repo: str, pr_number: int) -> list[dict]:
+        return self._paginate(f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews")
+
+    def pr_has_changes_requested(self, owner: str, repo: str, pr_number: int) -> bool:
+        # Forgejo spells it REQUEST_CHANGES; GitHub spells it CHANGES_REQUESTED.
+        # Accept both so the caller's question, not the forge's dialect, decides.
+        return any(
+            review.get("state") in ("REQUEST_CHANGES", "CHANGES_REQUESTED")
+            for review in self.list_pr_reviews(owner, repo, pr_number)
+        )
+
+    def post_comment(self, owner: str, repo: str, pr_number: int, body: str) -> dict:
+        return self._request(
+            "POST", f"/repos/{owner}/{repo}/issues/{pr_number}/comments", json={"body": body}
+        ).json()
+
+    def update_comment(self, owner: str, repo: str, comment_id: int, body: str) -> dict:
+        return self._request(
+            "PATCH", f"/repos/{owner}/{repo}/issues/comments/{comment_id}", json={"body": body}
+        ).json()
+
+    def get_pr_reactions(self, owner: str, repo: str, pr_number: int) -> list[dict]:
+        return self._paginate(f"/repos/{owner}/{repo}/issues/{pr_number}/reactions")
+
+    def get_comment_reactions(self, owner: str, repo: str, comment_id: int) -> list[dict]:
+        return self._paginate(f"/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions")
+
+    # ── CI signal ────────────────────────────────────────────────────────────
+
+    def set_commit_status(
+        self,
+        owner: str,
+        repo: str,
+        sha: str,
+        *,
+        state: str,
+        context: str,
+        description: str = "",
+        target_url: str | None = None,
+    ) -> dict:
+        payload: dict[str, Any] = {
+            "state": state,
+            "context": context,
+            "description": description,
+        }
+        if target_url is not None:
+            payload["target_url"] = target_url
+        return self._request(
+            "POST", f"/repos/{owner}/{repo}/statuses/{sha}", json=payload
+        ).json()
+
+    def get_check_runs(self, owner: str, repo: str, ref: str) -> list[dict]:
+        """Commit statuses, shaped like check runs.
+
+        The endpoint returns the full posting *history*; consumers dedupe to
+        latest-per-name by ``id`` exactly as they do on GitHub, which Forgejo's
+        monotonically increasing status ids support. The status word the
+        instance actually reported survives in ``output.title``.
+        """
+        statuses = self._paginate(f"/repos/{owner}/{repo}/commits/{ref}/statuses")
+        runs = []
+        for st in statuses:
+            word = str(st.get("status", ""))
+            run_status, conclusion = STATUS_TO_CHECK.get(word, ("completed", "failure"))
+            runs.append(
+                {
+                    "id": st.get("id", 0),
+                    "name": st.get("context", "unknown"),
+                    "status": run_status,
+                    "conclusion": conclusion,
+                    "output": {"title": word},
+                }
+            )
+        return runs
+
+    def _latest_runs(
+        self, owner: str, repo: str, pr_number: int, pr_data: dict | None
+    ) -> list[dict]:
+        if pr_data is None:
+            pr_data = self.get_pr(owner, repo, pr_number)
+        head_sha = (pr_data.get("head") or {}).get("sha", "")
+        if not head_sha:
+            return []
+        try:
+            check_runs = self.get_check_runs(owner, repo, head_sha)
+        except Exception:
+            return []
+        latest: dict[str, dict] = {}
+        for cr in check_runs:
+            name = cr.get("name", "unknown")
+            if cr.get("id", 0) > latest.get(name, {}).get("id", 0):
+                latest[name] = cr
+        return list(latest.values())
+
+    @staticmethod
+    def _kept(name: str, ignored_checks: list[str] | None) -> bool:
+        ignored = [s.lower() for s in (ignored_checks or [])]
+        return not (ignored and any(pat in name.lower() for pat in ignored))
+
+    def get_failed_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]:
+        """Human-readable descriptions of failing checks — GitHub-format strings."""
+        failed = []
+        for cr in self._latest_runs(owner, repo, pr_number, pr_data):
+            if cr.get("conclusion") in ("failure", "timed_out", "cancelled"):
+                name = cr.get("name", "unknown")
+                if not self._kept(name, ignored_checks):
+                    continue
+                summary = (cr.get("output") or {}).get("title") or cr.get("conclusion", "failed")
+                failed.append(f"{name}: {summary}")
+        return failed
+
+    def get_incomplete_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]:
+        """Names of checks not yet terminal. Non-empty means "not green yet"."""
+        return [
+            cr.get("name", "unknown")
+            for cr in self._latest_runs(owner, repo, pr_number, pr_data)
+            if cr.get("status") != "completed"
+            and self._kept(cr.get("name", "unknown"), ignored_checks)
+        ]
+
+    def get_completed_checks(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        pr_data: dict | None = None,
+        ignored_checks: list[str] | None = None,
+    ) -> list[str]:
+        """Names of checks in a terminal state.
+
+        Same contract as the GitHub client: a gate must require this NON-EMPTY,
+        or the no-CI-yet window reads as green.
+        """
+        return [
+            cr.get("name", "unknown")
+            for cr in self._latest_runs(owner, repo, pr_number, pr_data)
+            if cr.get("status") == "completed"
+            and self._kept(cr.get("name", "unknown"), ignored_checks)
+        ]
+
+    # ── branches ─────────────────────────────────────────────────────────────
+
+    def get_branch_head(self, owner: str, repo: str, branch: str) -> str | None:
+        try:
+            resp = self._request("GET", f"/repos/{owner}/{repo}/branches/{branch}")
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        return ((resp.json().get("commit") or {}).get("id")) or None
+
+    def get_branch_protection(self, owner: str, repo: str, branch: str) -> dict | None:
+        """The protection rule, translated to the two paths the gate reads.
+
+        ``required_status_checks.contexts`` ← ``status_check_contexts`` when
+        ``enable_status_check`` is on; ``enforce_admins.enabled`` ←
+        ``apply_to_admins``, which is the same guarantee under Forgejo's name:
+        repository admins cannot bypass the rule. The untranslated rule rides
+        along under ``_forgejo`` so a reader can always check what the instance
+        actually said.
+        """
+        try:
+            resp = self._request(
+                "GET", f"/repos/{owner}/{repo}/branch_protections/{branch}"
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        rule = resp.json()
+        contexts = (
+            list(rule.get("status_check_contexts") or [])
+            if rule.get("enable_status_check")
+            else []
+        )
+        return {
+            "required_status_checks": {"contexts": contexts},
+            "enforce_admins": {"enabled": bool(rule.get("apply_to_admins"))},
+            "_forgejo": rule,
+        }
+
+    def delete_branch(self, owner: str, repo: str, branch: str) -> None:
+        self._request("DELETE", f"/repos/{owner}/{repo}/branches/{branch}")

--- a/src/operations_center/adapters/pr/__init__.py
+++ b/src/operations_center/adapters/pr/__init__.py
@@ -271,12 +271,32 @@ def make_pr_client(settings: Any) -> PRClient:
     token is fatal" behaviour. Callers that resolve their own token, or report a
     missing one their own way, use :func:`pr_client_from_token` instead.
 
-    There is intentionally no backend switch yet. The board factory has one
-    because a Forgejo board client exists; no Forgejo PR client does, and
-    ``docs/specs/forgejo-pr-adapter.md`` argues it should not be written before
-    the ``enforce_admins`` question is settled. A config knob selecting a backend
-    that cannot be built would advertise a capability the fleet does not have.
+    `pr_backend` selects the forge, and it is independent of `board_backend` on
+    purpose: the board cut over to Forgejo first (#516), while review stays on
+    GitHub until `audit` is produced by Forgejo Actions and the live gate
+    verification in ``docs/specs/forgejo-pr-adapter.md`` passes. Flipping this
+    setting is the cutover act, not a side effect. The earlier "no backend
+    switch yet" stance ended when `ForgejoPRClient` became real — a knob may
+    only exist once the thing it selects does.
     """
+    backend = getattr(settings, "pr_backend", "github")
+    if not isinstance(backend, str):
+        backend = "github"
+
+    if backend == "forgejo":
+        from operations_center.adapters.forgejo.pr_client import ForgejoPRClient
+
+        cfg = settings.forgejo
+        if cfg is None:
+            raise RuntimeError(
+                "pr_backend is 'forgejo' but no `forgejo:` settings block is "
+                "configured — the reviewer has no forge to talk to"
+            )
+        return ForgejoPRClient(cfg.base_url, settings.forgejo_token())
+
+    if backend != "github":
+        raise RuntimeError(f"unknown pr_backend {backend!r} (github, forgejo)")
+
     token = settings.git_token()
     if not token:
         raise RuntimeError("no git token — set GIT_TOKEN in .env")

--- a/src/operations_center/config/settings.py
+++ b/src/operations_center/config/settings.py
@@ -684,6 +684,11 @@ class TaskAdmissionSettings(BaseModel):
 
 class Settings(BaseModel):
     plane: PlaneSettings | None = None
+    # Which forge the PR/review surface talks to. Independent of board_backend:
+    # the board cut over first (#516); review moves only after `audit` exists on
+    # Forgejo Actions (docs/specs/forgejo-pr-adapter.md, B4). Flipping this is
+    # the cutover act, not a side effect.
+    pr_backend: str = "github"
     # Which board the fleet talks to. Explicit rather than inferred from whether
     # `forgejo:` is configured — repointing the board is not something that
     # should happen as a side effect of adding a config block.

--- a/tests/unit/adapters/test_forgejo_pr_client.py
+++ b/tests/unit/adapters/test_forgejo_pr_client.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ProtocolWarden
+"""Tests for the Forgejo PR adapter.
+
+The spec's two decisive findings shape this suite:
+
+* **B1 — no Checks API.** ``get_check_runs`` synthesizes runs from statuses
+  under a lossy translation, so the loss tests are the point: ``warning`` must
+  be distinguishable from ``success`` (neutral, completed, not failed),
+  ``error`` must fail while keeping its own name in the text, ``pending`` must
+  read as incomplete, and the no-CI-at-all window must leave completed empty.
+* **B2 — the fail-closed gate.** ``get_branch_protection`` must produce
+  exactly the two paths ``_branch_protection_ok`` reads, from what the
+  instance actually said — ``apply_to_admins`` in, ``enforce_admins.enabled``
+  out — and a missing rule must be ``None``, which the gate refuses.
+
+No live server: httpx.MockTransport serves the shapes recorded from the live
+Forgejo 13 probe (2026-08-18).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+
+from operations_center.adapters.forgejo.pr_client import (
+    STATUS_TO_CHECK,
+    ForgejoPRClient,
+)
+from operations_center.adapters.pr import PRClient
+
+OWNER, REPO = "protocolwarden", "widget"
+BASE = "https://forge.local"
+
+
+def _client(handler) -> ForgejoPRClient:
+    return ForgejoPRClient(BASE, "tok", transport=httpx.MockTransport(handler))
+
+
+def _status(sid: int, context: str, word: str) -> dict:
+    return {"id": sid, "context": context, "status": word, "description": "d"}
+
+
+def _paged(request: httpx.Request, items: list) -> httpx.Response:
+    page = int(request.url.params.get("page", "1"))
+    limit = int(request.url.params.get("limit", "50"))
+    return httpx.Response(200, json=items[(page - 1) * limit : page * limit])
+
+
+# ── the seam ─────────────────────────────────────────────────────────────────
+
+
+def test_satisfies_the_pr_protocol():
+    """Every operation the reviewer calls exists; a missing one is an
+    AttributeError mid-merge, discovered in production."""
+    ops = {n for n in dir(PRClient) if not n.startswith("_")}
+    missing = sorted(op for op in ops if not hasattr(ForgejoPRClient, op))
+    assert not missing, f"ForgejoPRClient lacks: {missing}"
+
+
+# ── B1: the status→check translation and its chosen losses ───────────────────
+
+
+def test_translation_covers_every_forgejo_state():
+    assert set(STATUS_TO_CHECK) == {"pending", "success", "failure", "error", "warning"}
+
+
+def test_warning_is_neutral_not_success_and_not_failed():
+    """Forgejo's fifth state. Folding it into success would let "completed
+    with warnings" masquerade as "passed"; folding it into failure would block
+    merges Forgejo itself would not block."""
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, [_status(1, "lint", "warning")])
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    runs = c.get_check_runs(OWNER, REPO, "abc")
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["conclusion"] == "neutral"
+    assert c.get_failed_checks(OWNER, REPO, 1) == []
+    assert c.get_completed_checks(OWNER, REPO, 1) == ["lint"]
+
+
+def test_error_fails_but_keeps_its_own_name_in_the_text():
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, [_status(1, "build", "error")])
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert c.get_failed_checks(OWNER, REPO, 1) == ["build: error"]
+
+
+def test_pending_is_incomplete_not_failed_not_completed():
+    """Collapsing pending into either terminal bucket re-creates the #503
+    failure mode: merging mid-CI."""
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, [_status(1, "tests", "pending")])
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert c.get_incomplete_checks(OWNER, REPO, 1) == ["tests"]
+    assert c.get_failed_checks(OWNER, REPO, 1) == []
+    assert c.get_completed_checks(OWNER, REPO, 1) == []
+
+
+def test_no_statuses_at_all_reads_as_nothing_completed():
+    """The no-CI-yet window: failed and incomplete are empty, and completed is
+    TOO — the gate's "completed must be non-empty" clause is what stops this
+    window from reading as green."""
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, [])
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert c.get_failed_checks(OWNER, REPO, 1) == []
+    assert c.get_incomplete_checks(OWNER, REPO, 1) == []
+    assert c.get_completed_checks(OWNER, REPO, 1) == []
+
+
+def test_history_dedupes_to_the_latest_status_per_context():
+    """The endpoint returns posting history. A context that failed and was
+    re-posted green must count once, as green — the same latest-by-id rule the
+    GitHub client applies to re-run check suites."""
+    history = [
+        _status(1, "tests", "failure"),
+        _status(2, "tests", "success"),
+        _status(3, "lint", "failure"),
+    ]
+
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, history)
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert c.get_failed_checks(OWNER, REPO, 1) == ["lint: failure"]
+    assert sorted(c.get_completed_checks(OWNER, REPO, 1)) == ["lint", "tests"]
+
+
+def test_ignored_checks_filter_matches_github_semantics():
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, [_status(1, "Flaky suite", "failure"),
+                                    _status(2, "real", "failure")])
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert c.get_failed_checks(OWNER, REPO, 1, ignored_checks=["flaky"]) == ["real: failure"]
+
+
+def test_statuses_paginate_to_exhaustion():
+    """120 statuses > 2 pages. A page-one-only read hides 70 of them."""
+    history = [_status(i, f"ctx-{i}", "success") for i in range(1, 121)]
+
+    def handler(request):
+        if "statuses" in request.url.path:
+            return _paged(request, history)
+        return httpx.Response(200, json={"head": {"sha": "abc"}})
+
+    c = _client(handler)
+    assert len(c.get_completed_checks(OWNER, REPO, 1)) == 120
+
+
+# ── B2: the gate translation ─────────────────────────────────────────────────
+
+
+def test_branch_protection_translates_to_what_the_gate_reads():
+    """apply_to_admins is enforce_admins under Forgejo's name; the raw rule
+    rides along so nothing is asserted the instance did not say."""
+    rule = {
+        "branch_name": "main",
+        "enable_status_check": True,
+        "status_check_contexts": ["audit", "reviewer-verdict"],
+        "apply_to_admins": True,
+    }
+
+    def handler(request):
+        assert request.url.path.endswith("/branch_protections/main")
+        return httpx.Response(200, json=rule)
+
+    got = _client(handler).get_branch_protection(OWNER, REPO, "main")
+    assert got["required_status_checks"]["contexts"] == ["audit", "reviewer-verdict"]
+    assert got["enforce_admins"]["enabled"] is True
+    assert got["_forgejo"] == rule
+
+
+def test_branch_protection_without_admin_bit_reports_false_not_true():
+    """The honest failure the spec demanded: reporting true because protection
+    merely exists would remove the control while the logs say it passed."""
+    def handler(request):
+        return httpx.Response(200, json={
+            "enable_status_check": True,
+            "status_check_contexts": ["reviewer-verdict"],
+            "apply_to_admins": False,
+        })
+
+    got = _client(handler).get_branch_protection(OWNER, REPO, "main")
+    assert got["enforce_admins"]["enabled"] is False
+
+
+def test_branch_protection_with_checks_disabled_reports_no_contexts():
+    """Contexts listed but enable_status_check off = not required. Reporting
+    them as required would satisfy the gate with a rule Forgejo is not
+    enforcing."""
+    def handler(request):
+        return httpx.Response(200, json={
+            "enable_status_check": False,
+            "status_check_contexts": ["reviewer-verdict"],
+            "apply_to_admins": True,
+        })
+
+    got = _client(handler).get_branch_protection(OWNER, REPO, "main")
+    assert got["required_status_checks"]["contexts"] == []
+
+
+def test_missing_protection_is_none_which_the_gate_refuses():
+    def handler(request):
+        return httpx.Response(404, json={"message": "not found"})
+
+    assert _client(handler).get_branch_protection(OWNER, REPO, "main") is None
+
+
+# ── pull requests ────────────────────────────────────────────────────────────
+
+
+def test_merge_pr_sends_the_forgejo_do_verb():
+    seen = {}
+
+    def handler(request):
+        if request.url.path.endswith("/merge"):
+            seen.update(json.loads(request.content))
+            return httpx.Response(200)
+        return httpx.Response(200, json={})
+
+    out = _client(handler).merge_pr(OWNER, REPO, 7, merge_method="squash")
+    assert seen == {"Do": "squash"}
+    assert out["merged"] is True
+
+
+def test_find_pr_by_head_filters_client_side_across_pages():
+    prs = [{"number": i, "head": {"ref": f"b-{i}"}} for i in range(1, 91)]
+
+    def handler(request):
+        return _paged(request, prs)
+
+    c = _client(handler)
+    assert c.find_pr_by_head(OWNER, REPO, "b-88")["number"] == 88
+    assert c.find_pr_by_head(OWNER, REPO, "nope") is None
+
+
+def test_create_and_merge_deletes_the_head_branch():
+    calls = []
+
+    def handler(request):
+        calls.append((request.method, request.url.path))
+        if request.method == "POST" and request.url.path.endswith("/pulls"):
+            return httpx.Response(201, json={"number": 9, "html_url": "http://f/pr/9"})
+        if request.url.path.endswith("/merge"):
+            return httpx.Response(200)
+        if request.method == "DELETE":
+            return httpx.Response(204)
+        return httpx.Response(200, json={})
+
+    url = _client(handler).create_and_merge(
+        OWNER, REPO, head="feat", base="main", title="t"
+    )
+    assert url == "http://f/pr/9"
+    assert ("DELETE", f"/api/v1/repos/{OWNER}/{REPO}/branches/feat") in calls
+
+
+def test_changes_requested_accepts_both_forge_dialects():
+    def make(states):
+        def handler(request):
+            if request.url.path.endswith("/reviews"):
+                return _paged(request, [{"id": i, "state": s} for i, s in enumerate(states)])
+            return httpx.Response(200, json=[])
+        return handler
+
+    assert _client(make(["APPROVED", "REQUEST_CHANGES"])).pr_has_changes_requested(OWNER, REPO, 1)
+    assert _client(make(["CHANGES_REQUESTED"])).pr_has_changes_requested(OWNER, REPO, 1)
+    assert not _client(make(["APPROVED", "COMMENT"])).pr_has_changes_requested(OWNER, REPO, 1)
+
+
+# ── files and branches ───────────────────────────────────────────────────────
+
+
+def test_file_content_round_trip_and_404():
+    payload = {"content": base64.b64encode(b"hello").decode(), "sha": "blob1"}
+
+    def handler(request):
+        if "missing" in request.url.path:
+            return httpx.Response(404, json={})
+        return httpx.Response(200, json=payload)
+
+    c = _client(handler)
+    assert c.get_file_content(OWNER, REPO, "a.txt", "main") == ("hello", "blob1")
+    assert c.get_file_content(OWNER, REPO, "missing.txt", "main") is None
+
+
+def test_update_file_sends_base64_and_blob_sha():
+    seen = {}
+
+    def handler(request):
+        seen.update(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    ok = _client(handler).update_file(
+        OWNER, REPO, "a.txt", new_text="hi", message="m", branch="b", blob_sha="s1"
+    )
+    assert ok
+    assert base64.b64decode(seen["content"]).decode() == "hi"
+    assert seen["sha"] == "s1"
+
+
+def test_branch_head_and_missing_branch():
+    def handler(request):
+        if "gone" in request.url.path:
+            return httpx.Response(404, json={})
+        return httpx.Response(200, json={"commit": {"id": "abc123"}})
+
+    c = _client(handler)
+    assert c.get_branch_head(OWNER, REPO, "main") == "abc123"
+    assert c.get_branch_head(OWNER, REPO, "gone") is None
+
+
+def test_review_comments_flatten_across_reviews():
+    def handler(request):
+        p = request.url.path
+        if p.endswith("/reviews"):
+            return _paged(request, [{"id": 1}, {"id": 2}])
+        if "/reviews/1/comments" in p:
+            return _paged(request, [{"body": "r1c1"}])
+        if "/reviews/2/comments" in p:
+            return _paged(request, [{"body": "r2c1"}, {"body": "r2c2"}])
+        return httpx.Response(200, json=[])
+
+    got = _client(handler).list_pr_review_comments(OWNER, REPO, 5)
+    assert [c["body"] for c in got] == ["r1c1", "r2c1", "r2c2"]

--- a/tests/unit/adapters/test_pr_seam.py
+++ b/tests/unit/adapters/test_pr_seam.py
@@ -187,6 +187,57 @@ def test_factory_refuses_without_a_token():
         pr.make_pr_client(_Settings())
 
 
+def test_factory_builds_forgejo_when_selected(monkeypatch):
+    from operations_center.adapters import pr
+
+    built = {}
+
+    class _Fake:
+        def __init__(self, base_url, token):
+            built["base_url"] = base_url
+            built["token"] = token
+
+    monkeypatch.setattr(
+        "operations_center.adapters.forgejo.pr_client.ForgejoPRClient",
+        _Fake,
+        raising=False,
+    )
+
+    class _Forgejo:
+        base_url = "http://forge.local"
+
+    class _Settings:
+        pr_backend = "forgejo"
+        forgejo = _Forgejo()
+
+        def forgejo_token(self):
+            return "ftok"
+
+    pr.make_pr_client(_Settings())
+    assert built == {"base_url": "http://forge.local", "token": "ftok"}
+
+
+def test_factory_refuses_forgejo_backend_without_a_block():
+    from operations_center.adapters import pr
+
+    class _Settings:
+        pr_backend = "forgejo"
+        forgejo = None
+
+    with pytest.raises(RuntimeError, match="no `forgejo:` settings block"):
+        pr.make_pr_client(_Settings())
+
+
+def test_factory_rejects_an_unknown_pr_backend():
+    from operations_center.adapters import pr
+
+    class _Settings:
+        pr_backend = "gitlab"
+
+    with pytest.raises(RuntimeError, match="unknown pr_backend"):
+        pr.make_pr_client(_Settings())
+
+
 # ── the pure helpers ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Implements the Forgejo PR adapter per [the spec](docs/specs/forgejo-pr-adapter.md) — and revises the spec with what the **live instance** actually said, which changes its hardest finding.

## B2 dissolved: `apply_to_admins` exists

The spec's decisive concern was that `enforce_admins` had no Forgejo equivalent, leaving only bad options for the fail-closed merge gate. Probing the running Forgejo 13 showed branch protection carries **`apply_to_admins`** — the same guarantee under Forgejo's name. Both paths `_branch_protection_ok` reads now map 1:1 and truthfully:

```
required_status_checks.contexts  ←  status_check_contexts (when enable_status_check)
enforce_admins.enabled           ←  apply_to_admins
```

`get_branch_protection` returns exactly that shape, keeps the untranslated rule under `_forgejo`, and returns `None` for a missing rule — which the gate refuses. What remains of B2 is one cutover checklist line: flip `apply_to_admins` on.

## B1 handled as specced: statuses → check runs, losses chosen not implied

`check-runs` is a confirmed 404. `get_check_runs` synthesizes runs from commit statuses under `STATUS_TO_CHECK`: `pending`→in_progress, `success`→success, `failure`/`error`→failure (the original word survives in `output.title`, so failure strings read `"build: error"`), and Forgejo's fifth state **`warning`→`neutral`** — completed, not passed, not failed, matching Forgejo's own non-blocking semantics. Folding it into success would let "completed with warnings" masquerade as "passed".

The three gate helpers reproduce the GitHub client's contracts on top: latest-per-name dedupe by id (the endpoint returns posting *history*; ids are monotonic), `"name: summary"` failure strings, and **completed-must-be-non-empty** so the no-CI-yet window cannot read as green.

## Factory + settings

`make_pr_client` gains the `pr_backend` switch (default `github`), deliberately independent of `board_backend`: the board cut over first (#516); review moves only after `audit` is produced by Forgejo Actions. Flipping it is the cutover act, not a side effect. The earlier "no backend switch yet" stance ended when the thing the knob selects became real.

## Verified live, negative cases first

Against `bp-probe` on the running instance: a rule created **without** the admin bit reports `enabled: False`; a missing rule reports `None`; then `apply_to_admins` was PATCHed on and re-read `True` through the adapter. The five posted probe statuses come back through the helpers as `failed=["probe-error: error", "probe-failure: failure"]`, `incomplete=["probe-pending"]`, `completed=` all four terminal contexts.

Plus 24 MockTransport tests on shapes recorded from the same probe, and 3 new seam tests for the factory branch. Full unit suite: only the two known egress-proxy socket collisions. `ruff` clean, `ty` at the 13 baseline, audit clean. (The link checker reports one broken link in worktrees only — `docs/backends/aider_local.md` points at a sibling repo that worktrees don't have; `broken: 0` from the real checkout.)

## Remaining on the spec

`audit` on Forgejo Actions, then cutover with GitHub demoted to mirror. Review stays on GitHub until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
