### PR TITLE
fix(fleet): start the egress proxy with the fleet, not beside it

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,22 @@
+## 2026-08-19 — the egress proxy joins the fleet lifecycle
+
+Found while recovering from the host dropping the fleet: `watch-all` starts
+seven roles and the watchdog, but never the L7/SNI egress proxy. Per-task
+enforcement fails CLOSED, so with `OC_EGRESS_PROXY` pointing at nothing every
+executor refuses to run — the fleet looks healthy and cannot execute. The only
+signal was one ERROR line per role at boot.
+
+`start/stop/status_egress_proxy` now mirror the watchdog, wired into
+watch-all / -stop / -status and dev-up / -down / -status / -restart, plus
+`egress-proxy-{start,stop,status}` for repairing it without restarting
+everything. Started before the roles so their containment self-check reports
+the truth. No-op when `OC_EGRESS_PROXY` is unset — containment is opt-in, and
+starting a proxy nobody routes through is its own kind of lie. Refuses to adopt
+a port another process already serves.
+
+PID handling follows #499: match the recorded pid's cmdline, never a bare
+`kill -0`, so a recycled pid cannot be reported as the proxy.
+
 ## 2026-08-19 — setup wizard onboards onto Forgejo; board ratchet at zero
 
 The wizard was the last file importing `PlaneClient`. It now walks a new

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,17 @@
+## 2026-08-19 — council caught the status line lying about containment
+
+#520's correctness reviewer found that `watch-all-status` and `status` never
+called `load_env_file`, so `status_egress_proxy` read an unset OC_EGRESS_PROXY
+and printed "not configured" about a proxy that was configured and listening —
+the same class of lie the status line was added to prevent. Both branches now
+load the env; all four status paths do.
+
+Method note: my first attempt to prove the fix "failed" because the worktree
+has no `.env.operations-center.local`, so `load_env_file` had nothing to
+source. Same measurement-environment trap as the missing venv and the phantom
+ty diagnostics. Re-verified with OPERATIONS_CENTER_ENV_FILE pointed at the real
+file: before "not configured", after "running (pid ..., 127.0.0.1:8889)".
+
 ## 2026-08-19 — the egress proxy joins the fleet lifecycle
 
 Found while recovering from the host dropping the fleet: `watch-all` starts

--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,20 @@
+## 2026-08-19 — council round 2: unset is not the same as misconfigured
+
+#520 again, and the reviewer was right again. `egress_proxy_hostport` returned
+failure for two different situations — OC_EGRESS_PROXY unset, and set but
+unparseable — and both printed "not configured (OC_EGRESS_PROXY unset)". So an
+operator with `OC_EGRESS_PROXY=http://host` (no port) was told their variable
+was unset when it was set and wrong. Worse, `start_egress_proxy` returned 0 on
+that path, so the fleet would boot with no proxy and no warning and every
+executor would fail closed against an endpoint that never existed.
+
+Now three outcomes: rc 0 usable, rc 1 unset (opt-in no-op), rc 2 misconfigured
+(loud, and start refuses rather than guessing a port). Verified across six
+shapes: unset, valid, no port, non-numeric port, no host, and no scheme.
+
+Third instance in this PR of the same root theme — a status surface that
+reported something other than what was true. The council caught two of them.
+
 ## 2026-08-19 — council caught the status line lying about containment
 
 #520's correctness reviewer found that `watch-all-status` and `status` never

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -205,6 +205,9 @@ Usage:
   scripts/operations-center.sh watch-all
   scripts/operations-center.sh watch-all-stop
   scripts/operations-center.sh watch-all-status
+  scripts/operations-center.sh egress-proxy-status
+  scripts/operations-center.sh egress-proxy-start
+  scripts/operations-center.sh egress-proxy-stop
   scripts/operations-center.sh intake [--once]
   scripts/operations-center.sh status
   scripts/operations-center.sh watchdog
@@ -673,6 +676,115 @@ stop_watch_role() {
   rm -f "${pid_file}"
 }
 
