### PR TITLE
docs: branch protection IS in the backup — correct both runbooks

### DIFF
--- a/.console/backlog.md
+++ b/.console/backlog.md
@@ -4,6 +4,30 @@ _Durable work inventory. Update after each meaningful chunk of progress._
 
 ## Up Next
 
+### Verify the restored forge on the new machine, before trusting any gate
+
+The fleet was archived on 2026-08-20 and moves to a different host. Restoring a
+volume backup brings back the repos, PRs, API tokens, runner registration AND
+branch protection — but "it came back" is an assumption until checked, and an
+unprotected `main` looks exactly like a protected one until something merges that
+should not have.
+
+On arrival, in this order:
+
+1. `./deploy/forgejo/apply-branch-protection.sh --check` — expect
+   "matches branch-protection.json". Apply only if it reports drift.
+2. `docker logs forgejo-runner 2>&1 | grep 'declared successfully'` — the runner
+   must come up with the `ubuntu-latest` label, or nothing is ever scheduled.
+3. Open a throwaway PR and confirm all three: the
+   `custodian-audit / audit (pull_request)` context appears and goes green, the
+   review watcher posts `reviewer-verdict` on its own, and the merge is REFUSED
+   while either is pending. The third is the one worth being fussy about — a gate
+   that never blocks anything is indistinguishable from a gate that works.
+
+Also outstanding on arrival: rebase PR #4 (`chore/retire-plane-leftovers`), which
+is behind main with stale CI, and rotate the Forgejo and GitHub tokens — both
+travelled on removable media during the move.
+
 ### The reviewer posts a green verdict without CI (guardrail path — needs K=3 council)
 
 `_phase0_ci_fix` (`entrypoints/pr_review_watcher/main.py:2360`) is a bare

--- a/.console/log.md
+++ b/.console/log.md
@@ -27,6 +27,23 @@ ignored.
 
 README got a pointer beside the existing `ROOT_URL` section rather than a second
 copy of the `container.network: host` explanation, which it already covers well.
+## 2026-08-20 — two runbooks claiming protection is not backed up
+
+Both `docs/operator/setup.md` and `deploy/forgejo/README.md` said branch
+protection is "NOT part of any backup". That is false, and it matters on exactly
+the path being taken right now: protection lives in `gitea.db`, which is inside
+`forgejo-data.tgz`, so restoring a volume backup brings it back along with the
+repos, the PRs and the API tokens.
+
+The intent was "it is not in the git repo, so cloning gets you none of it" —
+true, and a different statement. Left as written it sends someone restoring an
+instance to re-apply a rule that is already correct, and, worse, implies the
+restore left them exposed when it did not.
+
+Both now split the two procedures explicitly: restoring a backup means VERIFY
+with `--check`; a fresh instance means APPLY. Filed the corresponding
+new-machine verification task in backlog.md, since "protection came back" is an
+assumption until something checks it.
 
 ## 2026-08-20 — measuring jitter and calling it degradation
 

--- a/deploy/forgejo/README.md
+++ b/deploy/forgejo/README.md
@@ -114,8 +114,11 @@ docker compose -f deploy/forgejo/docker-compose.yml up -d forgejo
    `oc-ci-runner:latest` before starting the daemon, or every job fails at
    image pull.
 
-5. Apply branch protection. It is not in any backup and a fresh instance starts
-   **unprotected**, which is the failure mode that looks fine:
+5. Apply branch protection. It lives in the forge's database, so a FRESH instance
+   like this one starts **unprotected** — the failure mode that looks completely
+   fine. (Restoring a volume backup is different: protection comes back with the
+   database. See "Moving to another machine" below, where you verify rather than
+   apply.)
 
 ```bash
 ./deploy/forgejo/apply-branch-protection.sh

--- a/docs/operator/setup.md
+++ b/docs/operator/setup.md
@@ -65,10 +65,19 @@ and the CI that produces the `audit` status branch protection requires.
 
 Standing the instance itself up on a new machine — containers, runner
 registration, the CI job image, and branch protection — is
-`deploy/forgejo/README.md`, not this guide. Note that branch protection is NOT
-part of any backup: it lives in the forge's own database, so a fresh instance
-starts unprotected. Re-apply it with
-`deploy/forgejo/apply-branch-protection.sh` and verify with `--check`.
+`deploy/forgejo/README.md`, not this guide.
+
+Branch protection lives in the forge's own database, not in this repo, so
+cloning gets you none of it. Which of the two procedures you are running decides
+what that means:
+
+* **Restoring a volume backup** (moving an instance): protection comes back with
+  the database, along with the repos, PRs and API tokens. Verify with
+  `deploy/forgejo/apply-branch-protection.sh --check`; only apply if that reports
+  drift.
+* **A fresh instance**: nothing is there and it starts **unprotected**, which is
+  the failure mode that looks completely fine. Apply it with
+  `deploy/forgejo/apply-branch-protection.sh`, then `--check`.
 
 **Plane was retired at the 2026-08-19 cutover** and never ran on this fleet.
 `board_backend` accepts only `forgejo`.


### PR DESCRIPTION
Recovered from the old machine's Forgejo instance, where this is open as PR #5. That instance is down for the fleet move, so the branch is republished here.

`docs/operator/setup.md` and `deploy/forgejo/README.md` both stated that branch protection is **"NOT part of any backup"**. That is false, and it misleads on exactly the path being taken right now: protection lives in `gitea.db`, which is inside the `forgejo-data` volume archive, so restoring a backup brings it back together with the repos, the pull requests and the API tokens.

The intended claim was "it is not in the git repo, so cloning gets you none of it" — true, and a different statement. As written it sends someone restoring an instance to re-apply a rule that is already correct, and implies the restore left them exposed when it did not.

Both docs now split the two procedures explicitly:

- **Restoring a volume backup** — protection comes back with the database. VERIFY with `deploy/forgejo/apply-branch-protection.sh --check`; apply only if that reports drift.
- **A fresh instance** — nothing is there and it starts **unprotected**, which is the failure mode that looks completely fine. APPLY, then `--check`.

Adds the corresponding new-machine task to the backlog. "Protection came back" is an assumption until something checks it, and an unprotected `main` looks exactly like a protected one right up until something merges that should not have.

**Rebase note:** the original commit (`c8a6e728`) sat on the Forgejo-side history, which this remote does not share, so it was cherry-picked onto `main`. `.console/log.md` auto-merged against the entry added by #528. The `docs/operator/setup.md` and `deploy/forgejo/README.md` hunks are byte-identical to the original — only the blob hash differs.

> **Note on ordering:** this and the Plane-leftovers sweep both touch `docs/operator/setup.md`, `.console/backlog.md` and `.console/log.md`. Whichever merges second will likely need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
