### PR TITLE
test(dependency-check): fix the assertion that left main red

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,16 @@
+## 2026-08-19 — pushed a red test, caught it one command later
+
+Shipping the council fix for #521 I added five probe tests and pushed before
+reading the result: one asserted `normalize_version("13.0.5+gitea-1.22.0")`
+yields `"13.0.5"`. It does not — that helper strips a leading tool name
+("codex-cli 0.117.0"), not a build suffix. My assertion was wrong, not the
+code, and keeping the suffix is better anyway: "+gitea-1.22.0" tells an
+operator which Gitea API generation their Forgejo speaks.
+
+The lesson is ordering, not the assertion: the gate output and the push were in
+one script, so the push did not wait on the result. Gate first, read, then
+push.
+
 ## 2026-08-19 — council: a health probe must not be able to throw
 
 The Forgejo row I added to `dependency_check` called `response.json()`

--- a/tests/test_dependency_check.py
+++ b/tests/test_dependency_check.py
@@ -108,8 +108,14 @@ def _probe(monkeypatch, response):
 
 
 def test_board_status_reports_version_and_health(monkeypatch):
+    """The full version string survives, gitea-compat suffix and all.
+
+    `normalize_version` strips a leading tool name ("codex-cli 0.117.0"), not a
+    build suffix — and the suffix is worth keeping: it is how an operator tells
+    which Gitea API generation their Forgejo speaks.
+    """
     assert _probe(monkeypatch, _Resp(200, {"version": "13.0.5+gitea-1.22.0"})) == (
-        "13.0.5",
+        "13.0.5+gitea-1.22.0",
         True,
     )
 


### PR DESCRIPTION
**Main is red.** `tests/test_dependency_check.py::test_board_status_reports_version_and_health` fails on `6f0a55e4`.

The test is mine, from #521, and the assertion was wrong — not the code:

```python
normalize_version("13.0.5+gitea-1.22.0")   # -> "13.0.5+gitea-1.22.0", not "13.0.5"
```

That helper strips a leading **tool name** (`"codex-cli 0.117.0"` → `"0.117.0"`), not a build suffix. Keeping the suffix is the better behaviour anyway: `+gitea-1.22.0` is how an operator tells which Gitea API generation their Forgejo speaks — exactly what a dependency report exists to surface.

## How it reached main

Two things lined up:

1. I put the gate run and the `git push` in one script, so the push didn't wait on the result. **Gate first, read, then push** — the ordering was the mistake, not the assertion.
2. `tests/test_dependency_check.py` is **not in any CI job**. CI runs `tests/unit`, `tests/test_pr_review_watcher.py`, `tests/integration/reviewer`, and `tests/integration/observer`. So CI was green, the reviewer's verdict was SUCCESS, and #521 merged with a red test in an un-gated suite — while I was fixing it on the branch, which by then belonged to a closed PR.

This is the un-gated-suite gap I flagged in #512 landing for real, rather than hypothetically. Roughly 1,830 tests sit outside the gate; this one was **new** and still invisible.

## Verification

`tests/test_dependency_check.py`: 1 failed, 10 passed → **11 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