+# ── egress proxy ─────────────────────────────────────────────────────────────
+# The L7/SNI allowlist proxy is part of the fleet's containment posture, not a
+# side service an operator is expected to remember. Per-task enforcement fails
+# CLOSED (EgressContainmentRequiredError), so whenever OC_EGRESS_PROXY points at
+# nothing listening, every executor refuses to run and the boot-time
+# containment self-check logs "configured but unreachable". Until now the proxy
+# lived outside watch-all, so a host reboot left the fleet up but unable to
+# execute anything — which is how it was found.
+#
+# Skipped entirely when OC_EGRESS_PROXY is unset: containment is opt-in, and
+# starting a proxy nobody routes through would be its own kind of lie.
+
+egress_proxy_hostport() {
+  local url="${OC_EGRESS_PROXY:-}"
+  [[ -n "${url}" ]] || return 1
+  url="${url#*://}"
+  url="${url%%/*}"
+  [[ "${url}" == *:* ]] || return 1
+  printf '%s' "${url}"
+}
+
+egress_proxy_live_pid() {
+  # Not a bare `kill -0`: the kernel recycles pids, and reporting a stranger's
+  # pid as "the proxy" is the same lie #499 fixed for the watch roles.
+  local pid_file="${WATCH_DIR}/egress-proxy.pid"
+  [[ -f "${pid_file}" ]] || return 1
+  local pid
+  pid="$(cat "${pid_file}" 2>/dev/null)" || return 1
+  [[ -n "${pid}" ]] || return 1
+  if tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null | grep -q 'egress_proxy'; then
+    printf '%s' "${pid}"
+    return 0
+  fi
+  return 1
+}
+
+start_egress_proxy() {
+  local hostport
+  hostport="$(egress_proxy_hostport)" || return 0   # containment not configured
+  local pid
+  if pid="$(egress_proxy_live_pid)"; then
+    echo "egress-proxy already running with PID ${pid}"
+    return 0
+  fi
+  rm -f "${WATCH_DIR}/egress-proxy.pid"
+  mkdir -p "${WATCH_DIR}"
+  local host="${hostport%%:*}"
+  local port="${hostport##*:}"
+  # Someone else already holds the port (a systemd unit, a manual run). Adopting
+  # it is wrong — we did not start it and must not claim its pid — but killing it
+  # is worse. Leave it and say so.
+  if ss -ltn 2>/dev/null | awk '{print $4}' | grep -q ":${port}$"; then
+    echo "egress-proxy: ${hostport} is already served by another process — leaving it alone"
+    return 0
+  fi
+  local log_file="${WATCH_DIR}/$(timestamp)_egress-proxy.log"
+  setsid "${VENV_DIR}/bin/python" -m operations_center.entrypoints.egress_proxy.main \
+    --host "${host}" --port "${port}" >"${log_file}" 2>&1 </dev/null &
+  # `setsid` may fork, so $! can be a wrapper that has already exited. Resolve
+  # the pid that actually holds the socket instead of recording a guess.
+  local started=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 0.3
+    started="$(pgrep -f "egress_proxy.main --host ${host} --port ${port}" | head -1)"
+    [[ -n "${started}" ]] && break
+  done
+  if [[ -z "${started}" ]]; then
+    echo "egress-proxy FAILED to start — see ${log_file}" >&2
+    return 1
+  fi
+  echo "${started}" > "${WATCH_DIR}/egress-proxy.pid"
+  echo "egress-proxy started: pid=${started} endpoint=${hostport} log=${log_file}"
+}
+
+stop_egress_proxy() {
+  local pid_file="${WATCH_DIR}/egress-proxy.pid"
+  if [[ ! -f "${pid_file}" ]]; then
+    echo "egress-proxy is not running"
+    return 0
+  fi
+  local pid
+  pid="$(egress_proxy_live_pid)" || pid=""
+  rm -f "${pid_file}"
+  if [[ -n "${pid}" ]]; then
+    kill "${pid}" >/dev/null 2>&1 || true
+    echo "egress-proxy stopped (pid ${pid})"
+  else
+    echo "egress-proxy was not running (stale pid file)"
+  fi
+}
+
+status_egress_proxy() {
+  local hostport
+  if ! hostport="$(egress_proxy_hostport)"; then
+    echo "egress-proxy: not configured (OC_EGRESS_PROXY unset)"
+    return 0
+  fi
+  local pid
+  if pid="$(egress_proxy_live_pid)"; then
+    echo "egress-proxy: running (pid ${pid}, ${hostport})"
+  elif ss -ltn 2>/dev/null | awk '{print $4}' | grep -q ":${hostport##*:}$"; then
+    echo "egress-proxy: served by another process on ${hostport} (not started by watch-all)"
+  else
+    # Not cosmetic: executors fail closed against this, so "stopped" means the
+    # fleet cannot execute, however healthy the watchers look.
+    echo "egress-proxy: STOPPED — ${hostport} unreachable, executors will refuse to run"
+  fi
+}
+
 start_watchdog() {
   local pid_file="${WATCH_DIR}/watchdog.pid"
   if [[ -f "${pid_file}" ]] && kill -0 "$(cat "${pid_file}")" >/dev/null 2>&1; then
@@ -840,7 +952,7 @@ shift || true
 cd "${ROOT_DIR}"
 # Skip janitor for read-only / stop commands — they're fast and don't need it.
 case "${cmd}" in
-  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|providers-status|doctor|status|worker-backend-status|worker-backend-probe|loop-start|loop-stop|loop-status|loop-log|budget) ;;
+  watch-all-status|dev-status|watch-all-stop|watch-stop|watchdog-stop|egress-proxy-status|egress-proxy-stop|providers-status|doctor|status|worker-backend-status|worker-backend-probe|loop-start|loop-stop|loop-status|loop-log|budget) ;;
   *) run_janitor ;;
 esac
 
