### PR TITLE
test(egress): pin the default SNI posture so the shell cannot decide the result

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,31 @@
+## 2026-08-19 — env leakage, not a flake: suite is fully green
+
+Two egress-proxy tests failed on every gate run this session. I twice explained
+them as a socket collision with the live proxy on :8889 — both times wrong. The
+proxy's domain-fronting guard (`OC_EGRESS_SNI_STRICT`, opt-in, added #379/#382)
+pins SNI == CONNECT host; `.env.operations-center.local` exports it as `1`; my
+gate scripts sourced that file before running pytest. The two tests asserting
+*default* (non-strict) behaviour never pinned the variable, so they inherited
+production posture and failed. CI never sets it, so CI was always green.
+
+Fixed by pinning the default posture with `monkeypatch.delenv` — symmetric with
+`test_strict_sni_pin_denies_allowlisted_mismatch`, which already sets it. Green
+now with the variable set, unset, or the fleet env sourced.
+
+Correcting earlier entries and PR bodies: the "8 pre-existing failures" baseline
+quoted in #512/#514/#515/#516/#517 was 6 real + 2 self-inflicted, and the phrase
+"known egress flake" above is wrong. Those PRs' comparisons still hold (same
+polluted env on both sides) but the number did not. `tests/unit` is 8703 passed,
+0 failed.
+
+Also: the fleet died with the host around 19:53 (all 8 roles at once, stale
+pidfiles; Forgejo survived on its docker restart policy). Restarted it, cleared
+#517's `reviewer_backend_unavailable` escalation — the cause was a Claude
+session limit plus a DNS blip, not the code — and the reviewer immediately
+re-reviewed, LGTM'd and merged it. The egress proxy is NOT part of `watch-all`
+and needed a separate restart; worth wiring in, since containment fails closed
+per-task without it.
+
 ## 2026-08-18 — Forgejo PR client implemented; B2 dissolved by a live probe
 
 Probing the live instance rewrote the spec's hardest finding: Forgejo 13 has

--- a/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
+++ b/tests/unit/entrypoints/egress_proxy/test_egress_proxy.py
@@ -86,8 +86,13 @@ class TestExtractSni:
 
 
 
-def test_proxy_denies_then_tunnels():
+def test_proxy_denies_then_tunnels(monkeypatch):
     """Integration: a denied CONNECT host gets 403; an allowed one tunnels."""
+    # Pin the DEFAULT posture: these assert non-strict behaviour, so an
+    # ambient OC_EGRESS_SNI_STRICT=1 (exported by .env.operations-center.local)
+    # must not decide the outcome. Symmetric with
+    # test_strict_sni_pin_denies_allowlisted_mismatch, which sets it.
+    monkeypatch.delenv("OC_EGRESS_SNI_STRICT", raising=False)
     from operations_center.entrypoints.egress_proxy.main import _handle
 
     async def scenario():
@@ -197,9 +202,14 @@ def test_missing_sni_fails_closed():
     asyncio.run(scenario())
 
 
-def test_segmented_client_hello_still_tunnels():
+def test_segmented_client_hello_still_tunnels(monkeypatch):
     """Regression: a ClientHello split across TCP segments must NOT read as 'no SNI'
     and get dropped — the proxy assembles the full record before deciding."""
+    # Pin the DEFAULT posture: these assert non-strict behaviour, so an
+    # ambient OC_EGRESS_SNI_STRICT=1 (exported by .env.operations-center.local)
+    # must not decide the outcome. Symmetric with
+    # test_strict_sni_pin_denies_allowlisted_mismatch, which sets it.
+    monkeypatch.delenv("OC_EGRESS_SNI_STRICT", raising=False)
     from operations_center.entrypoints.egress_proxy.main import _handle
 
     async def scenario():


### PR DESCRIPTION
Two tests in this file failed on every local gate run this session, and were repeatedly dismissed — by me, twice, with a wrong explanation about a socket collision on port 8889. Here is what was actually happening.

## The cause

The proxy's domain-fronting guard is **opt-in at runtime**:

```python
sni_ok = sni is not None and host_allowed(sni, allowlist)
if sni_ok and os.environ.get("OC_EGRESS_SNI_STRICT") == "1":
    sni_ok = sni.lower() == host.lower()
```

`.env.operations-center.local` exports `OC_EGRESS_SNI_STRICT=1`, because that is the posture the fleet runs in. Anyone who sources the fleet env before running pytest — the natural thing to do, and what every gate script in this session did — hands **production posture** to two tests that assert the **default permissive** behaviour.

They then fail on a `CONNECT 127.0.0.1` carrying an SNI of `github.com` — which is exactly the mismatch strict mode exists to refuse. CI never sets the variable, so CI was always green and the local failure looked environmental.

## The fix

`test_strict_sni_pin_denies_allowlisted_mismatch` already does this correctly with `monkeypatch.setenv`. This adds the symmetric half: the two permissive-mode tests `delenv` it, so **each test states the posture it is testing and neither inherits one.**

**The proxy is not changed.** Its behaviour was correct throughout — it refused a connection whose ClientHello disagreed with its CONNECT target, which is the attack the guard was added for.

## Verification

Green three ways — variable unset, variable set to `1`, and with the full fleet env sourced:

| environment | before | after |
|---|---|---|
| clean (what CI does) | 14 passed | 14 passed |
| `OC_EGRESS_SNI_STRICT=1` | 2 failed | 14 passed |
| fleet env sourced | 2 failed | 14 passed |

`tests/unit` is **8703 passed, 0 failed** in every case. `ruff` clean, `ty` at the 13-diagnostic baseline.

## Correcting the record

The "8 pre-existing failures" baseline I quoted in #512, #514, #515, #516 and #517 was **6 real + 2 self-inflicted**. Those PRs' comparisons still hold — I ran both sides with the same polluted env, so "no failures added" was true — but the number was wrong, and calling them a "flake" was wrong. `.console/log.md` carries the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
