### PR TITLE
test(board): explain the namespace-package trap when the assertion fires

### DIFF
--- a/.console/log.md
+++ b/.console/log.md
@@ -1,3 +1,18 @@
+## 2026-08-19 — an empty directory is still an importable package
+
+After #521 merged, `tests/unit/adapters/test_board_seam.py::test_the_retired_backend_is_actually_gone`
+failed in the live checkout while passing in CI. Not a flake: git removes
+tracked files, not directories that still hold an untracked `__pycache__`, so
+`src/operations_center/adapters/plane/` survived as an empty dir. An empty
+directory is a PEP 420 namespace package — `import
+operations_center.adapters.plane` still succeeded, returning a module with
+`__file__` of None. Any `except ImportError` fallback would have taken the
+wrong branch silently.
+
+CI never sees it (fresh checkout), but anyone pulling the deletion with a
+populated `__pycache__` will. The assertion now names the trap and prints the
+`rmdir` that fixes it.
+
 ## 2026-08-19 — pushed a red test, caught it one command later
 
 Shipping the council fix for #521 I added five probe tests and pushed before

--- a/tests/unit/adapters/test_board_seam.py
+++ b/tests/unit/adapters/test_board_seam.py
@@ -312,8 +312,15 @@ def test_the_retired_backend_is_actually_gone():
     truth about how the fleet talks to a board — one nothing exercises, and so
     one nothing keeps honest.
     """
-    assert not (SRC / "adapters" / "plane").exists(), (
-        "adapters/plane is back; the board backend is Forgejo"
+    plane_dir = SRC / "adapters" / "plane"
+    assert not plane_dir.exists(), (
+        f"{plane_dir} exists. If it is EMPTY, git left it behind when the "
+        "deletion landed — it removes tracked files, not directories that still "
+        "held a __pycache__. That matters more than it looks: an empty directory "
+        "is a PEP 420 namespace package, so `import "
+        "operations_center.adapters.plane` still succeeds, with __file__ None, "
+        "and any `except ImportError` fallback silently takes the wrong branch. "
+        f"Fix with: rmdir {plane_dir}"
     )
     # Deliberately importers, not every mention: several docstrings narrate the
     # migration ("callers imported PlaneClient by name..."), and that history is


### PR DESCRIPTION
`test_the_retired_backend_is_actually_gone` failed in a working checkout while passing in CI. Not a flake — and the reason is worth writing down rather than just clearing.

## What happened

git removes tracked *files*, not directories that still hold an untracked `__pycache__`. So after #521, `src/operations_center/adapters/plane/` survived as an **empty directory**.

An empty directory is a [PEP 420](https://peps.python.org/pep-0420/) namespace package:

```
>>> import operations_center.adapters.plane as m
>>> m.__file__
None
```

The import **succeeds**. Any `except ImportError:` fallback would have taken the wrong branch without saying so — which is precisely the class of silent-wrong-answer this seam's tests exist to prevent.

## Why CI can't see it

Fresh checkout, nothing left behind. Anyone who *pulls* the deletion with a populated `__pycache__` reproduces it immediately. That asymmetry is why the message matters more than the assertion.

## The change

The assertion now says what happened, why an empty directory isn't harmless, and prints the exact `rmdir` that fixes it. Verified both ways — it fires with that message when the directory exists, and the file is 14 passed on a clean tree.

No behaviour change: the test already caught the condition, it just couldn't explain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