@@ -860,6 +972,7 @@ case "${cmd}" in
   dev-up)
     ensure_venv
     load_env_file
+    start_egress_proxy
     start_watch_role intake
     start_watch_role goal
     start_watch_role test
@@ -872,6 +985,7 @@ case "${cmd}" in
   dev-down)
     load_env_file
     stop_watchdog
+    stop_egress_proxy
     stop_watch_role intake
     stop_watch_role goal
     stop_watch_role test
@@ -901,6 +1015,7 @@ case "${cmd}" in
   dev-restart)
     load_env_file
     stop_watchdog
+    stop_egress_proxy
     stop_watch_role intake
     stop_watch_role goal
     stop_watch_role test
@@ -909,6 +1024,7 @@ case "${cmd}" in
     stop_watch_role review
     stop_watch_role spec
     ensure_venv
+    start_egress_proxy
     start_watch_role intake
     start_watch_role goal
     start_watch_role test
@@ -920,6 +1036,7 @@ case "${cmd}" in
     ;;
   dev-status)
     load_env_file
+    status_egress_proxy
     status_watch_role intake
     status_watch_role goal
     status_watch_role test
@@ -988,6 +1105,9 @@ case "${cmd}" in
   watch-all)
     ensure_venv
     load_env_file
+    # Before the roles: each logs a containment self-check at boot, and the
+    # answer should be the truth after the proxy is up, not before.
+    start_egress_proxy
     start_watch_role intake
     start_watch_role goal
     start_watch_role test
@@ -999,6 +1119,7 @@ case "${cmd}" in
     ;;
   watch-all-stop)
     stop_watchdog
+    stop_egress_proxy
     stop_watch_role intake
     stop_watch_role goal
     stop_watch_role test
@@ -1008,6 +1129,7 @@ case "${cmd}" in
     stop_watch_role spec
     ;;
   watch-all-status)
+    status_egress_proxy
     status_watch_role intake
     status_watch_role goal
     status_watch_role test
@@ -1019,6 +1141,20 @@ case "${cmd}" in
     ;;
   status)
     status_watchdog
+    status_egress_proxy
+    ;;
+  egress-proxy-status)
+    load_env_file
+    status_egress_proxy
+    ;;
+  egress-proxy-start)
+    ensure_venv
+    load_env_file
+    start_egress_proxy
+    ;;
+  egress-proxy-stop)
+    load_env_file
+    stop_egress_proxy
     ;;
   worker)
     ensure_venv

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -1129,6 +1129,11 @@ case "${cmd}" in
     stop_watch_role spec
     ;;
   watch-all-status)
+    # Containment lives in the env file, so read it before reporting on it:
+    # without this, status_egress_proxy sees an unset OC_EGRESS_PROXY and says
+    # "not configured" about a proxy that is configured and running. Reporting a
+    # live guardrail as absent is the same class of lie this change removes.
+    load_env_file
     status_egress_proxy
     status_watch_role intake
     status_watch_role goal
@@ -1140,6 +1145,7 @@ case "${cmd}" in
     status_watchdog
     ;;
   status)
+    load_env_file
     status_watchdog
     status_egress_proxy
     ;;

--- a/scripts/operations-center.sh
+++ b/scripts/operations-center.sh
@@ -688,12 +688,23 @@ stop_watch_role() {
 # Skipped entirely when OC_EGRESS_PROXY is unset: containment is opt-in, and
 # starting a proxy nobody routes through would be its own kind of lie.
 
+# Three outcomes, deliberately distinct — collapsing the last two into "not
+# configured" tells an operator their variable is unset when it is set and
+# wrong, which is the same misreporting this whole change removes.
+#
+#   rc 0 + "host:port"  usable endpoint
+#   rc 1                OC_EGRESS_PROXY unset/empty — containment is opt-in
+#   rc 2                set, but no usable host:port — a misconfiguration
 egress_proxy_hostport() {
   local url="${OC_EGRESS_PROXY:-}"
   [[ -n "${url}" ]] || return 1
   url="${url#*://}"
   url="${url%%/*}"
-  [[ "${url}" == *:* ]] || return 1
+  local host="${url%%:*}"
+  local port="${url##*:}"
+  [[ "${url}" == *:* ]] || return 2
+  [[ -n "${host}" ]] || return 2
+  [[ "${port}" =~ ^[0-9]+$ ]] || return 2
   printf '%s' "${url}"
 }
 
@@ -714,7 +725,19 @@ egress_proxy_live_pid() {
 
 start_egress_proxy() {
   local hostport
-  hostport="$(egress_proxy_hostport)" || return 0   # containment not configured
+  local rc=0
+  hostport="$(egress_proxy_hostport)" || rc=$?
+  if [[ "${rc}" -eq 1 ]]; then
+    return 0                      # containment not configured — opt-in
+  fi
+  if [[ "${rc}" -ne 0 ]]; then
+    # Returning 0 here would start the fleet with no proxy and no warning, and
+    # every executor would then fail closed against an endpoint that never
+    # existed. Refuse loudly instead of guessing a port.
+    echo "egress-proxy: OC_EGRESS_PROXY='${OC_EGRESS_PROXY}' is not a usable host:port" >&2
+    echo "egress-proxy: refusing to guess — executors will fail closed until this is fixed" >&2
+    return 1
+  fi
   local pid
   if pid="$(egress_proxy_live_pid)"; then
     echo "egress-proxy already running with PID ${pid}"
@@ -769,8 +792,14 @@ stop_egress_proxy() {
 
 status_egress_proxy() {
   local hostport
-  if ! hostport="$(egress_proxy_hostport)"; then
+  local rc=0
+  hostport="$(egress_proxy_hostport)" || rc=$?
+  if [[ "${rc}" -eq 1 ]]; then
     echo "egress-proxy: not configured (OC_EGRESS_PROXY unset)"
+    return 0
+  fi
+  if [[ "${rc}" -ne 0 ]]; then
+    echo "egress-proxy: MISCONFIGURED — OC_EGRESS_PROXY='${OC_EGRESS_PROXY}' is not a usable host:port; executors will refuse to run"
     return 0
   fi
   local pid


### PR DESCRIPTION
Found while recovering the fleet after the host dropped it overnight.

## The gap

`watch-all` starts seven roles and the watchdog — and never the L7/SNI egress allowlist proxy. That proxy is not an optional extra: per-task enforcement **fails closed** (`EgressContainmentRequiredError`), so when `OC_EGRESS_PROXY` points at nothing listening, **every executor refuses to run.**

The fleet reports seven healthy watchers and cannot execute a single task. The only signal is one ERROR line per role at boot:

```
containment self-check FAILED — egress proxy configured but unreachable (http://127.0.0.1:8889)
```

which is easy to read past — I did, until executors would have started failing.

## The fix

`start_egress_proxy` / `stop_egress_proxy` / `status_egress_proxy` mirror the watchdog trio, wired into `watch-all`, `watch-all-stop`, `watch-all-status`, `dev-up`, `dev-down`, `dev-status`, `dev-restart`. Started **before** the roles, so the containment self-check each role logs at boot reports the state after the proxy is up rather than before.

Plus `egress-proxy-{start,stop,status}` so an operator who sees the status line can repair containment without restarting seven watchers.

## Deliberate behaviours

- **No-op when `OC_EGRESS_PROXY` is unset.** Containment is opt-in; starting a proxy nothing routes through would be its own kind of lie.
- **Refuses to adopt a port another process already serves.** We didn't start it, so we must not record its pid — and killing it would be worse.
- **Status says the consequence**, not just the state: `STOPPED — executors will refuse to run`.
- **PID handling follows #499**: the recorded pid is matched against the process cmdline, never a bare `kill -0`, so a recycled pid can't be reported as the proxy. Start resolves the listening pid with `pgrep` rather than trusting `$!`, which under `setsid` can be a wrapper that already exited.

## Verified end to end

Against a live instance on a spare port (`18889`, leaving the fleet's own `:8889` untouched):

| step | result |
|---|---|
| status before | `STOPPED — executors will refuse to run` |
| start | `pid=5794 endpoint=127.0.0.1:18889` |
| status after | `running (pid 5794, 127.0.0.1:18889)` |
| socket + pid | listening; recorded pid's cmdline is `egress_proxy.main --host 127.0.0.1 --port 18889` |
| second start | `already running with PID 5794` |
| stop | socket released |
| stop again | `is not running` |
| stale pid file | reports `STOPPED`, clears without claiming a kill |
| fleet's `:8889` | untouched throughout |

`bash -n` clean, `ruff` clean, custodian audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
